### PR TITLE
chore: update GitHub Actions to use latest versions of actions and dependencies

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,18 +22,19 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-            role-to-assume: ${{ vars.DEV_AWS_ROLE_ARN }}
-            aws-region: ${{ vars.DEV_AWS_REGION }}
+      # This is not working from Public repos.
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@v5.0.0
+      #   with:
+      #       role-to-assume: ${{ vars.DEV_AWS_ROLE_ARN }}
+      #       aws-region: ${{ vars.DEV_AWS_REGION }}
 
-      - name: Claude Code Action
-        uses: SchematicHQ/actions/claude@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          use_bedrock: "true"
-          aws_account_id: ${{ vars.DEV_AWS_ACCOUNT_ID }}
-          aws_region: ${{ vars.DEV_AWS_REGION }}
+      # - name: Claude Code Action
+      #   uses: SchematicHQ/actions/claude@main
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     use_bedrock: "true"
+      #     aws_account_id: ${{ vars.DEV_AWS_ACCOUNT_ID }}
+      #     aws_region: ${{ vars.DEV_AWS_REGION }}

--- a/.github/workflows/dependabot-metadata.yml
+++ b/.github/workflows/dependabot-metadata.yml
@@ -18,12 +18,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
-        
-      - name: Dependabot Metadata
-        uses: SchematicHQ/actions/dependabot@main
-        id: dependabot
-        with:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        uses: actions/checkout@v5.0.0
+
+      # This is not working from Public repos.
+      # - name: Dependabot Metadata
+      #   uses: SchematicHQ/actions/dependabot@main
+      #   id: dependabot
+      #   with:
+      #     LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/deploy_components.yml
+++ b/.github/workflows/deploy_components.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -31,10 +31,10 @@ jobs:
       contents: read
     needs: [lint]
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
       - name: Set Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -59,9 +59,9 @@ jobs:
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     needs: [publish]
     steps:
-      - uses: runs-on/action@v2
+      - uses: runs-on/action@v2.0.3
       - name: Checkout schematic-components
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           path: schematic-components
 
@@ -72,14 +72,14 @@ jobs:
           echo "SCHEMATIC_COMPONENTS_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Checkout example app
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           repository: schematichq/schematic-next-example
           path: schematic-next-example
           token: ${{ secrets.DEPENDENT_UPDATE_PAT }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.HAS_CHANGES == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v7.0.8
         with:
           token: ${{ secrets.DEPENDENT_UPDATE_PAT }}
           commit-message: Update @schematichq/schematic-components to ${{ steps.get_version.outputs.SCHEMATIC_COMPONENTS_VERSION }}
@@ -115,7 +115,7 @@ jobs:
     runs-on: runs-on=${{ github.run_id }}/runner=1cpu-linux-arm64
     needs: [publish]
     steps:
-      - uses: rtCamp/action-slack-notify@v2
+      - uses: rtCamp/action-slack-notify@v2.3.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TITLE: Updated schematic-components

--- a/.github/workflows/deploy_js.yml
+++ b/.github/workflows/deploy_js.yml
@@ -15,9 +15,9 @@ jobs:
     name: Lint
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -31,9 +31,9 @@ jobs:
     name: Test
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -48,11 +48,11 @@ jobs:
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     needs: ["test", "lint"]
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
 
       - name: Set Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
 
@@ -69,7 +69,7 @@ jobs:
         run: yarn build:browser
 
       - name: 🚀auth-oidc-aws-prod
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5.0.0
         with:
           role-to-assume: ${{ vars.PROD_AWS_ROLE_ARN }}
           aws-region: ${{ vars.PROD_AWS_REGION }}
@@ -96,10 +96,10 @@ jobs:
       contents: read
     needs: ["test", "lint"]
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
       - name: Set Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -121,7 +121,7 @@ jobs:
     runs-on: runs-on=${{ github.run_id }}/runner=1cpu-linux-arm64
     needs: [deploy, publish]
     steps:
-      - uses: rtCamp/action-slack-notify@v2
+      - uses: rtCamp/action-slack-notify@v2.3.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TITLE: Updated schematic-js

--- a/.github/workflows/deploy_react.yml
+++ b/.github/workflows/deploy_react.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -31,10 +31,10 @@ jobs:
       contents: read
     needs: [lint]
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
       - name: Set Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -59,9 +59,9 @@ jobs:
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     needs: [publish]
     steps:
-      - uses: runs-on/action@v2
+      - uses: runs-on/action@v2.0.3
       - name: Checkout schematic-react
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           path: schematic-react
 
@@ -72,14 +72,14 @@ jobs:
           echo "SCHEMATIC_REACT_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Checkout example app
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           repository: schematichq/schematic-next-example
           path: schematic-next-example
           token: ${{ secrets.DEPENDENT_UPDATE_PAT }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.HAS_CHANGES == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v7.0.8
         with:
           token: ${{ secrets.DEPENDENT_UPDATE_PAT }}
           commit-message: Update @schematichq/schematic-react to ${{ steps.get_version.outputs.SCHEMATIC_REACT_VERSION }}
@@ -115,7 +115,7 @@ jobs:
     runs-on: runs-on=${{ github.run_id }}/runner=1cpu-linux-arm64
     needs: [publish]
     steps:
-      - uses: rtCamp/action-slack-notify@v2
+      - uses: rtCamp/action-slack-notify@v2.3.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TITLE: Updated schematic-react

--- a/.github/workflows/pull_request_components.yml
+++ b/.github/workflows/pull_request_components.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -26,9 +26,9 @@ jobs:
     name: Lint
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -26,9 +26,9 @@ jobs:
     name: Lint
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -42,9 +42,9 @@ jobs:
     name: Test
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install

--- a/.github/workflows/pull_request_react.yml
+++ b/.github/workflows/pull_request_react.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install
@@ -26,9 +26,9 @@ jobs:
     name: Lint
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20.x
       - name: Yarn install

--- a/.github/workflows/pull_request_vercel.yml
+++ b/.github/workflows/pull_request_vercel.yml
@@ -19,12 +19,12 @@ jobs:
   deploy:
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     steps:
-      - uses: runs-on/action@v2
+      - uses: runs-on/action@v2.0.3
       - name: Checkout Components Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: '20.x'
 
@@ -45,7 +45,7 @@ jobs:
           yarn link
 
       - name: Clone Demo App
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           repository: ${{ env.DEMO_APP_REPO }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Comment PR with Preview URL
         if: github.event_name == 'pull_request' && env.DEPLOYMENT_URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8.0.0
         with:
           script: |
             const deploymentUrl = process.env.DEPLOYMENT_URL;


### PR DESCRIPTION
- bump workflows to latest
- use semver for better management with dependabot
- comment out `actions` repo, as it will not working and not supported at the moment, hacks and workaround not worth it.
- for claude we can use the public one, but still I don't want to run AWS Access on public repo, for now.