### PR TITLE
useSchematicFlagCheck hook for React

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -69,11 +69,50 @@ To check a flag, you can use the `useSchematicFlag` hook:
 
 ```tsx
 import { useSchematicFlag } from "@schematichq/schematic-react";
+import { Feature, Fallback } from "./components";
 
 const MyComponent = () => {
     const isFeatureEnabled = useSchematicFlag("my-flag-key");
 
     return isFeatureEnabled ? <Feature /> : <Fallback />;
+};
+```
+
+For flags that are checking company access to a feature based on usage, you can render additional states using the `useSchematicFlagCheck` hook, e.g.:
+
+```tsx
+import {
+    useSchematicFlagCheck,
+    useSchematicIsPending,
+} from "@schematichq/schematic-react";
+import { Feature, Loader, NoAccess } from "./components";
+
+const MyComponent = () => {
+    const schematicIsPending = useSchematicIsPending();
+    const {
+        featureAllocation,
+        featureUsage,
+        featureUsageExceeded,
+        value: isFeatureEnabled,
+    } = useSchematicFlagCheck("my-flag-key");
+
+    // loading state
+    if (schematicIsPending) {
+        return <Loader />;
+    }
+
+    // usage exceeded state
+    if (featureUsageExceeded) {
+        return (
+            <div>
+                You have used all of your usage ({featureUsage} /{" "}
+                {featureAllocation})
+            </div>
+        );
+    }
+
+    // either feature or "no access" state
+    return isFeatureEnabled ? <Feature /> : <NoAccess />;
 };
 ```
 

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-react",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "main": "dist/schematic-react.cjs.js",
   "module": "dist/schematic-react.esm.js",
   "types": "dist/schematic-react.d.ts",
@@ -28,7 +28,7 @@
     "tsc": "npx tsc"
   },
   "dependencies": {
-    "@schematichq/schematic-js": "^1.0.2"
+    "@schematichq/schematic-js": "^1.1.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.47.9",

--- a/react/src/hooks/schematic.ts
+++ b/react/src/hooks/schematic.ts
@@ -52,7 +52,10 @@ export const useSchematicEvents = (opts?: SchematicHookOpts) => {
   return useMemo(() => ({ track, identify }), [track, identify]);
 };
 
-export const useSchematicFlag = (key: string, opts?: UseSchematicFlagOpts) => {
+export const useSchematicFlag = (
+  key: string,
+  opts?: UseSchematicFlagOpts,
+): boolean => {
   const client = useSchematicClient(opts);
   const fallback = opts?.fallback ?? false;
 
@@ -65,6 +68,35 @@ export const useSchematicFlag = (key: string, opts?: UseSchematicFlagOpts) => {
     const value = client.getFlagValue(key);
     return typeof value === "undefined" ? fallback : value;
   }, [client, key, fallback]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+};
+
+export const useSchematicFlagCheck = (
+  key: string,
+  opts?: UseSchematicFlagOpts,
+): SchematicJS.CheckFlagReturn => {
+  const client = useSchematicClient(opts);
+  const fallback = opts?.fallback ?? false;
+
+  const fallbackCheck = useMemo(
+    () => ({
+      flag: key,
+      reason: "Fallback",
+      value: fallback,
+    }),
+    [key, fallback],
+  );
+
+  const subscribe = useCallback(
+    (callback: () => void) => client.addFlagCheckListener(key, callback),
+    [client, key],
+  );
+
+  const getSnapshot = useCallback(() => {
+    const check = client.getFlagCheck(key);
+    return check ?? fallbackCheck;
+  }, [client, key, fallbackCheck]);
 
   return useSyncExternalStore(subscribe, getSnapshot);
 };

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -7,6 +7,7 @@ import {
   useSchematicContext,
   useSchematicEvents,
   useSchematicFlag,
+  useSchematicFlagCheck,
   useSchematicIsPending,
   type SchematicHookOpts,
   type UseSchematicFlagOpts,
@@ -17,22 +18,22 @@ export {
   useSchematicContext,
   useSchematicEvents,
   useSchematicFlag,
+  useSchematicFlagCheck,
   useSchematicIsPending,
   SchematicProvider,
 };
 
 export type { SchematicHookOpts, SchematicProviderProps, UseSchematicFlagOpts };
 
-export { Schematic } from "@schematichq/schematic-js";
+export { RuleType, Schematic, UsagePeriod } from "@schematichq/schematic-js";
 
 export type {
+  CheckFlagReturn,
   Event,
   EventBody,
   EventBodyIdentify,
   EventBodyTrack,
   EventType,
-  FlagCheckResponseBody,
-  FlagCheckWithKeyResponseBody,
   Keys,
   SchematicContext,
   SchematicOptions,


### PR DESCRIPTION
needs https://github.com/SchematicHQ/schematic-js/pull/219

Adds new `useSchematicFlagCheck` hook which will return the full check object, rather than just its boolean value.