### PR TITLE
Handle cases where company has no billing plan

### DIFF
--- a/components/src/api/.openapi-generator/FILES
+++ b/components/src/api/.openapi-generator/FILES
@@ -3,7 +3,6 @@ apis/CheckoutApi.ts
 apis/index.ts
 index.ts
 models/ApiError.ts
-models/BillingPlan.ts
 models/BillingPriceResponseData.ts
 models/BillingProductDetailResponseData.ts
 models/BillingProductForSubscriptionResponseData.ts
@@ -13,6 +12,7 @@ models/ChangeSubscriptionRequestBody.ts
 models/CheckoutResponse.ts
 models/CompanyDetailResponseData.ts
 models/CompanyPlanDetailResponseData.ts
+models/CompanyPlanWithBillingSubView.ts
 models/CompanyResponseData.ts
 models/CompanySubscriptionResponseData.ts
 models/ComponentHydrateResponseData.ts

--- a/components/src/api/apis/index.ts
+++ b/components/src/api/apis/index.ts
@@ -1,3 +1,3 @@
 /* tslint:disable */
- 
+
 export * from "./CheckoutApi";

--- a/components/src/api/index.ts
+++ b/components/src/api/index.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
- 
+
 export * from "./runtime";
 export * from "./apis/index";
 export * from "./models/index";

--- a/components/src/api/models/CompanyDetailResponseData.ts
+++ b/components/src/api/models/CompanyDetailResponseData.ts
@@ -13,6 +13,12 @@
  */
 
 import { mapValues } from "../runtime";
+import type { CompanyPlanWithBillingSubView } from "./CompanyPlanWithBillingSubView";
+import {
+  CompanyPlanWithBillingSubViewFromJSON,
+  CompanyPlanWithBillingSubViewFromJSONTyped,
+  CompanyPlanWithBillingSubViewToJSON,
+} from "./CompanyPlanWithBillingSubView";
 import type { PreviewObject } from "./PreviewObject";
 import {
   PreviewObjectFromJSON,
@@ -37,12 +43,6 @@ import {
   EntityTraitDetailResponseDataFromJSONTyped,
   EntityTraitDetailResponseDataToJSON,
 } from "./EntityTraitDetailResponseData";
-import type { BillingPlan } from "./BillingPlan";
-import {
-  BillingPlanFromJSON,
-  BillingPlanFromJSONTyped,
-  BillingPlanToJSON,
-} from "./BillingPlan";
 
 /**
  *
@@ -52,10 +52,10 @@ import {
 export interface CompanyDetailResponseData {
   /**
    *
-   * @type {Array<BillingPlan>}
+   * @type {Array<CompanyPlanWithBillingSubView>}
    * @memberof CompanyDetailResponseData
    */
-  addOns: Array<BillingPlan>;
+  addOns: Array<CompanyPlanWithBillingSubView>;
   /**
    *
    * @type {Array<BillingSubscriptionResponseData>}
@@ -112,10 +112,10 @@ export interface CompanyDetailResponseData {
   name: string;
   /**
    *
-   * @type {BillingPlan}
+   * @type {CompanyPlanWithBillingSubView}
    * @memberof CompanyDetailResponseData
    */
-  plan?: BillingPlan;
+  plan?: CompanyPlanWithBillingSubView;
   /**
    *
    * @type {Array<PreviewObject>}
@@ -182,7 +182,9 @@ export function CompanyDetailResponseDataFromJSONTyped(
     return json;
   }
   return {
-    addOns: (json["add_ons"] as Array<any>).map(BillingPlanFromJSON),
+    addOns: (json["add_ons"] as Array<any>).map(
+      CompanyPlanWithBillingSubViewFromJSON,
+    ),
     billingSubscriptions: (json["billing_subscriptions"] as Array<any>).map(
       BillingSubscriptionResponseDataFromJSON,
     ),
@@ -197,7 +199,10 @@ export function CompanyDetailResponseDataFromJSONTyped(
       json["last_seen_at"] == null ? undefined : new Date(json["last_seen_at"]),
     logoUrl: json["logo_url"] == null ? undefined : json["logo_url"],
     name: json["name"],
-    plan: json["plan"] == null ? undefined : BillingPlanFromJSON(json["plan"]),
+    plan:
+      json["plan"] == null
+        ? undefined
+        : CompanyPlanWithBillingSubViewFromJSON(json["plan"]),
     plans: (json["plans"] as Array<any>).map(PreviewObjectFromJSON),
     traits: json["traits"] == null ? undefined : json["traits"],
     updatedAt: new Date(json["updated_at"]),
@@ -212,7 +217,9 @@ export function CompanyDetailResponseDataToJSON(
     return value;
   }
   return {
-    add_ons: (value["addOns"] as Array<any>).map(BillingPlanToJSON),
+    add_ons: (value["addOns"] as Array<any>).map(
+      CompanyPlanWithBillingSubViewToJSON,
+    ),
     billing_subscriptions: (value["billingSubscriptions"] as Array<any>).map(
       BillingSubscriptionResponseDataToJSON,
     ),
@@ -229,7 +236,7 @@ export function CompanyDetailResponseDataToJSON(
         : (value["lastSeenAt"] as any).toISOString(),
     logo_url: value["logoUrl"],
     name: value["name"],
-    plan: BillingPlanToJSON(value["plan"]),
+    plan: CompanyPlanWithBillingSubViewToJSON(value["plan"]),
     plans: (value["plans"] as Array<any>).map(PreviewObjectToJSON),
     traits: value["traits"],
     updated_at: value["updatedAt"].toISOString(),

--- a/components/src/api/models/CompanyPlanWithBillingSubView.ts
+++ b/components/src/api/models/CompanyPlanWithBillingSubView.ts
@@ -16,68 +16,82 @@ import { mapValues } from "../runtime";
 /**
  *
  * @export
- * @interface BillingPlan
+ * @interface CompanyPlanWithBillingSubView
  */
-export interface BillingPlan {
+export interface CompanyPlanWithBillingSubView {
   /**
    *
    * @type {string}
-   * @memberof BillingPlan
+   * @memberof CompanyPlanWithBillingSubView
+   */
+  billingProductId?: string | null;
+  /**
+   *
+   * @type {string}
+   * @memberof CompanyPlanWithBillingSubView
    */
   description?: string | null;
   /**
    *
    * @type {string}
-   * @memberof BillingPlan
+   * @memberof CompanyPlanWithBillingSubView
    */
   id: string;
   /**
    *
    * @type {string}
-   * @memberof BillingPlan
+   * @memberof CompanyPlanWithBillingSubView
    */
   imageUrl?: string | null;
   /**
    *
    * @type {string}
-   * @memberof BillingPlan
+   * @memberof CompanyPlanWithBillingSubView
    */
   name: string;
   /**
    *
    * @type {string}
-   * @memberof BillingPlan
+   * @memberof CompanyPlanWithBillingSubView
    */
   planPeriod?: string | null;
   /**
    *
    * @type {number}
-   * @memberof BillingPlan
+   * @memberof CompanyPlanWithBillingSubView
    */
   planPrice?: number | null;
 }
 
 /**
- * Check if a given object implements the BillingPlan interface.
+ * Check if a given object implements the CompanyPlanWithBillingSubView interface.
  */
-export function instanceOfBillingPlan(value: object): value is BillingPlan {
+export function instanceOfCompanyPlanWithBillingSubView(
+  value: object,
+): value is CompanyPlanWithBillingSubView {
   if (!("id" in value) || value["id"] === undefined) return false;
   if (!("name" in value) || value["name"] === undefined) return false;
   return true;
 }
 
-export function BillingPlanFromJSON(json: any): BillingPlan {
-  return BillingPlanFromJSONTyped(json, false);
+export function CompanyPlanWithBillingSubViewFromJSON(
+  json: any,
+): CompanyPlanWithBillingSubView {
+  return CompanyPlanWithBillingSubViewFromJSONTyped(json, false);
 }
 
-export function BillingPlanFromJSONTyped(
+export function CompanyPlanWithBillingSubViewFromJSONTyped(
   json: any,
   ignoreDiscriminator: boolean,
-): BillingPlan {
+): CompanyPlanWithBillingSubView {
   if (json == null) {
     return json;
   }
   return {
+    billingProductId:
+      json["billing_product_id"] == null
+        ? undefined
+        : json["billing_product_id"],
     description: json["description"] == null ? undefined : json["description"],
     id: json["id"],
     imageUrl: json["image_url"] == null ? undefined : json["image_url"],
@@ -87,11 +101,14 @@ export function BillingPlanFromJSONTyped(
   };
 }
 
-export function BillingPlanToJSON(value?: BillingPlan | null): any {
+export function CompanyPlanWithBillingSubViewToJSON(
+  value?: CompanyPlanWithBillingSubView | null,
+): any {
   if (value == null) {
     return value;
   }
   return {
+    billing_product_id: value["billingProductId"],
     description: value["description"],
     id: value["id"],
     image_url: value["imageUrl"],

--- a/components/src/api/models/index.ts
+++ b/components/src/api/models/index.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
- 
+
 export * from "./ApiError";
-export * from "./BillingPlan";
 export * from "./BillingPriceResponseData";
 export * from "./BillingProductDetailResponseData";
 export * from "./BillingProductForSubscriptionResponseData";
@@ -11,6 +10,7 @@ export * from "./ChangeSubscriptionRequestBody";
 export * from "./CheckoutResponse";
 export * from "./CompanyDetailResponseData";
 export * from "./CompanyPlanDetailResponseData";
+export * from "./CompanyPlanWithBillingSubView";
 export * from "./CompanyResponseData";
 export * from "./CompanySubscriptionResponseData";
 export * from "./ComponentHydrateResponseData";

--- a/components/src/components/elements/included-features/IncludedFeatures.tsx
+++ b/components/src/components/elements/included-features/IncludedFeatures.tsx
@@ -75,6 +75,21 @@ export const IncludedFeatures = forwardRef<
 
   const isLightBackground = useIsLightBackground();
 
+  // Check if we should render this component at all:
+  // * If there are any plans or add-ons, render it, even if the list is empty.
+  // * If there are any features, show it (e.g., there could be features available via company overrides
+  //  even if the company has no plan or add-ons).
+  // * If none of the above, don't render the component.
+  const shouldShowFeatures =
+    (data.featureUsage?.features ?? []).length > 0 ||
+    data.company?.plan ||
+    (data.company?.addOns ?? []).length > 0 ||
+    false;
+
+  if (!shouldShowFeatures) {
+    return null;
+  }
+
   return (
     <Element
       as={Flex}

--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -83,12 +83,17 @@ export const PlanManager = forwardRef<
   const theme = useTheme();
   const { data, layout, setLayout } = useEmbed();
 
+  // Can change plan if there is a publishable key, a current plan with a billing association, and
+  // some active plans
   const { currentPlan, canChangePlan } = useMemo(() => {
     return {
       currentPlan: data.company?.plan,
-      canChangePlan: data.activePlans.length > 0,
+      canChangePlan:
+        data.stripeEmbed?.publishableKey &&
+        data.company?.plan?.billingProductId &&
+        data.activePlans.length > 0,
     };
-  }, [data.company, data.activePlans]);
+  }, [data.company, data.activePlans, data.stripeEmbed?.publishableKey]);
 
   return (
     <Element


### PR DESCRIPTION
Before starting on subscribe work, there are a few cases I wanted to make sure we're handling in the current state: https://linear.app/schematic/issue/SCH-1920/subscribe#comment-833b6efa

company has no Schematic plan, but they do have a stripe subscription (containing a product or products that are not linked to Schematic plans)
* expected behavior: they should not be able to upgrade or downgrade

company has a Schematic plan, but it's not linked to a Stripe product (e.g. via default plan), and they don't have a Stripe subscription
* expected behavior: they should not be able to upgrade or downgrade

company has a Schematic plan, but it's not linked to a Stripe product (e.g. via default plan), and they do have a Stripe subscription but its product(s) are not linked to Schematic
* expected behavior: they should not be able to upgrade or downgrade