### PR TITLE
Debug mode, offline mode, and flag check events

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -82,6 +82,36 @@ await schematic.checkFlag("some-flag-key");
 schematic.cleanup();
 ```
 
+## Troubleshooting
+
+For debugging and development, Schematic supports two special modes:
+
+### Debug Mode
+
+Enables console logging of all Schematic operations:
+
+```typescript
+// Enable at initialization
+const schematic = new Schematic("your-api-key", { debug: true });
+
+// Or via URL parameter
+// https://yoursite.com/?schematic_debug=true
+```
+
+### Offline Mode
+
+Prevents network requests and returns fallback values for all flag checks:
+
+```typescript
+// Enable at initialization
+const schematic = new Schematic("your-api-key", { offline: true });
+
+// Or via URL parameter
+// https://yoursite.com/?schematic_offline=true
+```
+
+Offline mode automatically enables debug mode to help with troubleshooting.
+
 ## License
 
 MIT

--- a/js/jest.config.js
+++ b/js/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   transform: {
     "^.+\\.(ts|tsx)?$": "ts-jest",
   },
+  testMatch: ["<rootDir>/src/**/*.spec.ts"],
 };
 
 global.WebSocket = require("mock-socket").WebSocket;

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/schematic.cjs.js",
   "module": "dist/schematic.esm.js",
   "types": "dist/schematic.d.ts",

--- a/js/src/types/index.ts
+++ b/js/src/types/index.ts
@@ -1,6 +1,7 @@
 import { CheckFlagResponseDataFromJSON } from "./api/models/CheckFlagResponseData";
+import { EventBodyFlagCheck } from "./api/models/EventBodyFlagCheck";
 
-export type EventType = "identify" | "track";
+export type EventType = "identify" | "track" | "flag_check";
 
 /** A record of unique key-value pairs used for identifying a company or user */
 export type Keys = Record<string, string>;
@@ -34,7 +35,7 @@ export type EventBodyTrack = SchematicContext & {
   traits?: Traits;
 };
 
-export type EventBody = EventBodyIdentify | EventBodyTrack;
+export type EventBody = EventBodyIdentify | EventBodyTrack | EventBodyFlagCheck;
 
 export type Event = {
   api_key: string;
@@ -116,8 +117,17 @@ export type SchematicOptions = {
   /** Optionally provide a custom API URL */
   apiUrl?: string;
 
+  /** Enable debug mode to log flag check results and events to the console.
+   * Can also be enabled at runtime via URL query parameter "schematic_debug=true" */
+  debug?: boolean;
+
   /** Optionally provide a custom event URL */
   eventUrl?: string;
+
+  /** Enable offline mode to prevent all network requests.
+   * When enabled, events are only logged not sent, and flag checks return fallback values.
+   * Can also be enabled at runtime via URL query parameter "schematic_offline=true" */
+  offline?: boolean;
 
   /** Optionally provide a custom storage persister for client-side storage */
   storage?: StoragePersister;
@@ -191,6 +201,8 @@ export const CheckFlagReturnFromJSON = (
   };
 };
 
+export type { EventBodyFlagCheck } from "./api/models/EventBodyFlagCheck";
+export { EventBodyFlagCheckToJSON } from "./api/models/EventBodyFlagCheck";
 export type { CheckFlagResponseData } from "./api/models/CheckFlagResponseData";
 export { CheckFlagResponseFromJSON } from "./api/models/CheckFlagResponse";
 export { CheckFlagsResponseFromJSON } from "./api/models/CheckFlagsResponse";

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.2.1';
+export const version = '1.2.2';


### PR DESCRIPTION
* Adds a debug mode; in debug mode, we log a lot of things like flag checks, events, etc. Debug mode can be initialized either with a `debug` initialization option, or at runtime using a `schematic_debug` query param.
* Adds an offline model; in offline mode, no network requests are attempted. All flag checks will just return their fallback values, and events will simply log (we enabled debug mode automatically when offline mode is enabled). Similalrly, this can be enabled via an initialization option (`offline`) or a query parameter (`schematic_offline`).
* Adds flag check events; flag check events will be sent anytime a single flag check is executed (`checkFlag` function), or (so that this works with React), anytime there are listeners in websocket mode where the flag value has changed (this is what will make this work with useSchematicFlag and useSchematicEntitlement; for any instance of either of those two hooks, we'll log the initial flag check and log again if it changes).


Offline mode:
![image](https://github.com/user-attachments/assets/5ef7b9da-caec-4308-bb42-e79a0387426d)


Debug mode:
![image](https://github.com/user-attachments/assets/9b78791b-9a72-469c-bfd9-d6c93c9ada95)


Flag checks logs from React showing in app: 
![image](https://github.com/user-attachments/assets/e5197a8a-7477-423c-8842-97dca6631cfe)
