### PR TITLE
await websocket connection for flag check

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -44,7 +44,7 @@ schematic.identify({
 schematic.track({ event: "query" });
 
 // Check a flag
-schematic.checkFlag("some-flag-key");
+await schematic.checkFlag("some-flag-key");
 ```
 
 By default, `checkFlag` will perform a network request to get the flag value for this user. If you'd like to check all flags at once in order to minimize network requests, you can use `checkFlags`:
@@ -61,7 +61,7 @@ schematic.identify({
     },
 });
 
-schematic.checkFlags();
+await schematic.checkFlags();
 ```
 
 Alternatively, you can run in websocket mode, which will keep a persistent connection open to the Schematic service and receive flag updates in real time:
@@ -69,14 +69,14 @@ Alternatively, you can run in websocket mode, which will keep a persistent conne
 ```typescript
 import { Schematic } from "@schematichq/schematic-js";
 
-const schematic = new Schematic("your-api-key", { useWebSocket: true});
+const schematic = new Schematic("your-api-key", { useWebSocket: true });
 
 schematic.identify({
     keys: { id: "my-user-id" },
     company: { keys: { id: "my-company-id" } },
 });
 
-schematic.checkFlag("some-flag-key");
+await schematic.checkFlag("some-flag-key");
 ```
 
 ## License

--- a/js/jest.config.js
+++ b/js/jest.config.js
@@ -3,6 +3,8 @@ module.exports = {
   preset: "ts-jest/presets/js-with-ts-esm",
   testEnvironment: "jsdom",
   transform: {
-    '^.+\\.(ts|tsx)?$': 'ts-jest',
+    "^.+\\.(ts|tsx)?$": "ts-jest",
   },
 };
+
+global.WebSocket = require("mock-socket").WebSocket;

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/schematic.cjs.js",
   "module": "dist/schematic.esm.js",
   "types": "dist/schematic.d.ts",
@@ -44,6 +44,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-esbuild": "^0.3.0",
     "jest-fetch-mock": "^3.0.3",
+    "mock-socket": "^9.3.1",
     "prettier": "^3.3.3",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.2"


### PR DESCRIPTION
This fixes a race condition that exists in websocket mode, where the user would call checkFlag before the websocket connection is established, and it would always return the fallback value. In this situation, we want to wait for the websocket connection to be established before getting a value and resolving the checkFlag promise.

Additionally, we should now reconnect on checkFlag if the connection has been lost.