### PR TITLE
fix: `PaymentForm` label should follow `colorMode`

### DIFF
--- a/components/src/components/embed/Embed.tsx
+++ b/components/src/components/embed/Embed.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useState } from "react";
 import { ThemeContext } from "styled-components";
 
 import { TEXT_BASE_SIZE } from "../../const";
-import { stub } from "../../context";
+import { EmbedSettings, stub } from "../../context";
 import { useEmbed } from "../../hooks";
 import type { SerializedNodeWithChildren } from "../../types";
 import { ERROR_UNKNOWN, isCheckoutData, isError } from "../../utils";
@@ -99,7 +99,11 @@ export const SchematicEmbed = ({ id, accessToken }: EmbedProps) => {
         );
         const ast = getEditorState(json);
         if (ast) {
-          updateSettings({ ...ast.ROOT.props.settings }, { update: false });
+          const settings = ast.ROOT.props.settings as EmbedSettings;
+          // do not apply the `colorMode` setting from the builder since the provider handles it
+          const { colorMode, ...theme } = settings.theme;
+          const updated = { mode: settings.mode, theme, badge: settings.badge };
+          updateSettings(updated, { update: true });
           nodes.push(...parseEditorState(ast));
           setChildren(nodes.map(renderer));
         }

--- a/components/src/components/shared/payment-form/styles.ts
+++ b/components/src/components/shared/payment-form/styles.ts
@@ -9,7 +9,7 @@ export const Label = styled.label`
   transition:
     transform 0.5s cubic-bezier(0.19, 1, 0.22, 1),
     opacity 0.5s cubic-bezier(0.19, 1, 0.22, 1);
-  color: #cdd6f4;
+  color: ${({ theme }) => (theme.colorMode === "dark" ? "#cdd6f4" : "#000000")};
   touch-action: manipulation;
 `;
 

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -425,11 +425,8 @@ export const EmbedProvider = ({
     const colorMode = darkModeQuery.matches ? "dark" : "light";
     dispatch({
       type: "UPDATE_SETTINGS",
-      settings: {
-        theme: {
-          colorMode,
-        },
-      },
+      settings: { theme: { colorMode } },
+      update: true,
     });
 
     function darkModeQueryHandler(event: MediaQueryListEvent) {
@@ -437,6 +434,7 @@ export const EmbedProvider = ({
       dispatch({
         type: "UPDATE_SETTINGS",
         settings: { theme: { colorMode: newColorMode } },
+        update: true,
       });
     }
 
@@ -500,8 +498,9 @@ export const EmbedProvider = ({
   }, [state.accessToken, apiConfig, customHeaders]);
 
   useEffect(() => {
-    const providedSettings = { ...(options.settings || {}) };
-    updateSettings(providedSettings, { update: false });
+    if (options.settings) {
+      updateSettings(options.settings, { update: true });
+    }
   }, [options.settings, updateSettings]);
 
   useEffect(() => {


### PR DESCRIPTION
Test by using dark mode then light mode with a dark card color and then a light card color configured in builder.

_Note_: "checkout settings -> billing email" must be enabled in `schematic-app` for your company. Look for the "Email" label color in the Stripe payment form.