### PR TITLE
Filter add-ons in "Add-ons Quantity" stage

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -926,7 +926,10 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
               isLoading={isLoading}
               period={planPeriod}
               selectedPlan={selectedPlan}
-              entitlements={addOnUsageBasedEntitlements}
+              entitlements={addOnUsageBasedEntitlements.filter(
+                (entitlement) =>
+                  entitlement.priceBehavior === PriceBehavior.PayInAdvance,
+              )}
               updateQuantity={updateAddOnEntitlementQuantity}
             />
           ) : checkoutStage === "credits" ? (

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -233,6 +233,15 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
     [usageBasedEntitlements],
   );
 
+  const addOnPayInAdvanceEntitlements = useMemo(
+    () =>
+      addOnUsageBasedEntitlements.filter(
+        (entitlement) =>
+          entitlement.priceBehavior === PriceBehavior.PayInAdvance,
+      ),
+    [addOnUsageBasedEntitlements],
+  );
+
   const [promoCode, setPromoCode] = useState<string | null>(null);
 
   const [isPaymentMethodRequired, setIsPaymentMethodRequired] = useState(false);
@@ -926,10 +935,7 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
               isLoading={isLoading}
               period={planPeriod}
               selectedPlan={selectedPlan}
-              entitlements={addOnUsageBasedEntitlements.filter(
-                (entitlement) =>
-                  entitlement.priceBehavior === PriceBehavior.PayInAdvance,
-              )}
+              entitlements={addOnPayInAdvanceEntitlements}
               updateQuantity={updateAddOnEntitlementQuantity}
             />
           ) : checkoutStage === "credits" ? (


### PR DESCRIPTION
Previously, we'd include pay-as-you-go types here, but it was only visible if an existing user was modifying a plan, so we missed it.
