### PR TITLE
Prevent excess websocket connections from schematic-react

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -77,6 +77,9 @@ schematic.identify({
 });
 
 await schematic.checkFlag("some-flag-key");
+
+// Close the connection when you're done with the Schematic client
+schematic.cleanup();
 ```
 
 ## License

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/schematic-react.cjs.js",
   "module": "dist/schematic-react.esm.js",
   "types": "dist/schematic-react.d.ts",

--- a/react/src/context/schematic.tsx
+++ b/react/src/context/schematic.tsx
@@ -1,5 +1,5 @@
 import * as SchematicJS from "@schematichq/schematic-js";
-import React, { createContext, useEffect, useMemo } from "react";
+import React, { createContext, useEffect, useMemo, useRef } from "react";
 
 type BaseSchematicProviderProps = Omit<
   SchematicJS.SchematicOptions,
@@ -36,16 +36,21 @@ export const SchematicProvider: React.FC<SchematicProviderProps> = ({
   publishableKey,
   ...clientOpts
 }) => {
+  const initialOptsRef = useRef({
+    publishableKey,
+    useWebSocket: clientOpts.useWebSocket ?? true,
+    ...clientOpts,
+  });
+
   const client = useMemo(() => {
-    const { useWebSocket = true } = clientOpts;
     if (providedClient) {
       return providedClient;
     }
-    return new SchematicJS.Schematic(publishableKey!, {
-      useWebSocket,
-      ...clientOpts,
+
+    return new SchematicJS.Schematic(initialOptsRef.current.publishableKey!, {
+      ...initialOptsRef.current,
     });
-  }, [providedClient, publishableKey, clientOpts]);
+  }, [providedClient]);
 
   useEffect(() => {
     // Clean up Schematic client (i.e., close websocket connection) when the


### PR DESCRIPTION
I noticed this morning we were creating a new websocket connection every time we would rerender the SchematicProvider component. This fixes that, so that even if the provider is re-rendered, we'll continue to reuse the same underlying client instance and thus not create excess websocket connections.
