### PR TITLE
Use post-trial plan for user display

### DIFF
--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -110,7 +110,7 @@ export const PlanManager = forwardRef<
     creditGroups,
     billingSubscription,
     canCheckout,
-    defaultPlan,
+    postTrialPlan,
     featureUsage,
     showZeroPriceAsFree,
     trialPaymentMethodRequired,
@@ -121,7 +121,7 @@ export const PlanManager = forwardRef<
         creditBundles,
         creditGrants,
         capabilities,
-        defaultPlan,
+        postTrialPlan,
         featureUsage,
         showZeroPriceAsFree,
         trialPaymentMethodRequired,
@@ -157,7 +157,7 @@ export const PlanManager = forwardRef<
         creditGroups,
         billingSubscription: company?.billingSubscription,
         canCheckout: capabilities?.checkout ?? true,
-        defaultPlan,
+        postTrialPlan,
         featureUsage: featureUsage?.features || [],
         showZeroPriceAsFree,
         trialPaymentMethodRequired: trialPaymentMethodRequired,
@@ -171,7 +171,7 @@ export const PlanManager = forwardRef<
       creditGroups: { plan: [], bundles: [], promotional: [] },
       billingSubscription: undefined,
       canCheckout: false,
-      defaultPlan: undefined,
+      postTrialPlan: undefined,
       featureUsage: [],
       showZeroPriceAsFree: false,
       trialPaymentMethodRequired: false,
@@ -232,9 +232,9 @@ export const PlanManager = forwardRef<
           <Text as="p" $size={0.8125 * settings.theme.typography.text.fontSize}>
             {trialPaymentMethodRequired
               ? t("After the trial, subscribe")
-              : defaultPlan
+              : postTrialPlan
                 ? t("After the trial, cancel", {
-                    defaultPlanName: defaultPlan?.name,
+                    postTrialPlanName: postTrialPlan?.name,
                   })
                 : t("After the trial, cancel no default", {
                     planName: currentPlan?.name,

--- a/components/src/localization/en.json
+++ b/components/src/localization/en.json
@@ -10,7 +10,7 @@
     "Add-ons Quantity": "Add-ons Quantity",
     "Additional": "Additional",
     "After the trial, cancel no default": "After the trial, you will be lose access to {{planName}} plan and your subscription will be cancelled.",
-    "After the trial, cancel": "After the trial, you will be downgraded to the {{defaultPlanName}} plan and your subscription will be cancelled.",
+    "After the trial, cancel": "After the trial, you will be downgraded to the {{postTrialPlanName}} plan and your subscription will be cancelled.",
     "After the trial, subscribe": "After the trial, subscription starts and you will be billed.",
     "Amount off": "{{amount}} off",
     "An invoice is created when charges reach $X; the rest is billed monthly.": "An invoice is created when charges reach {{amount}}; the rest is billed monthly.",


### PR DESCRIPTION
This is backwards compatible with the current system, so safe to release; right now, `postTrialPlan` will just be the default plan, but once we add fallback plans and trial expiry plans, the backend will take these into account and display the correct plan.