### PR TITLE
Fix `getServerSnapshot` errors

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-react",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "dist/schematic-react.cjs.js",
   "module": "dist/schematic-react.esm.js",
   "types": "dist/schematic-react.d.ts",

--- a/react/src/hooks/schematic.ts
+++ b/react/src/hooks/schematic.ts
@@ -69,7 +69,7 @@ export const useSchematicFlag = (
     return typeof value === "undefined" ? fallback : value;
   }, [client, key, fallback]);
 
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, () => fallback);
 };
 
 export const useSchematicEntitlement = (
@@ -98,7 +98,7 @@ export const useSchematicEntitlement = (
     return check ?? fallbackCheck;
   }, [client, key, fallbackCheck]);
 
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, () => fallbackCheck);
 };
 
 export const useSchematicIsPending = (opts?: SchematicHookOpts) => {
@@ -111,5 +111,5 @@ export const useSchematicIsPending = (opts?: SchematicHookOpts) => {
 
   const getSnapshot = useCallback(() => client.getIsPending(), [client]);
 
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, () => true);
 };

--- a/react/src/version.ts
+++ b/react/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.2.1";
+export const version = "1.2.3";


### PR DESCRIPTION
## Overview 

Our react SDK is not built for SSR. In our nextjs demo, we try to wrap the whole component in a check to make sure that we're never server rendering. Our users may not always do that, so we'd like to at least make sure we're not throwing errors. This PR (hopefully) achieves that. 

Specifically, there is a 3rd parameter to [useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore) that is a `fn` to generate a server snapshot. We are now using that and passing in the starting values we're already using. 

## Testing

I've opened a branch on the weather app to test this (`ryan/test-ssr`). If you load that branch now, you should see SSR errors thrown (in console, but the UI still loads). 

Next, we'll want to use our local version of this branch to "fix" the issues we're seeing with the weather app. 

1. In the `react` folder of this project, run `yarn link`. This should spit out a message saying it's done (or that it's been done before). 
    - Underneath the hood, this is setting up a symlink in your global npm folder to this project folder
3. The run `yarn build` to actually prepare the built files. (You can see these in the `dist` folder. The specific file that's will be used by the weather app is `dist/schematic-react.cjs.js` and `dist/schematic-react.d.ts`
4. In the weather app project, run `yarn link @schematichq/schematic-react`. This will cause the weather app to delete the npm package it downloaded and instead use the global symlink you created above (so now it will use your locally built version of `schematic-react`. 
    - If you browse into `node_modules/@schematichq/schematic-react` this should now be your local folder. You can tell because it will have a `src` directory which isn't part of the npm downloaded package
5. Run the weather app (`yarn dev`) and the server side errors should be gone. 

When you're done, run `yarn unlink @schematichq/schematic-react` in the weather app project to stop using your local copy. 