### PR TITLE
DEV-123 Handle trailing slashes in `EmbedProvider` base path

### DIFF
--- a/components/src/api/checkoutexternal/runtime.ts
+++ b/components/src/api/checkoutexternal/runtime.ts
@@ -42,7 +42,7 @@ export class Configuration {
 
   get basePath(): string {
     return this.configuration.basePath != null
-      ? this.configuration.basePath
+      ? this.configuration.basePath.replace(/\/+$/, "")
       : BASE_PATH;
   }
 


### PR DESCRIPTION
This is mostly to avoid a common issue with local dev

