### PR TITLE
fix: `useAvailablePlans` hook usage

### DIFF
--- a/components/src/components/elements/pricing-table/PricingTable.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.tsx
@@ -136,6 +136,8 @@ export const PricingTable = forwardRef<
     const { data, settings, isPending, hydratePublic } = useEmbed();
 
     const { currentPeriod, showPeriodToggle, isStandalone } = useMemo(() => {
+      const showPeriodToggle = data.showPeriodToggle ?? props.showPeriodToggle;
+
       if (isCheckoutData(data)) {
         const billingSubscription = data.company?.billingSubscription;
         const isTrialSubscription = billingSubscription?.status === "trialing";
@@ -145,7 +147,7 @@ export const PricingTable = forwardRef<
           currentPeriod: data.company?.plan?.planPeriod || "month",
           currentAddOns: data.company?.addOns || [],
           canCheckout: data.capabilities?.checkout ?? true,
-          showPeriodToggle: data.showPeriodToggle ?? props.showPeriodToggle,
+          showPeriodToggle,
           isTrialSubscription,
           willSubscriptionCancel,
           isStandalone: false,
@@ -156,7 +158,7 @@ export const PricingTable = forwardRef<
         currentPeriod: "month",
         currentAddOns: [],
         canCheckout: true,
-        showPeriodToggle: props.showPeriodToggle,
+        showPeriodToggle,
         isTrialSubscription: false,
         willSubscriptionCancel: false,
         isStandalone: true,

--- a/components/src/components/elements/pricing-table/PricingTable.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.tsx
@@ -136,7 +136,7 @@ export const PricingTable = forwardRef<
     const { data, settings, isPending, hydratePublic } = useEmbed();
 
     const { currentPeriod, showPeriodToggle, isStandalone } = useMemo(() => {
-      const showPeriodToggle = data.showPeriodToggle ?? props.showPeriodToggle;
+      const showPeriodToggle = data?.showPeriodToggle ?? props.showPeriodToggle;
 
       if (isCheckoutData(data)) {
         const billingSubscription = data.company?.billingSubscription;

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -108,22 +108,6 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
 
-  const currentPeriod = useMemo(
-    () =>
-      checkoutState?.period ||
-      (isCheckoutData(data) && data.company?.plan?.planPeriod) ||
-      "month",
-    [data, checkoutState?.period],
-  );
-
-  const [planPeriod, setPlanPeriod] = useState(currentPeriod);
-
-  const {
-    plans: availablePlans,
-    addOns: availableAddOns,
-    periods: availablePeriods,
-  } = useAvailablePlans(planPeriod);
-
   const {
     currentPlanId,
     currentEntitlements,
@@ -148,6 +132,24 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
       trialPaymentMethodRequired: false,
     };
   }, [data]);
+
+  const currentPeriod = useMemo(
+    () =>
+      checkoutState?.period ||
+      (isCheckoutData(data) && data.company?.plan?.planPeriod) ||
+      "month",
+    [data, checkoutState?.period],
+  );
+
+  const [planPeriod, setPlanPeriod] = useState(currentPeriod);
+
+  const {
+    plans: availablePlans,
+    addOns: availableAddOns,
+    periods: availablePeriods,
+  } = useAvailablePlans(planPeriod, {
+    useSelectedPeriod: showPeriodToggle,
+  });
 
   const [selectedPlan, setSelectedPlan] = useState<SelectedPlan | undefined>(
     () => {


### PR DESCRIPTION
- Allows `PricingTable` to honor the `showPeriodToggle` option from the plangroup config
- Filters the `availablePlans ` used in `CheckoutDialog` based on the `showPeriodToggle` option from the plangroup config