### PR TITLE
Explicit currency filter on EmbedProvider

### DIFF
--- a/components/src/components/elements/pricing-table/PricingTable.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.tsx
@@ -20,14 +20,18 @@ import {
 } from "../../../const";
 import { type FontStyle } from "../../../context";
 import {
-  useAvailableCurrencies,
+  useAvailableCurrenciesWithInvalid,
   useAvailablePlans,
   useEmbed,
 } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
 import { entitlementCountsReducer } from "../../../utils";
 import { Container, FussyChild } from "../../layout";
-import { CurrencyToggle, PeriodToggle } from "../../shared";
+import {
+  CurrencyToggle,
+  InvalidCurrencyNotice,
+  PeriodToggle,
+} from "../../shared";
 import { Box, Flex, Loader, Text } from "../../ui";
 
 import { AddOn } from "./AddOn";
@@ -166,12 +170,23 @@ export const PricingTable = forwardRef<
     () => data?.company?.plan?.planPeriod || "month",
   );
 
-  const currencies = useAvailableCurrencies();
-  const [selectedCurrency, setSelectedCurrency] = useState(DEFAULT_CURRENCY);
+  const { currencies, invalidFilterEntries } =
+    useAvailableCurrenciesWithInvalid();
+  const [selectedCurrency, setSelectedCurrency] = useState(
+    () => currencies[0] ?? DEFAULT_CURRENCY,
+  );
+
+  useEffect(() => {
+    if (currencies.length > 0 && !currencies.includes(selectedCurrency)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSelectedCurrency(currencies[0]);
+    }
+  }, [currencies, selectedCurrency]);
 
   const showPeriodToggle =
     rest.showPeriodToggle ?? data?.displaySettings?.showPeriodToggle ?? true;
   const showCurrencySelector = currencies.length > 1;
+  const hasNoUsableCurrency = currencies.length === 0;
   const { plans, addOns, periods } = useAvailablePlans(selectedPeriod, {
     useSelectedPeriod: showPeriodToggle,
   });
@@ -224,6 +239,14 @@ export const PricingTable = forwardRef<
       >
         <Loader aria-label="loading" $size="2xl" />
       </Flex>
+    );
+  }
+
+  if (hasNoUsableCurrency) {
+    return (
+      <Container>
+        <InvalidCurrencyNotice invalidEntries={invalidFilterEntries} />
+      </Container>
     );
   }
 

--- a/components/src/components/elements/pricing-table/PricingTable.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.tsx
@@ -142,7 +142,8 @@ export const PricingTable = forwardRef<
 
   const { t } = useTranslation();
 
-  const { data, settings, isPending, hydratePublic } = useEmbed();
+  const { data, settings, isPending, hydratePublic, currencyFilter } =
+    useEmbed();
 
   const getCallToActionTarget = useCallback(
     (url?: string, target?: HTMLAttributeAnchorTarget) => {
@@ -185,7 +186,9 @@ export const PricingTable = forwardRef<
 
   const showPeriodToggle =
     rest.showPeriodToggle ?? data?.displaySettings?.showPeriodToggle ?? true;
+  const hasCurrencyFilter = !!currencyFilter && currencyFilter.length > 0;
   const showCurrencySelector = currencies.length > 1;
+  const hasCurrency = currencies.length > 1 || hasCurrencyFilter;
   const hasNoUsableCurrency = currencies.length === 0;
   const { plans, addOns, periods } = useAvailablePlans(selectedPeriod, {
     useSelectedPeriod: showPeriodToggle,
@@ -347,9 +350,7 @@ export const PricingTable = forwardRef<
                     }}
                     plans={self}
                     selectedPeriod={planPeriod}
-                    currency={
-                      showCurrencySelector ? selectedCurrency : undefined
-                    }
+                    currency={hasCurrency ? selectedCurrency : undefined}
                     entitlementCounts={entitlementCounts}
                     handleToggleShowAll={handleToggleShowAll}
                   />
@@ -396,9 +397,7 @@ export const PricingTable = forwardRef<
                         onCallToAction: rest.onCallToAction,
                       }}
                       selectedPeriod={addOnPeriod}
-                      currency={
-                        showCurrencySelector ? selectedCurrency : undefined
-                      }
+                      currency={hasCurrency ? selectedCurrency : undefined}
                     />
                   );
                 })}

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../../api/checkoutexternal";
 import { DEFAULT_CURRENCY, TEXT_BASE_SIZE } from "../../../const";
 import {
-  useAvailableCurrencies,
+  useAvailableCurrenciesWithInvalid,
   useAvailablePlans,
   useEmbed,
   useIsLightBackground,
@@ -39,6 +39,7 @@ import {
 } from "../../../utils";
 import {
   CurrencyToggle,
+  InvalidCurrencyNotice,
   PeriodToggle,
   SubscriptionSidebar,
 } from "../../shared";
@@ -121,6 +122,8 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     setCheckoutState,
     previewCheckout,
     setLayout,
+    currencyFilter,
+    debug,
   } = useEmbed();
 
   const isLightBackground = useIsLightBackground();
@@ -193,17 +196,38 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
   const [planPeriod, setPlanPeriod] = useState(getValidatedPeriod);
 
-  const currencies = useAvailableCurrencies();
+  const { currencies, invalidFilterEntries } =
+    useAvailableCurrenciesWithInvalid();
   const lockedCurrency = useSubscriptionCurrency();
+  const hasCurrencyFilter = !!currencyFilter && currencyFilter.length > 0;
+  const filterBlocksSubscriptionCurrency =
+    hasCurrencyFilter &&
+    !!lockedCurrency &&
+    !currencyFilter!.includes(lockedCurrency);
   const [selectedCurrency, setSelectedCurrency] = useState(
     () =>
       lockedCurrency ??
-      checkoutState?.selectedCurrency ??
+      (checkoutState?.selectedCurrency &&
+      currencies.includes(checkoutState.selectedCurrency)
+        ? checkoutState.selectedCurrency
+        : undefined) ??
       currencies[0] ??
       DEFAULT_CURRENCY,
   );
   const showCurrencySelector = currencies.length > 1 && !lockedCurrency;
   const hasCurrency = currencies.length > 1 || !!lockedCurrency;
+  const hasNoUsableCurrency = !lockedCurrency && currencies.length === 0;
+
+  useEffect(() => {
+    if (filterBlocksSubscriptionCurrency) {
+      console.error(
+        `[Schematic] currencyFilter excludes the active subscription currency (${lockedCurrency}); keeping subscription currency.`,
+      );
+      debug("currencyFilter conflicts with subscription currency", {
+        lockedCurrency,
+      });
+    }
+  }, [filterBlocksSubscriptionCurrency, lockedCurrency, debug]);
 
   // Keep currency pinned to the subscription currency when it loads async
   useEffect(() => {
@@ -1082,6 +1106,25 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
   const canCheckout = data?.capabilities?.checkout ?? true;
   if (!canCheckout) {
     return null;
+  }
+
+  if (hasNoUsableCurrency) {
+    return (
+      <Dialog
+        ref={dialogRef}
+        isModal={isModal}
+        size="lg"
+        top={top}
+        onClose={handleClose}
+        {...(!isModal && { open: layout === "checkout" })}
+      >
+        <DialogContent>
+          <Flex $padding="2rem" $justifyContent="center">
+            <InvalidCurrencyNotice invalidEntries={invalidFilterEntries} />
+          </Flex>
+        </DialogContent>
+      </Dialog>
+    );
   }
 
   return (

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -215,7 +215,8 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       DEFAULT_CURRENCY,
   );
   const showCurrencySelector = currencies.length > 1 && !lockedCurrency;
-  const hasCurrency = currencies.length > 1 || !!lockedCurrency;
+  const hasCurrency =
+    !!lockedCurrency || currencies.length > 1 || hasCurrencyFilter;
   const hasNoUsableCurrency = !lockedCurrency && currencies.length === 0;
 
   useEffect(() => {

--- a/components/src/components/shared/index.ts
+++ b/components/src/components/shared/index.ts
@@ -2,6 +2,7 @@ export * from "./billing-threshold-tooltip";
 export * from "./checkout-dialog";
 export * from "./currency-toggle";
 export * from "./hard-limit-tooltip";
+export * from "./invalid-currency-notice";
 export * from "./payment-dialog";
 export * from "./payment-form";
 export * from "./period-toggle";

--- a/components/src/components/shared/invalid-currency-notice/InvalidCurrencyNotice.tsx
+++ b/components/src/components/shared/invalid-currency-notice/InvalidCurrencyNotice.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+
+import { useEmbed } from "../../../hooks";
+import { Flex, Text } from "../../ui";
+
+interface InvalidCurrencyNoticeProps {
+  invalidEntries?: string[];
+}
+
+export const InvalidCurrencyNotice = ({
+  invalidEntries = [],
+}: InvalidCurrencyNoticeProps) => {
+  const { settings } = useEmbed();
+  const { t } = useTranslation();
+
+  return (
+    <Flex
+      data-testid="sch-invalid-currency-notice"
+      $flexDirection="column"
+      $justifyContent="center"
+      $alignItems="center"
+      $gap="0.5rem"
+      $padding="1.5rem"
+      $borderWidth="1px"
+      $borderStyle="solid"
+      $borderColor={settings.theme.danger}
+      $borderRadius="0.5rem"
+    >
+      <Text $weight={600} $color={settings.theme.danger}>
+        {t("No supported currencies are available.")}
+      </Text>
+
+      {invalidEntries.length > 0 && (
+        <Text $size={13} $color={settings.theme.danger}>
+          {t("Invalid currency filter: {{entries}}", {
+            entries: invalidEntries.join(", "),
+          })}
+        </Text>
+      )}
+    </Flex>
+  );
+};

--- a/components/src/components/shared/invalid-currency-notice/index.ts
+++ b/components/src/components/shared/invalid-currency-notice/index.ts
@@ -1,0 +1,1 @@
+export * from "./InvalidCurrencyNotice";

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -44,19 +44,36 @@ export interface EmbedProviderProps {
   apiConfig?: ConfigurationParameters;
   settings?: DeepPartial<EmbedSettings>;
   debug?: boolean;
+  /**
+   * Restricts which currencies are presented in components that support
+   * multi-currency display (PricingTable, CheckoutDialog). Entries are
+   * ISO-4217 codes; case-insensitive. Omit to disable filtering.
+   */
+  currencyFilter?: string[];
 }
+
+const normalizeCurrencyFilter = (
+  filter: string[] | undefined,
+): string[] | undefined => {
+  if (!filter || filter.length === 0) return undefined;
+  return Array.from(new Set(filter.map((c) => c.toUpperCase())));
+};
 
 export const EmbedProvider = ({
   children,
   apiKey,
   apiConfig,
+  currencyFilter,
   ...options
 }: EmbedProviderProps) => {
   const sessionId = useMemo(() => uuidv4(), []);
   const styleRef = useRef<HTMLLinkElement>(null);
 
   const [state, dispatch] = useReducer(reducer, options, (opts) => {
-    const providedState = { settings: opts.settings || {} };
+    const providedState = {
+      settings: opts.settings || {},
+      currencyFilter: normalizeCurrencyFilter(currencyFilter),
+    };
     const resolvedState = merge({}, initialState, providedState);
 
     return resolvedState;
@@ -526,6 +543,13 @@ export const EmbedProvider = ({
   }, [options.settings, updateSettings]);
 
   useEffect(() => {
+    dispatch({
+      type: "SET_CURRENCY_FILTER",
+      currencyFilter: normalizeCurrencyFilter(currencyFilter),
+    });
+  }, [currencyFilter]);
+
+  useEffect(() => {
     function planChangedHandler(event: Event) {
       if (event instanceof CustomEvent) {
         debug("plan changed", event.detail);
@@ -550,6 +574,7 @@ export const EmbedProvider = ({
         settings: state.settings,
         layout: state.layout,
         checkoutState: state.checkoutState,
+        currencyFilter: state.currencyFilter,
         hydratePublic: debouncedHydratePublic,
         hydrate: debouncedHydrate,
         hydrateComponent: debouncedHydrateComponent,

--- a/components/src/context/embedReducer.ts
+++ b/components/src/context/embedReducer.ts
@@ -54,7 +54,8 @@ type EmbedAction =
   | { type: "CHANGE_LAYOUT"; layout: EmbedLayout }
   | { type: "SET_CHECKOUT_STATE"; state: CheckoutState }
   | { type: "SET_PLANID_BYPASS"; config: string | BypassConfig }
-  | { type: "CLEAR_CHECKOUT_STATE" };
+  | { type: "CLEAR_CHECKOUT_STATE" }
+  | { type: "SET_CURRENCY_FILTER"; currencyFilter?: string[] };
 
 function normalize(data?: HydrateData): HydrateDataWithCompanyContext {
   return merge({}, data, {
@@ -284,6 +285,13 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
       return {
         ...state,
         checkoutState: undefined,
+      };
+    }
+
+    case "SET_CURRENCY_FILTER": {
+      return {
+        ...state,
+        currencyFilter: action.currencyFilter,
       };
     }
   }

--- a/components/src/context/embedState.ts
+++ b/components/src/context/embedState.ts
@@ -290,6 +290,7 @@ export interface EmbedState {
   settings: EmbedSettings;
   layout: EmbedLayout;
   checkoutState?: CheckoutState;
+  currencyFilter?: string[];
 }
 
 export const initialState: EmbedState = {

--- a/components/src/hooks/useAvailableCurrencies.ts
+++ b/components/src/hooks/useAvailableCurrencies.ts
@@ -4,7 +4,18 @@ import { DEFAULT_CURRENCY } from "../const";
 
 import { useEmbed } from "./useEmbed";
 
-export function useAvailableCurrencies(): string[] {
+const sortCurrencies = (currencies: string[]): string[] =>
+  [...currencies].sort((a, b) => {
+    if (a === DEFAULT_CURRENCY) return -1;
+    if (b === DEFAULT_CURRENCY) return 1;
+    return a.localeCompare(b);
+  });
+
+/**
+ * Returns the full, unfiltered set of currencies present in the hydrated
+ * plan and add-on data, with DEFAULT_CURRENCY guaranteed to be included.
+ */
+function useHydratedCurrencies(): string[] {
   const { data } = useEmbed();
 
   return useMemo(() => {
@@ -19,12 +30,64 @@ export function useAvailableCurrencies(): string[] {
       }
     }
 
-    return Array.from(currencySet).sort((a, b) => {
-      if (a === DEFAULT_CURRENCY) return -1;
-      if (b === DEFAULT_CURRENCY) return 1;
-      return a.localeCompare(b);
-    });
+    return sortCurrencies(Array.from(currencySet));
   }, [data?.activePlans, data?.activeAddOns]);
+}
+
+/**
+ * Returns the currencies that should be displayed in the UI. When a
+ * `currencyFilter` is configured on EmbedProvider, this is the intersection
+ * of the filter with the hydrated currency set. Otherwise it is the full
+ * hydrated set.
+ */
+export function useAvailableCurrencies(): string[] {
+  const { currencies } = useAvailableCurrenciesWithInvalid();
+  return currencies;
+}
+
+export interface AvailableCurrenciesResult {
+  currencies: string[];
+  invalidFilterEntries: string[];
+}
+
+/**
+ * Like `useAvailableCurrencies` but also returns the list of filter entries
+ * that did not match any currency in the hydrated data. Consumers can render
+ * an error notice and (optionally) log these invalid inputs.
+ */
+export function useAvailableCurrenciesWithInvalid(): AvailableCurrenciesResult {
+  const { currencyFilter, debug } = useEmbed();
+  const hydrated = useHydratedCurrencies();
+
+  return useMemo(() => {
+    if (!currencyFilter || currencyFilter.length === 0) {
+      return { currencies: hydrated, invalidFilterEntries: [] };
+    }
+
+    const hydratedSet = new Set(hydrated);
+    const matched: string[] = [];
+    const invalid: string[] = [];
+
+    for (const entry of currencyFilter) {
+      if (hydratedSet.has(entry)) {
+        matched.push(entry);
+      } else {
+        invalid.push(entry);
+      }
+    }
+
+    if (invalid.length > 0) {
+      console.error(
+        `[Schematic] currencyFilter contains currencies not available in the hydrated plan data: ${invalid.join(", ")}`,
+      );
+      debug("invalid currencyFilter entries", invalid);
+    }
+
+    return {
+      currencies: sortCurrencies(matched),
+      invalidFilterEntries: invalid,
+    };
+  }, [currencyFilter, hydrated, debug]);
 }
 
 /**


### PR DESCRIPTION
A new property can be provided that filters the products and prices
available to `Checkout` or `PricingTable`

     <EmbedProvider apiConfig={apiConfig} currencyFilter={['EUR']}>
       <SchematicEmbed accessToken={accessToken} id={componentId} />
     </EmbedProvider>

It accepts a list of currencies, and customer code is expected to
provide these somehow. For instance, if they want to only allow checkout
with EUR based on geo-location, customers would do that out of band
and initialize context on page load.

