### PR TITLE
Allow an alternative form to `identify`

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -233,10 +233,9 @@ export class Schematic {
    */
   identify = (body: EventBodyIdentify): Promise<void> => {
     try {
-      let userKeys = body.user?.keys || body.keys
       this.setContext({
         company: body.company?.keys,
-        user: userKeys,
+        user: body.user?.keys || body.keys,
       });
     } catch (error) {
       console.error("Error setting context:", error);

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -233,9 +233,10 @@ export class Schematic {
    */
   identify = (body: EventBodyIdentify): Promise<void> => {
     try {
+      let userKeys = body.user?.keys || body.keys
       this.setContext({
         company: body.company?.keys,
-        user: body.keys,
+        user: userKeys,
       });
     } catch (error) {
       console.error("Error setting context:", error);

--- a/js/src/types/index.ts
+++ b/js/src/types/index.ts
@@ -23,6 +23,11 @@ export type EventBodyIdentify = {
     name?: string;
     traits?: Traits;
   };
+  user?: {
+    keys?: Keys;
+    name?: string;
+    traits?: Traits;
+  };
   keys?: Keys;
   name?: string;
   traits?: Traits;


### PR DESCRIPTION
`identify` and `track` use a different shape for passing in user/company data

```js
identify({
  company: { keys: { }, name: "", traits: { } },
  // user data
  keys: { },
  name: "",
  traits: { }
})

track({
  company: { keys: { }, name: "", traits: { } },
  user: { keys: { }, name: "", traits: { } },
})
```

This PR allows `identify` to work like `track` (i.e. passing in a `user` object with the relevant data, instead of attaching them at the top level). This confused Sonny (and I found it confusing when applying), and _not_ having a specific `user` key leaves us open to some downstream name collisions. 

In this PR, I opt to use `body.users.keys || body.keys`, but we could also merge the 2 arrays. 

After merging this, I think we change the docs to use the new form. We could start issue warnings, or just leave it for now. 