### PR TITLE
Refactor useSchematicFlag to use useSyncExternalStore and add useSchematicIsPending hook

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -29,7 +29,7 @@
     "tsc": "npx tsc"
   },
   "dependencies": {
-    "@schematichq/schematic-js": "^0.1.13",
+    "@schematichq/schematic-js": "^0.1.14",
     "@stripe/react-stripe-js": "^2.8.0",
     "@stripe/stripe-js": "^4.3.0",
     "lodash.merge": "^4.6.2",

--- a/react/src/components/embed/ComponentTree.tsx
+++ b/react/src/components/embed/ComponentTree.tsx
@@ -66,12 +66,12 @@ export const ComponentTree = () => {
     setChildren(nodes.map(renderer));
   }, [nodes]);
 
-  if (Children.count(children) === 0) {
-    return <Loading />;
-  }
-
   if (error) {
     return <Error message={error.message} />;
+  }
+
+  if (Children.count(children) === 0) {
+    return <Loading />;
   }
 
   return <>{children}</>;

--- a/react/src/hooks/schematic.ts
+++ b/react/src/hooks/schematic.ts
@@ -1,6 +1,6 @@
 import * as SchematicJS from "@schematichq/schematic-js";
-import { useContext, useMemo, useSyncExternalStore } from "react";
-import { SchematicContext } from "../context";
+import { useMemo, useSyncExternalStore, useCallback } from "react";
+import { useSchematic } from "../context";
 
 export interface SchematicFlags {
   [key: string]: boolean;
@@ -14,48 +14,57 @@ export type UseSchematicFlagOpts = SchematicHookOpts & {
   fallback?: boolean;
 };
 
-export const useSchematic = () => useContext(SchematicContext);
-
 export const useSchematicClient = (opts?: SchematicHookOpts) => {
   const schematic = useSchematic();
   const { client } = opts ?? {};
 
-  if (client) {
-    return client;
-  }
-
-  // TODO: Fix this in types
-  return schematic.client as SchematicJS.Schematic;
+  return useMemo(() => {
+    if (client) {
+      return client;
+    }
+    return schematic.client;
+  }, [client, schematic.client]);
 };
 
 export const useSchematicContext = (opts?: SchematicHookOpts) => {
   const client = useSchematicClient(opts);
-  const { setContext } = client;
-  return { setContext };
+  return useMemo(
+    () => ({
+      setContext: client.setContext.bind(client),
+    }),
+    [client],
+  );
 };
 
 export const useSchematicEvents = (opts?: SchematicHookOpts) => {
   const client = useSchematicClient(opts);
-  const { track, identify } = client;
-  return { track, identify };
+
+  const track = useCallback(
+    (...args: Parameters<typeof client.track>) => client.track(...args),
+    [client],
+  );
+
+  const identify = useCallback(
+    (...args: Parameters<typeof client.identify>) => client.identify(...args),
+    [client],
+  );
+
+  return useMemo(() => ({ track, identify }), [track, identify]);
 };
 
 export const useSchematicFlag = (key: string, opts?: UseSchematicFlagOpts) => {
   const client = useSchematicClient(opts);
   const fallback = opts?.fallback ?? false;
 
-  const subscribe = useMemo(
-    () => (callback: () => void) => client.addFlagValueListener(key, callback),
+  const subscribe = useCallback(
+    (callback: () => void) => client.addFlagValueListener(key, callback),
     [client, key],
   );
 
-  const getSnapshot = useMemo(
-    () => () => {
-      const value = client.getFlagValue(key);
-      return typeof value === "undefined" ? fallback : value;
-    },
-    [client, key, fallback],
-  );
+  const getSnapshot = useCallback(() => {
+    const value = client.getFlagValue(key);
+    return typeof value === "undefined" ? fallback : value;
+  }, [client, key, fallback]);
 
   return useSyncExternalStore(subscribe, getSnapshot);
 };
@@ -63,12 +72,12 @@ export const useSchematicFlag = (key: string, opts?: UseSchematicFlagOpts) => {
 export const useSchematicIsPending = (opts?: SchematicHookOpts) => {
   const client = useSchematicClient(opts);
 
-  const subscribe = useMemo(
-    () => (callback: () => void) => client.addIsPendingListener(callback),
+  const subscribe = useCallback(
+    (callback: () => void) => client.addIsPendingListener(callback),
     [client],
   );
 
-  const getSnapshot = useMemo(() => () => client.getIsPending(), [client]);
+  const getSnapshot = useCallback(() => client.getIsPending(), [client]);
 
   return useSyncExternalStore(subscribe, getSnapshot);
 };

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -1,6 +1,7 @@
 import {
   defaultSettings,
   defaultTheme,
+  useSchematic,
   EmbedContext,
   EmbedProvider,
   SchematicProvider,
@@ -10,7 +11,6 @@ import {
 } from "./context";
 import {
   useEmbed,
-  useSchematic,
   useSchematicContext,
   useSchematicEvents,
   useSchematicFlag,

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -14,6 +14,7 @@ import {
   useSchematicContext,
   useSchematicEvents,
   useSchematicFlag,
+  useSchematicIsPending,
   type SchematicHookOpts,
   type UseSchematicFlagOpts,
 } from "./hooks";
@@ -28,6 +29,7 @@ export {
   useSchematicContext,
   useSchematicEvents,
   useSchematicFlag,
+  useSchematicIsPending,
   EmbedContext,
   EmbedProvider,
   SchematicProvider,


### PR DESCRIPTION
I believe this gets live re-rendering of React components working well as targeting changes, including with Next.js. I've also added a `useIsSchematicPending` hook that can be used to block rendering until schematic data is ready, if so desired (for example, in the sample app we were erroneously showing a "no access" view during the loading state sometimes).