### PR TITLE
Selected plan entitlement details are overwriting feature usage details on initial load

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -200,7 +200,6 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
       [],
     ),
   );
-  console.debug(usageBasedEntitlements);
 
   const [addOnUsageBasedEntitlements, setAddOnUsageBasedEntitlements] =
     useState<UsageBasedEntitlement[]>(() => {
@@ -613,6 +612,7 @@ export const CheckoutDialog = ({ top = 0 }: CheckoutDialogProps) => {
       });
     },
     [
+      selectedPlan?.id,
       planPeriod,
       shouldTrial,
       willTrialWithoutPaymentMethod,


### PR DESCRIPTION
This prevents certain attributes like `allocation` defined by the user's current feature usage from being overwritten during plan selection if the plan is _not_ actually changing.