### PR TITLE
add two minor fixes

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-components",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/schematic-components.cjs.js",
   "module": "dist/schematic-components.esm.js",
   "types": "dist/schematic-components.d.ts",

--- a/components/src/components/shared/checkout-dialog/Checkout.tsx
+++ b/components/src/components/shared/checkout-dialog/Checkout.tsx
@@ -105,7 +105,12 @@ export const Checkout = ({
             <Text $size={18}>{t("Add payment method")}</Text>
           </Box>
 
-          <PaymentForm onConfirm={(value) => setPaymentMethodId(value)} />
+          <PaymentForm
+            onConfirm={(value) => {
+              setPaymentMethodId(value);
+              togglePaymentForm();
+            }}
+          />
 
           {data.subscription?.paymentMethod && (
             <Box>

--- a/components/src/components/shared/payment-form/PaymentForm.tsx
+++ b/components/src/components/shared/payment-form/PaymentForm.tsx
@@ -84,6 +84,7 @@ export const PaymentForm = ({ onConfirm }: PaymentFormProps) => {
         id="submit"
         disabled={isLoading || !stripe || !elements || isConfirmed}
         isLoading={isLoading}
+        style={{ flexShrink: 0 }}
         $color="primary"
       >
         {isLoading ? t("Loading") : t("Save payment method")}


### PR DESCRIPTION
adds two small fixes noticed during final (final) bug bash

we were unable to add a promo code after adding our payment method, so this change toggles the payment form correctly after successfully saving a payment method

the save payment method button also could get squished in certain circumstances, so this change forces it to full height