### PR TITLE
Update to included credits in plan design

### DIFF
--- a/components/src/components/elements/pricing-table/Plan.tsx
+++ b/components/src/components/elements/pricing-table/Plan.tsx
@@ -125,9 +125,7 @@ export const Plan = ({
     isHydratedPlan(plan) && plan.current && currentPeriod === selectedPeriod;
   const { price: planPrice, currency: planCurrency } =
     getPlanPrice(plan, selectedPeriod) || {};
-  const credits = isHydratedPlan(plan)
-    ? groupPlanCreditGrants(plan.includedCreditGrants)
-    : [];
+  const credits = groupPlanCreditGrants(plan.includedCreditGrants);
 
   const hasUsageBasedEntitlements = plan.entitlements.some(
     (entitlement) => !!entitlement.priceBehavior,

--- a/components/src/components/shared/checkout-dialog/Plan.tsx
+++ b/components/src/components/shared/checkout-dialog/Plan.tsx
@@ -314,9 +314,7 @@ export const Plan = ({
       {plans.map((plan, planIndex) => {
         const { price: planPrice, currency: planCurrency } =
           getPlanPrice(plan, period) || {};
-        const credits = isHydratedPlan(plan)
-          ? groupPlanCreditGrants(plan.includedCreditGrants)
-          : [];
+        const credits = groupPlanCreditGrants(plan.includedCreditGrants);
         const hasUsageBasedEntitlements = plan.entitlements.some(
           (entitlement) => !!entitlement.priceBehavior,
         );


### PR DESCRIPTION
Included credit grants are now available via the `public/plans` api endpoint, so we no longer need to check for the type of `hydrate` data.