### PR TITLE
SCH-4346 Fix email label color

### DIFF
--- a/components/src/components/shared/payment-form/PaymentForm.tsx
+++ b/components/src/components/shared/payment-form/PaymentForm.tsx
@@ -98,7 +98,7 @@ export const PaymentForm = ({ onConfirm }: PaymentFormProps) => {
 
       {stripe && isCheckoutData(data) && data.checkoutSettings.collectEmail && (
         <Box data-field="name" $marginBottom="1.5rem" $verticalAlign="top">
-          <Label htmlFor="email">Email</Label>
+          <Label htmlFor="email" className="color-black">Email</Label>
           <Input
             id="email"
             type="text"


### PR DESCRIPTION
The label color for email in checkout settings doesn't match the other labels. The other's are from Stripe directly and are `#000`. 

<img width="1192" height="691" alt="Screenshot 2025-09-10 at 3 46 06 PM" src="https://github.com/user-attachments/assets/3e0a3cc8-ff16-4718-a711-7237b6a44c8c" />
