### PR TITLE
Revert "Normalize Embed data between PublicPlansResponseData and `ComponentHydrateResponseData` (#557)"

### DIFF
--- a/components/src/components/elements/included-features/IncludedFeatures.tsx
+++ b/components/src/components/elements/included-features/IncludedFeatures.tsx
@@ -10,7 +10,11 @@ import {
   useWrapChildren,
 } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
-import { createKeyboardExecutionHandler, toPrettyDate } from "../../../utils";
+import {
+  createKeyboardExecutionHandler,
+  isCheckoutData,
+  toPrettyDate,
+} from "../../../utils";
 import { Element } from "../../layout";
 import { Box, Flex, Icon, Text } from "../../ui";
 
@@ -91,32 +95,35 @@ export const IncludedFeatures = forwardRef<
   const [showCount, setShowCount] = useState(VISIBLE_ENTITLEMENT_COUNT);
 
   const { plan, addOns, featureUsage } = useMemo(() => {
-    const orderedFeatureUsage = props.visibleFeatures?.reduce(
-      (acc: FeatureUsageResponseData[], id) => {
-        const mappedFeatureUsage = data?.featureUsage?.features.find(
-          (usage) => usage.feature?.id === id,
-        );
+    if (isCheckoutData(data)) {
+      const orderedFeatureUsage = props.visibleFeatures?.reduce(
+        (acc: FeatureUsageResponseData[], id) => {
+          const mappedFeatureUsage = data.featureUsage?.features.find(
+            (usage) => usage.feature?.id === id,
+          );
 
-        if (mappedFeatureUsage) {
-          acc.push(mappedFeatureUsage);
-        }
+          if (mappedFeatureUsage) {
+            acc.push(mappedFeatureUsage);
+          }
 
-        return acc;
-      },
-      [],
-    );
+          return acc;
+        },
+        [],
+      );
+
+      return {
+        plan: data.company?.plan,
+        addOns: data.company?.addOns || [],
+        featureUsage: orderedFeatureUsage || data.featureUsage?.features || [],
+      };
+    }
 
     return {
-      plan: data?.company?.plan,
-      addOns: data?.company?.addOns || [],
-      featureUsage: orderedFeatureUsage || data?.featureUsage?.features || [],
+      plan: undefined,
+      addOns: [],
+      featureUsage: [],
     };
-  }, [
-    props.visibleFeatures,
-    data?.company?.plan,
-    data?.company?.addOns,
-    data?.featureUsage?.features,
-  ]);
+  }, [props.visibleFeatures, data]);
 
   const featureListSize = featureUsage.length;
 

--- a/components/src/components/elements/included-features/UsageDetails.tsx
+++ b/components/src/components/elements/included-features/UsageDetails.tsx
@@ -10,6 +10,7 @@ import {
   formatNumber,
   getFeatureName,
   getUsageDetails,
+  isCheckoutData,
   shortenPeriod,
   toPrettyDate,
 } from "../../../utils";
@@ -52,8 +53,11 @@ export const UsageDetails = ({
   const { data } = useEmbed();
 
   const period = useMemo(() => {
-    return data?.company?.plan?.planPeriod || undefined;
-  }, [data?.company?.plan?.planPeriod]);
+    return isCheckoutData(data) &&
+      typeof data.company?.plan?.planPeriod === "string"
+      ? data.company.plan.planPeriod
+      : undefined;
+  }, [data]);
 
   const { billingPrice, cost, currentTier } = useMemo(
     () => getUsageDetails(entitlement, period),

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -21,6 +21,7 @@ import {
   getFeatureName,
   getUsageDetails,
   groupCreditGrants,
+  isCheckoutData,
   modifyDate,
   toPrettyDate,
   type UsageDetails,
@@ -171,45 +172,51 @@ export const MeteredFeatures = forwardRef<
   const isLightBackground = useIsLightBackground();
 
   const { period, meteredFeatures, creditGroups } = useMemo(() => {
-    const period = data?.company?.plan?.planPeriod || undefined;
-    const orderedFeatureUsage = props.visibleFeatures?.reduce(
-      (acc: FeatureUsageResponseData[], id) => {
-        const mappedFeatureUsage = data?.featureUsage?.features.find(
-          (usage) => usage.feature?.id === id,
-        );
+    if (isCheckoutData(data)) {
+      const period =
+        typeof data.company?.plan?.planPeriod === "string"
+          ? data.company?.plan?.planPeriod
+          : undefined;
+      const orderedFeatureUsage = props.visibleFeatures?.reduce(
+        (acc: FeatureUsageResponseData[], id) => {
+          const mappedFeatureUsage = data.featureUsage?.features.find(
+            (usage) => usage.feature?.id === id,
+          );
 
-        if (mappedFeatureUsage) {
-          acc.push(mappedFeatureUsage);
-        }
+          if (mappedFeatureUsage) {
+            acc.push(mappedFeatureUsage);
+          }
 
-        return acc;
-      },
-      [],
-    );
+          return acc;
+        },
+        [],
+      );
+
+      return {
+        period,
+        meteredFeatures: (
+          orderedFeatureUsage ||
+          data.featureUsage?.features ||
+          []
+        ).filter(
+          ({ priceBehavior, feature }) =>
+            // credit-based entitlements behave differently and should not be shown as a metered feature
+            priceBehavior !== PriceBehavior.Credit &&
+            (feature?.featureType === FeatureType.Event ||
+              feature?.featureType === FeatureType.Trait),
+        ),
+        creditGroups: groupCreditGrants(data.creditGrants, {
+          groupBy: "credit",
+        }),
+      };
+    }
 
     return {
-      period,
-      meteredFeatures: (
-        orderedFeatureUsage ||
-        data?.featureUsage?.features ||
-        []
-      ).filter(
-        ({ priceBehavior, feature }) =>
-          // credit-based entitlements behave differently and should not be shown as a metered feature
-          priceBehavior !== PriceBehavior.Credit &&
-          (feature?.featureType === FeatureType.Event ||
-            feature?.featureType === FeatureType.Trait),
-      ),
-      creditGroups: groupCreditGrants(data?.creditGrants || [], {
-        groupBy: "credit",
-      }),
+      period: undefined,
+      meteredFeatures: [],
+      creditGroups: [],
     };
-  }, [
-    props.visibleFeatures,
-    data?.company?.plan?.planPeriod,
-    data?.featureUsage?.features,
-    data?.creditGrants,
-  ]);
+  }, [props.visibleFeatures, data]);
 
   const [creditVisibility, setCreditVisibility] = useState(
     creditGroups.map(({ id }) => ({ id, isExpanded: false })),

--- a/components/src/components/elements/payment-method/PaymentMethod.tsx
+++ b/components/src/components/elements/payment-method/PaymentMethod.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from "react";
 import { type FontStyle } from "../../../context";
 import { useEmbed } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
+import { isCheckoutData } from "../../../utils";
 import { Element } from "../../layout";
 
 import { PaymentMethodElement } from "./PaymentMethodElement";
@@ -47,31 +48,38 @@ export const PaymentMethod = forwardRef<
   const { data, setLayout } = useEmbed();
 
   const { paymentMethod, monthsToExpiration } = useMemo(() => {
-    const paymentMethod =
-      data?.subscription?.paymentMethod || data?.company?.defaultPaymentMethod;
+    if (isCheckoutData(data)) {
+      const paymentMethod =
+        data.subscription?.paymentMethod || data.company?.defaultPaymentMethod;
 
-    let monthsToExpiration: number | undefined;
-    if (
-      typeof paymentMethod?.cardExpYear === "number" &&
-      typeof paymentMethod?.cardExpMonth === "number"
-    ) {
-      const now = new Date();
-      const currentYear = now.getFullYear();
-      const currentMonth = now.getMonth();
-      const timeToExpiration = Math.round(
-        +new Date(paymentMethod.cardExpYear, paymentMethod.cardExpMonth - 1) -
-          +new Date(currentYear, currentMonth),
-      );
-      monthsToExpiration = Math.round(
-        timeToExpiration / (1000 * 60 * 60 * 24 * 30),
-      );
+      let monthsToExpiration: number | undefined;
+      if (
+        typeof paymentMethod?.cardExpYear === "number" &&
+        typeof paymentMethod?.cardExpMonth === "number"
+      ) {
+        const now = new Date();
+        const currentYear = now.getFullYear();
+        const currentMonth = now.getMonth();
+        const timeToExpiration = Math.round(
+          +new Date(paymentMethod.cardExpYear, paymentMethod.cardExpMonth - 1) -
+            +new Date(currentYear, currentMonth),
+        );
+        monthsToExpiration = Math.round(
+          timeToExpiration / (1000 * 60 * 60 * 24 * 30),
+        );
+      }
+
+      return {
+        paymentMethod,
+        monthsToExpiration,
+      };
     }
 
     return {
-      paymentMethod,
-      monthsToExpiration,
+      paymentMethod: undefined,
+      monthsToExpiration: undefined,
     };
-  }, [data?.company?.defaultPaymentMethod, data?.subscription?.paymentMethod]);
+  }, [data]);
 
   return (
     <Element ref={ref} className={className}>

--- a/components/src/components/elements/payment-method/PaymentMethodDetails.tsx
+++ b/components/src/components/elements/payment-method/PaymentMethodDetails.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../../api/checkoutexternal";
 import { type FontStyle } from "../../../context";
 import { useEmbed, useIsLightBackground } from "../../../hooks";
-import { createKeyboardExecutionHandler } from "../../../utils";
+import { createKeyboardExecutionHandler, isCheckoutData } from "../../../utils";
 import { PaymentForm } from "../../shared";
 import { Box, Button, Flex, Icon, Loader, Text } from "../../ui";
 
@@ -67,16 +67,20 @@ export const PaymentMethodDetails = ({
   } = useEmbed();
 
   const { defaultPaymentMethod, paymentMethods, subscription } = useMemo(() => {
+    if (isCheckoutData(data)) {
+      return {
+        defaultPaymentMethod: data.company?.defaultPaymentMethod,
+        paymentMethods: data.company?.paymentMethods || [],
+        subscription: data.subscription,
+      };
+    }
+
     return {
-      defaultPaymentMethod: data?.company?.defaultPaymentMethod,
-      paymentMethods: data?.company?.paymentMethods || [],
-      subscription: data?.subscription,
+      defaultPaymentMethod: undefined,
+      paymentMethods: [],
+      subscription: undefined,
     };
-  }, [
-    data?.company?.defaultPaymentMethod,
-    data?.company?.paymentMethods,
-    data?.subscription,
-  ]);
+  }, [data]);
 
   const isLightBackground = useIsLightBackground();
 

--- a/components/src/components/elements/pricing-table/Plan.tsx
+++ b/components/src/components/elements/pricing-table/Plan.tsx
@@ -10,6 +10,8 @@ import {
   getPlanPrice,
   groupPlanCreditGrants,
   hexToHSL,
+  isCheckoutData,
+  isHydratedPlan,
 } from "../../../utils";
 import { cardBoxShadow } from "../../layout";
 import { Box, Button, Flex, Icon, Text, Tooltip } from "../../ui";
@@ -52,7 +54,7 @@ export const Plan = ({
 
   const { t } = useTranslation();
 
-  const { data, settings, accessToken, setCheckoutState } = useEmbed();
+  const { data, settings, setCheckoutState } = useEmbed();
 
   const isLightBackground = useIsLightBackground();
 
@@ -63,34 +65,36 @@ export const Plan = ({
     canCheckout,
     isTrialSubscription,
     willSubscriptionCancel,
-    showCallToAction,
     isStandalone,
+    showCallToAction,
   } = useMemo(() => {
-    const billingSubscription = data?.company?.billingSubscription;
-    const isTrialSubscription = billingSubscription?.status === "trialing";
-    const willSubscriptionCancel =
-      typeof billingSubscription?.cancelAt === "number";
-    const isStandalone = typeof accessToken === "undefined";
+    if (isCheckoutData(data)) {
+      const billingSubscription = data.company?.billingSubscription;
+      const isTrialSubscription = billingSubscription?.status === "trialing";
+      const willSubscriptionCancel =
+        typeof billingSubscription?.cancelAt === "number";
+
+      return {
+        currentPeriod: data.company?.plan?.planPeriod || "month",
+        canCheckout: data.capabilities?.checkout ?? true,
+        isTrialSubscription,
+        willSubscriptionCancel,
+        isStandalone: false,
+        showCallToAction: true,
+      };
+    }
 
     return {
-      currentPeriod: data?.company?.plan?.planPeriod || "month",
-      canCheckout: data?.capabilities?.checkout ?? true,
-      isTrialSubscription,
-      willSubscriptionCancel,
+      currentPeriod: "month",
+      canCheckout: true,
+      isTrialSubscription: false,
+      willSubscriptionCancel: false,
+      isStandalone: true,
       showCallToAction:
-        !isStandalone ||
         typeof sharedProps.callToActionUrl === "string" ||
         typeof sharedProps.onCallToAction === "function",
-      isStandalone,
     };
-  }, [
-    sharedProps.callToActionUrl,
-    sharedProps.onCallToAction,
-    data?.company?.billingSubscription,
-    data?.company?.plan?.planPeriod,
-    data?.capabilities?.checkout,
-    accessToken,
-  ]);
+  }, [data, sharedProps.callToActionUrl, sharedProps.onCallToAction]);
 
   const callToActionTarget = useMemo(() => {
     if (sharedProps.callToActionTarget) {
@@ -113,9 +117,12 @@ export const Plan = ({
 
   const cardPadding = settings.theme.card.padding / TEXT_BASE_SIZE;
 
-  const currentPlanIndex = plans.findIndex((plan) => plan.current);
+  const currentPlanIndex = plans.findIndex(
+    (plan) => isHydratedPlan(plan) && plan.current,
+  );
 
-  const isActivePlan = plan.current && currentPeriod === selectedPeriod;
+  const isActivePlan =
+    isHydratedPlan(plan) && plan.current && currentPeriod === selectedPeriod;
   const { price: planPrice, currency: planCurrency } =
     getPlanPrice(plan, selectedPeriod) || {};
   const credits = groupPlanCreditGrants(plan.includedCreditGrants);
@@ -341,7 +348,8 @@ export const Plan = ({
             <Button
               type="button"
               disabled={
-                (!plan.valid && !plan.custom) || (!isStandalone && !canCheckout)
+                ((isHydratedPlan(plan) && !plan.valid) || !canCheckout) &&
+                !plan.custom
               }
               {...(index > currentPlanIndex
                 ? {
@@ -372,7 +380,11 @@ export const Plan = ({
                       onClick: () => {
                         sharedProps.onCallToAction?.(plan);
 
-                        if (!isStandalone && !plan.custom) {
+                        if (
+                          !isStandalone &&
+                          isHydratedPlan(plan) &&
+                          !plan.custom
+                        ) {
                           setCheckoutState({
                             period: selectedPeriod,
                             planId: isActivePlan ? null : plan.id,
@@ -385,7 +397,7 @@ export const Plan = ({
             >
               {plan.custom ? (
                 (plan.customPlanConfig?.ctaText ?? t("Talk to support"))
-              ) : !plan.valid ? (
+              ) : isHydratedPlan(plan) && !plan.valid ? (
                 <Tooltip
                   trigger={
                     <Text as={Box} $align="center">
@@ -398,7 +410,9 @@ export const Plan = ({
                     </Text>
                   }
                 />
-              ) : plan.companyCanTrial && plan.isTrialable ? (
+              ) : isHydratedPlan(plan) &&
+                plan.companyCanTrial &&
+                plan.isTrialable ? (
                 t("Start X day trial", { days: plan.trialDays })
               ) : (
                 t("Choose plan")

--- a/components/src/components/elements/unsubscribe-button/UnsubscribeButton.tsx
+++ b/components/src/components/elements/unsubscribe-button/UnsubscribeButton.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { useEmbed } from "../../../hooks";
 import { ComponentStyle, DeepPartial, ElementProps } from "../../../types";
+import { isCheckoutData } from "../../../utils";
 import { Element } from "../../layout";
 import {
   Button,
@@ -70,10 +71,12 @@ export const UnsubscribeButton = forwardRef<
 
   const hasActiveSubscription = useMemo(() => {
     return (
-      data?.subscription?.status !== "cancelled" &&
-      !data?.subscription?.cancelAt
+      isCheckoutData(data) &&
+      data.subscription &&
+      data.subscription.status !== "cancelled" &&
+      !data.subscription.cancelAt
     );
-  }, [data?.subscription?.status, data?.subscription?.cancelAt]);
+  }, [data]);
 
   if (!hasActiveSubscription) {
     return null;

--- a/components/src/components/elements/upcoming-bill/UpcomingBill.tsx
+++ b/components/src/components/elements/upcoming-bill/UpcomingBill.tsx
@@ -11,6 +11,7 @@ import type { DeepPartial, ElementProps } from "../../../types";
 import {
   ERROR_UNKNOWN,
   formatCurrency,
+  isCheckoutData,
   isError,
   toPrettyDate,
 } from "../../../utils";
@@ -74,18 +75,25 @@ export const UpcomingBill = forwardRef<
   const [balances, setBalances] = useState<CurrencyBalance[]>([]);
 
   const discounts = useMemo(() => {
-    return (data?.subscription?.discounts || []).map((discount) => ({
-      couponId: discount.couponId,
-      customerFacingCode: discount.customerFacingCode || undefined,
-      currency: discount.currency || undefined,
-      amountOff: discount.amountOff ?? undefined,
-      percentOff: discount.percentOff ?? undefined,
-      isActive: discount.isActive,
-    }));
+    return ((isCheckoutData(data) && data.subscription?.discounts) || []).map(
+      (discount) => ({
+        couponId: discount.couponId,
+        customerFacingCode: discount.customerFacingCode || undefined,
+        currency: discount.currency || undefined,
+        amountOff: discount.amountOff ?? undefined,
+        percentOff: discount.percentOff ?? undefined,
+        isActive: discount.isActive,
+      }),
+    );
   }, [data]);
 
   const getInvoice = useCallback(async () => {
-    if (data?.component?.id && !data?.subscription?.cancelAt) {
+    if (
+      isCheckoutData(data) &&
+      data.component?.id &&
+      data.subscription &&
+      !data.subscription.cancelAt
+    ) {
       try {
         setError(undefined);
         setIsLoading(true);
@@ -123,7 +131,11 @@ export const UpcomingBill = forwardRef<
     getBalances();
   }, [getBalances]);
 
-  if (!data?.subscription || data?.subscription.cancelAt) {
+  if (
+    !isCheckoutData(data) ||
+    !data.subscription ||
+    data.subscription.cancelAt
+  ) {
     return null;
   }
 

--- a/components/src/components/embed/Embed.tsx
+++ b/components/src/components/embed/Embed.tsx
@@ -6,7 +6,7 @@ import { TEXT_BASE_SIZE } from "../../const";
 import { stub } from "../../context";
 import { useEmbed } from "../../hooks";
 import type { SerializedNodeWithChildren } from "../../types";
-import { ERROR_UNKNOWN, isError } from "../../utils";
+import { ERROR_UNKNOWN, isCheckoutData, isError } from "../../utils";
 import { Box, Flex, Loader, Text } from "../ui";
 
 import { createRenderer, getEditorState, parseEditorState } from "./renderer";
@@ -89,7 +89,7 @@ export const SchematicEmbed = ({ id, accessToken }: EmbedProps) => {
     const renderer = createRenderer();
 
     try {
-      if (data?.component?.ast) {
+      if (isCheckoutData(data) && data.component?.ast) {
         const nodes: SerializedNodeWithChildren[] = [];
         const compressed = data.component.ast;
         // `inflate` is not guaranteed to return a string
@@ -107,7 +107,7 @@ export const SchematicEmbed = ({ id, accessToken }: EmbedProps) => {
     } catch (err) {
       setError(isError(err) ? err : ERROR_UNKNOWN);
     }
-  }, [data?.component?.ast, setError, updateSettings]);
+  }, [data, setError, updateSettings]);
 
   // `EmbedProvider` provides a `ThemeContext`, therefore we need ensure that one exists.
   // If there is no `EmbedContext` available, we must check for the missing theme.

--- a/components/src/components/layout/root/Root.tsx
+++ b/components/src/components/layout/root/Root.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react";
 
+import { type ComponentHydrateResponseData } from "../../../api/checkoutexternal";
 import { type EmbedSettings } from "../../../context";
-import { HydrateData } from "../../../types";
 
 import { Container } from "./styles";
 
@@ -9,7 +9,7 @@ export { Container };
 
 export interface RootProps
   extends Omit<React.HTMLProps<HTMLDivElement>, "data"> {
-  data?: HydrateData;
+  data?: ComponentHydrateResponseData;
   settings?: EmbedSettings;
 }
 

--- a/components/src/components/shared/checkout-dialog/AddOns.tsx
+++ b/components/src/components/shared/checkout-dialog/AddOns.tsx
@@ -8,6 +8,7 @@ import {
   formatCurrency,
   getAddOnPrice,
   hexToHSL,
+  isHydratedPlan,
 } from "../../../utils";
 import { cardBoxShadow } from "../../layout";
 import { Box, Button, Flex, Icon, Text } from "../../ui";
@@ -36,6 +37,8 @@ export const AddOns = ({ addOns, toggle, isLoading, period }: AddOnsProps) => {
     >
       {addOns.map((addOn, index) => {
         const { price, currency } = getAddOnPrice(addOn, period) || {};
+        const isAddOnValid = isHydratedPlan(addOn) && addOn.valid;
+        const isAddOnCurrent = isHydratedPlan(addOn) && addOn.current;
 
         const overageEntitlement = addOn.entitlements?.find(
           (entitlement) => entitlement.priceBehavior === PriceBehavior.Overage,
@@ -129,7 +132,7 @@ export const AddOns = ({ addOns, toggle, isLoading, period }: AddOnsProps) => {
                 </Flex>
               )}
 
-              {addOn.current && (
+              {isAddOnCurrent && (
                 <Flex
                   $position="absolute"
                   $right="1rem"
@@ -156,7 +159,7 @@ export const AddOns = ({ addOns, toggle, isLoading, period }: AddOnsProps) => {
               {!addOn.isSelected ? (
                 <Button
                   type="button"
-                  disabled={isLoading || !addOn.valid}
+                  disabled={isLoading || !isAddOnValid}
                   onClick={() => toggle(addOn.id)}
                   $size="sm"
                   $color="primary"
@@ -168,14 +171,14 @@ export const AddOns = ({ addOns, toggle, isLoading, period }: AddOnsProps) => {
               ) : (
                 <Button
                   type="button"
-                  disabled={isLoading || !addOn.valid}
+                  disabled={isLoading || !isAddOnValid}
                   onClick={() => toggle(addOn.id)}
                   $size="sm"
-                  $color={addOn.current ? "danger" : "primary"}
-                  $variant={addOn.current ? "ghost" : "text"}
+                  $color={isAddOnCurrent ? "danger" : "primary"}
+                  $variant={isAddOnCurrent ? "ghost" : "text"}
                   $fullWidth
                 >
-                  {addOn.current ? (
+                  {isAddOnCurrent ? (
                     t("Remove add-on")
                   ) : (
                     <>

--- a/components/src/components/shared/payment-form/PaymentForm.tsx
+++ b/components/src/components/shared/payment-form/PaymentForm.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useEmbed } from "../../../hooks";
+import { isCheckoutData } from "../../../utils";
 import { Box, Button, Flex, Text } from "../../ui";
 
 import { Input, Label } from "./styles";
@@ -30,7 +31,7 @@ export const PaymentForm = ({ onConfirm }: PaymentFormProps) => {
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isPaymentComplete, setIsPaymentComplete] = useState(false);
   const [isAddressComplete, setIsAddressComplete] = useState(
-    () => !data?.checkoutSettings.collectAddress,
+    () => !isCheckoutData(data) || !data.checkoutSettings.collectAddress,
   );
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (
@@ -95,7 +96,7 @@ export const PaymentForm = ({ onConfirm }: PaymentFormProps) => {
         />
       </Box>
 
-      {stripe && data?.checkoutSettings.collectEmail && (
+      {stripe && isCheckoutData(data) && data.checkoutSettings.collectEmail && (
         <Box data-field="name" $marginBottom="1.5rem" $verticalAlign="top">
           <Label htmlFor="email">Email</Label>
           <Input
@@ -109,23 +110,26 @@ export const PaymentForm = ({ onConfirm }: PaymentFormProps) => {
         </Box>
       )}
 
-      {(data?.checkoutSettings.collectAddress ||
-        data?.checkoutSettings.collectPhone) && (
-        <Box $marginBottom="3.5rem">
-          <AddressElement
-            options={{
-              mode: "billing",
-              fields: {
-                phone: data.checkoutSettings.collectPhone ? "always" : "never",
-              },
-            }}
-            id="address-element"
-            onChange={(event) => {
-              setIsAddressComplete(event.complete);
-            }}
-          />
-        </Box>
-      )}
+      {isCheckoutData(data) &&
+        (data.checkoutSettings.collectAddress ||
+          data.checkoutSettings.collectPhone) && (
+          <Box $marginBottom="3.5rem">
+            <AddressElement
+              options={{
+                mode: "billing",
+                fields: {
+                  phone: data.checkoutSettings.collectPhone
+                    ? "always"
+                    : "never",
+                },
+              }}
+              id="address-element"
+              onChange={(event) => {
+                setIsAddressComplete(event.complete);
+              }}
+            />
+          </Box>
+        )}
 
       <Button
         id="submit"

--- a/components/src/components/shared/unsubscribe-dialog/UnsubscribeDialog.tsx
+++ b/components/src/components/shared/unsubscribe-dialog/UnsubscribeDialog.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAvailablePlans, useEmbed } from "../../../hooks";
-import { toPrettyDate } from "../../../utils";
+import { isCheckoutData, toPrettyDate } from "../../../utils";
 import { Button, Flex, Modal, ModalHeader, Text } from "../../ui";
 import { createActiveUsageBasedEntitlementsReducer } from "../checkout-dialog";
 import { Sidebar } from "../sidebar";
@@ -23,16 +23,26 @@ export const UnsubscribeDialog = ({ top = 0 }: UnsubscribeDialogProps) => {
 
   const { planPeriod, currentPlan, currentAddOns, featureUsage, cancelDate } =
     useMemo(() => {
+      if (isCheckoutData(data)) {
+        return {
+          planPeriod: data.company?.plan?.planPeriod || "month",
+          currentPlan: data.company?.plan,
+          currentAddOns: data.company?.addOns || [],
+          featureUsage: data.featureUsage,
+          cancelDate: new Date(
+            data.subscription?.cancelAt ||
+              data.upcomingInvoice?.dueDate ||
+              Date.now(),
+          ),
+        };
+      }
+
       return {
-        planPeriod: data?.company?.plan?.planPeriod || "month",
-        currentPlan: data?.company?.plan,
-        currentAddOns: data?.company?.addOns || [],
-        featureUsage: data?.featureUsage,
-        cancelDate: new Date(
-          data?.subscription?.cancelAt ||
-            data?.upcomingInvoice?.dueDate ||
-            Date.now(),
-        ),
+        planPeriod: "month",
+        currentPlan: undefined,
+        currentAddOns: [],
+        featureUsage: undefined,
+        cancelDate: new Date(),
       };
     }, [data]);
 

--- a/components/src/context/EmbedContext.tsx
+++ b/components/src/context/EmbedContext.tsx
@@ -4,6 +4,7 @@ import {
   type ChangeSubscriptionRequestBody,
   type CheckoutResponse,
   type CheckoutUnsubscribeResponse,
+  type ComponentHydrateResponseData,
   type DeletePaymentMethodResponse,
   type FetchCustomerBalanceResponse,
   type GetSetupIntentResponse,
@@ -13,11 +14,7 @@ import {
   type UpdatePaymentMethodResponse,
 } from "../api/checkoutexternal";
 import type { PublicPlansResponseData } from "../api/componentspublic";
-import type {
-  DeepPartial,
-  HydrateData,
-  HydrateDataWithContext,
-} from "../types";
+import type { DeepPartial } from "../types";
 
 import {
   initialState,
@@ -32,11 +29,13 @@ type DebouncedApiPromise<R> = Promise<R | undefined> | undefined;
 
 export interface EmbedContextProps extends EmbedState {
   hydratePublic: () => DebouncedApiPromise<PublicPlansResponseData>;
-  hydrate: () => DebouncedApiPromise<HydrateDataWithContext>;
-  hydrateComponent: (id: string) => DebouncedApiPromise<HydrateDataWithContext>;
+  hydrate: () => DebouncedApiPromise<ComponentHydrateResponseData>;
+  hydrateComponent: (
+    id: string,
+  ) => DebouncedApiPromise<ComponentHydrateResponseData>;
   hydrateExternal: (
-    fn: () => Promise<HydrateData>,
-  ) => DebouncedApiPromise<HydrateData>;
+    fn: () => Promise<ComponentHydrateResponseData>,
+  ) => DebouncedApiPromise<ComponentHydrateResponseData>;
   getUpcomingInvoice: (
     id: string,
   ) => DebouncedApiPromise<HydrateUpcomingInvoiceResponse>;
@@ -60,7 +59,7 @@ export interface EmbedContextProps extends EmbedState {
   setError: (error: Error) => void;
   setLayout: (layout: EmbedLayout) => void;
   setCheckoutState: (state: CheckoutState) => void;
-  setData: (data: HydrateDataWithContext) => void;
+  setData: (data: ComponentHydrateResponseData) => void;
   updateSettings: (
     settings: DeepPartial<EmbedSettings>,
     options?: { update?: boolean },

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -18,6 +18,7 @@ import {
   CheckoutexternalApi,
   Configuration as CheckoutConfiguration,
   type ChangeSubscriptionRequestBody,
+  type ComponentHydrateResponseData,
   type ConfigurationParameters,
 } from "../api/checkoutexternal";
 import {
@@ -25,11 +26,7 @@ import {
   Configuration as PublicConfiguration,
 } from "../api/componentspublic";
 import { DEBOUNCE_SETTINGS, FETCH_DEBOUNCE_TIMEOUT } from "../const";
-import type {
-  DeepPartial,
-  HydrateData,
-  HydrateDataWithContext,
-} from "../types";
+import type { DeepPartial } from "../types";
 import { ERROR_UNKNOWN, isError } from "../utils";
 
 import { EmbedContext } from "./EmbedContext";
@@ -197,7 +194,7 @@ export const EmbedProvider = ({
    * Accepts a function that returns data in `hydrate` format
    */
   const hydrateExternal = useCallback(async function (
-    fn: () => Promise<HydrateData>,
+    fn: () => Promise<ComponentHydrateResponseData>,
   ) {
     dispatch({ type: "HYDRATE_STARTED" });
 
@@ -388,7 +385,7 @@ export const EmbedProvider = ({
     dispatch({ type: "SET_ACCESS_TOKEN", token });
   }, []);
 
-  const setData = useCallback((data: HydrateDataWithContext) => {
+  const setData = useCallback((data: ComponentHydrateResponseData) => {
     dispatch({ type: "SET_DATA", data });
   }, []);
 
@@ -524,7 +521,6 @@ export const EmbedProvider = ({
   return (
     <EmbedContext.Provider
       value={{
-        accessToken: state.accessToken,
         isPending: state.isPending,
         stale: state.stale,
         data: state.data,

--- a/components/src/context/embedReducer.ts
+++ b/components/src/context/embedReducer.ts
@@ -2,15 +2,13 @@ import merge from "lodash/merge";
 
 import {
   type BillingSubscriptionResponseData,
+  type ComponentHydrateResponseData,
   type DeleteResponse,
   type PaymentMethodResponseData,
 } from "../api/checkoutexternal";
 import { type PublicPlansResponseData } from "../api/componentspublic";
-import type {
-  DeepPartial,
-  HydrateData,
-  HydrateDataWithContext,
-} from "../types";
+import type { DeepPartial, HydrateData } from "../types";
+import { isCheckoutData } from "../utils";
 
 import {
   defaultSettings,
@@ -32,8 +30,8 @@ type EmbedAction =
   | { type: "SET_ACCESS_TOKEN"; token: string }
   | { type: "HYDRATE_STARTED" }
   | { type: "HYDRATE_PUBLIC"; data: PublicPlansResponseData }
-  | { type: "HYDRATE"; data: HydrateDataWithContext }
-  | { type: "HYDRATE_COMPONENT"; data: HydrateDataWithContext }
+  | { type: "HYDRATE"; data: ComponentHydrateResponseData }
+  | { type: "HYDRATE_COMPONENT"; data: ComponentHydrateResponseData }
   | {
       type: "HYDRATE_EXTERNAL";
       data: HydrateData;
@@ -44,10 +42,7 @@ type EmbedAction =
   | { type: "DELETE_PAYMENT_METHOD"; paymentMethodId: string }
   | { type: "RESET" }
   | { type: "ERROR"; error: Error }
-  | {
-      type: "SET_DATA";
-      data: HydrateDataWithContext;
-    }
+  | { type: "SET_DATA"; data: ComponentHydrateResponseData }
   | {
       type: "UPDATE_SETTINGS";
       settings: DeepPartial<EmbedSettings>;
@@ -55,31 +50,6 @@ type EmbedAction =
     }
   | { type: "CHANGE_LAYOUT"; layout: EmbedLayout }
   | { type: "SET_CHECKOUT_STATE"; state: CheckoutState };
-
-function normalize(data?: HydrateData): HydrateDataWithContext {
-  return merge({}, data, {
-    activePlans: data?.activePlans.map((plan) => ({
-      companyCanTrial: false,
-      current: false,
-      valid: true,
-      ...plan,
-    })),
-    activeAddOns: data?.activeAddOns.map((plan) => ({
-      companyCanTrial: false,
-      current: false,
-      valid: true,
-      ...plan,
-    })),
-    activeUsageBasedEntitlements: [],
-    checkoutSettings: {
-      collectAddress: false,
-      collectEmail: false,
-      collectPhone: false,
-    },
-    creditBundles: [],
-    creditGrants: [],
-  });
-}
 
 export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
   switch (action.type) {
@@ -104,7 +74,7 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
     case "HYDRATE_EXTERNAL": {
       return {
         ...state,
-        data: normalize(action.data),
+        data: action.data,
         error: undefined,
         isPending: false,
         stale: false,
@@ -122,45 +92,53 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
     }
 
     case "UPDATE_PAYMENT_METHOD": {
-      const updated = normalize(state.data);
-
-      if (updated.subscription) {
-        updated.subscription.paymentMethod = action.paymentMethod;
+      if (!isCheckoutData(state.data)) {
+        return state;
       }
 
-      if (updated.company) {
-        const updatedPaymentMethods = updated.company.paymentMethods.filter(
+      const data = { ...state.data };
+
+      if (data.subscription) {
+        data.subscription.paymentMethod = action.paymentMethod;
+      }
+
+      if (data.company) {
+        const updatedPaymentMethods = data.company.paymentMethods.filter(
           (paymentMethod) => paymentMethod.id !== action.paymentMethod.id,
         );
-        updated.company.paymentMethods = [
+        data.company.paymentMethods = [
           action.paymentMethod,
           ...updatedPaymentMethods,
         ];
 
-        if (!updated.subscription) {
-          updated.company.defaultPaymentMethod = action.paymentMethod;
+        if (!data.subscription) {
+          data.company.defaultPaymentMethod = action.paymentMethod;
         }
       }
 
       return {
         ...state,
-        data: updated,
+        data,
       };
     }
 
     case "DELETE_PAYMENT_METHOD": {
-      const updated = normalize(state.data);
+      if (!isCheckoutData(state.data)) {
+        return state;
+      }
 
-      if (updated.company) {
-        const paymentMethods = [...updated.company.paymentMethods];
-        updated.company.paymentMethods = paymentMethods.filter(
+      const data = { ...state.data };
+
+      if (data.company) {
+        const paymentMethods = [...data.company.paymentMethods];
+        data.company.paymentMethods = paymentMethods.filter(
           (paymentMethod) => paymentMethod.id !== action.paymentMethodId,
         );
       }
 
       return {
         ...state,
-        data: updated,
+        data,
       };
     }
 

--- a/components/src/context/embedReducer.ts
+++ b/components/src/context/embedReducer.ts
@@ -64,7 +64,7 @@ function normalize(data?: HydrateData): HydrateDataWithContext {
       valid: true,
       ...plan,
     })),
-    activeAddOns: data?.activePlans.map((plan) => ({
+    activeAddOns: data?.activeAddOns.map((plan) => ({
       companyCanTrial: false,
       current: false,
       valid: true,

--- a/components/src/context/embedState.ts
+++ b/components/src/context/embedState.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, HydrateDataWithContext } from "../types";
+import type { ComponentProps, HydrateData } from "../types";
 
 export interface TypographySettings {
   fontFamily: string;
@@ -139,7 +139,7 @@ export interface EmbedState {
   isPending: boolean;
   stale: boolean;
   accessToken?: string;
-  data?: HydrateDataWithContext;
+  data?: HydrateData;
   error?: Error;
   settings: EmbedSettings;
   layout: EmbedLayout;

--- a/components/src/hooks/useAvailablePlans.ts
+++ b/components/src/hooks/useAvailablePlans.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 
 import { type CompanyPlanDetailResponseData } from "../api/checkoutexternal";
+import { type PlanViewPublicResponseData } from "../api/componentspublic";
 import type { SelectedPlan } from "../types";
 import { ChargeType } from "../utils";
 
@@ -35,7 +36,9 @@ export function useAvailablePlans(
   }, [data?.activePlans, data?.activeAddOns]);
 
   const getActivePlans = useCallback(
-    (plans: CompanyPlanDetailResponseData[]): SelectedPlan[] => {
+    (
+      plans: (PlanViewPublicResponseData | CompanyPlanDetailResponseData)[],
+    ): SelectedPlan[] => {
       const activePlans =
         settings.mode === "edit"
           ? plans.slice()

--- a/components/src/hooks/useTrialEnd.ts
+++ b/components/src/hooks/useTrialEnd.ts
@@ -7,7 +7,7 @@ import {
   MINUTES_IN_MS,
   SECONDS_IN_MS,
 } from "../const";
-import { pluralize } from "../utils";
+import { isCheckoutData, pluralize } from "../utils";
 
 import { useEmbed } from ".";
 
@@ -17,7 +17,9 @@ export function useTrialEnd() {
   const { data } = useEmbed();
 
   const { endDate, formatted } = useMemo(() => {
-    const billingSubscription = data?.company?.billingSubscription;
+    const billingSubscription = isCheckoutData(data)
+      ? data.company?.billingSubscription
+      : undefined;
 
     const end =
       typeof billingSubscription?.trialEnd === "number"

--- a/components/src/types/api.ts
+++ b/components/src/types/api.ts
@@ -11,17 +11,18 @@ import {
   type FeatureUsageResponseData,
   type PlanEntitlementResponseData,
 } from "../api/checkoutexternal";
-import { type PublicPlansResponseData } from "../api/componentspublic";
+import {
+  type PlanViewPublicResponseData,
+  type PublicPlansResponseData,
+} from "../api/componentspublic";
 
 export type HydrateData =
   | PublicPlansResponseData
   | ComponentHydrateResponseData;
 
-export type HydrateDataWithContext = ComponentHydrateResponseData;
-
 export type BillingPrice = BillingPriceView | BillingPriceResponseData;
 
-export type Plan = CompanyPlanDetailResponseData;
+export type Plan = CompanyPlanDetailResponseData | PlanViewPublicResponseData;
 export type SelectedPlan = Plan & { isSelected: boolean };
 
 export interface Credit {

--- a/components/src/utils/api/hydrate.ts
+++ b/components/src/utils/api/hydrate.ts
@@ -1,0 +1,12 @@
+import { type ComponentHydrateResponseData } from "../../api/checkoutexternal";
+import type { HydrateData } from "../../types";
+
+export function isHydrateData(data?: unknown): data is HydrateData {
+  return typeof data === "object" && data !== null && "activePlans" in data;
+}
+
+export function isCheckoutData(
+  data?: unknown,
+): data is ComponentHydrateResponseData {
+  return typeof data === "object" && data !== null && "company" in data;
+}

--- a/components/src/utils/api/index.ts
+++ b/components/src/utils/api/index.ts
@@ -2,4 +2,5 @@ export * from "./billing";
 export * from "./credit";
 export * from "./entitlement";
 export * from "./feature";
+export * from "./hydrate";
 export * from "./plan";

--- a/components/src/utils/api/plan.ts
+++ b/components/src/utils/api/plan.ts
@@ -1,6 +1,13 @@
 import { type CompanyPlanDetailResponseData } from "../../api/checkoutexternal";
 import { type PlanViewPublicResponseData } from "../../api/componentspublic";
 import { VISIBLE_ENTITLEMENT_COUNT } from "../../const";
+import type { Plan } from "../../types";
+
+export function isHydratedPlan(
+  plan?: Plan,
+): plan is CompanyPlanDetailResponseData {
+  return typeof plan !== "undefined" && "current" in plan;
+}
 
 export function entitlementCountsReducer(
   acc: Record<


### PR DESCRIPTION
Out of an abundance of caution, let's revert this update to allow for a release without drastic internal changes.