### PR TITLE
schematic-react@0.1.11

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -44,7 +44,7 @@
   "types": "dist/schematic-react.d.ts",
   "version": "0.1.8",
   "dependencies": {
-    "@schematichq/schematic-js": "^0.1.10"
+    "@schematichq/schematic-js": "^0.1.12"
   },
   "peerDependencies": {
     "react": ">=18"


### PR DESCRIPTION
The primary goal of this PR is to fix an issue where websocket updates were not immediately updating React. I've made a few other changes:
1. Updated to work with the latest version of schematic-js; this prevented some cases where excess websocket connections were initialized.
2. Update the provider props such that all schematic-js client options are base props; most of these props are for testing purposes and i would expect to be used only by us, eg overriding the apiUrl, but I think it's nicer to have them be top-level props rather than accepting a nested options object.
3. Update the provider props such that either a client instance or a publishableKey is required. This way, we ensure that a client always exists if the provider component has rendered.


Demo of live updating fixed:

https://github.com/SchematicHQ/schematic-js/assets/3267277/eb9c741e-9109-4bf2-aa50-41faed620546

