### PR TITLE
[SCH-3067] Remove check for `accessToken` within the `Embed` wrapping component

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-components",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "main": "dist/schematic-components.cjs.js",
   "module": "dist/schematic-components.esm.js",
   "types": "dist/schematic-components.d.ts",

--- a/components/src/components/embed/Embed.tsx
+++ b/components/src/components/embed/Embed.tsx
@@ -15,19 +15,6 @@ export const SchematicEmbed = ({
   apiConfig,
   debug,
 }: EmbedProps) => {
-  if (accessToken?.length === 0) {
-    return <div>Please provide an access token.</div>;
-  }
-
-  if (!accessToken?.startsWith("token_")) {
-    return (
-      <div>
-        Invalid access token; your temporary access token will start with
-        "token_".
-      </div>
-    );
-  }
-
   return (
     <EmbedProvider
       id={id}


### PR DESCRIPTION
The provider handles "falsy" values by itself and the early return prevents a proper checkout flow.