### PR TITLE
Wait for context before sending track events to prevent identify/track race

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-* @SchematicHQ/frontend 
-
+components @SchematicHQ/frontend
+js @SchematicHQ/devtools
+react @SchematicHQ/devtools

--- a/js/.claude/settings.json
+++ b/js/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(awk:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(npx jest:*)",
+      "Bash(yarn)",
+      "Bash(yarn build)",
+      "Bash(yarn format)",
+      "Bash(yarn lint)",
+      "Bash(yarn openapi)",
+      "Bash(yarn test)"
+    ],
+    "deny": []
+  }
+}

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- Build: `yarn build`
+- Lint: `yarn lint`
+- Format: `yarn format`
+- Test all: `yarn test`
+- Test single file: `jest src/path/to/file.spec.ts`
+- Test specific test: `jest -t "test description pattern"`
+
+## Code Style
+
+- Use TypeScript with strict type checking
+- Follow ESLint rules, particularly `@typescript-eslint/strict-boolean-expressions`
+- Use explicit null/undefined checks instead of truthy/falsy patterns (e.g., `if (value === null)` not `if (!value)`)
+- Format code with Prettier
+- Use async/await for asynchronous code
+- Export types from dedicated type files
+- Use camelCase for variables/functions, PascalCase for classes/interfaces
+- Organize imports: built-ins first, then external modules, then local imports
+- For class properties, define private properties with leading underscore

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-js",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "dist/schematic.cjs.js",
   "module": "dist/schematic.esm.js",
   "types": "dist/schematic.d.ts",

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.2.2';
+export const version = '1.2.4';


### PR DESCRIPTION
Depending on client implementation, there can sometimes be a race such that the identify call happens slightly after some initial track events, leading those track events to be sent without a context and thus not attributed to any company or user. In a browser context, I think we can expect there to always be a context, so to prevent such issues we can enqueue context-less track events until context is set, at which point we send them in bulk.

I was able to repro this issue on the Weather demo app yesterday, there's an initial track event that occurs for the search that happens on page load, and its often sent without a context, while subsequent searches are correctly tracked because they occur after context is set.