### PR TITLE
Require payment if the plan contains pay-as-you-go or overage entitlements

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -136,15 +136,29 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
     [usageBasedEntitlements],
   );
 
+  const payAsYouGoOrOverageEntitlements = useMemo(
+    () =>
+      usageBasedEntitlements.filter(
+        (entitlement) =>
+          entitlement.priceBehavior === "pay_as_you_go" ||
+          entitlement.priceBehavior === "overage",
+      ),
+    [usageBasedEntitlements],
+  );
+
   const hasActiveAddOns = addOns.some((addOn) => addOn.isSelected);
   const hasActivePayInAdvanceEntitlements = payInAdvanceEntitlements.some(
     ({ quantity }) => quantity > 0,
   );
+  const hasPayAsYouGoOrOverageEntitlements =
+    payAsYouGoOrOverageEntitlements.length > 0;
+
   const requiresPayment =
     (!selectedPlan?.companyCanTrial || !!data.trialPaymentMethodRequired) &&
     (!selectedPlan?.isFree ||
       hasActiveAddOns ||
-      hasActivePayInAdvanceEntitlements);
+      hasActivePayInAdvanceEntitlements ||
+      hasPayAsYouGoOrOverageEntitlements);
 
   const checkoutStages = useMemo(() => {
     const stages: CheckoutStage[] = [


### PR DESCRIPTION
We should also prevent this on the setup side, but I think it's more important to check this during checkout. If there is a pay-as-you-go or overage entitlement included as part of the checkout, then the checkout must include a payment method, because the customer may incur charges against either of those entitlement prices.