### PR TITLE
fix(dialog): set zero padding on `Dialog`

### DIFF
--- a/components/src/components/ui/dialog/styles.ts
+++ b/components/src/components/ui/dialog/styles.ts
@@ -34,6 +34,7 @@ export const Dialog = styled.dialog<DialogProps>(
       height: fit-content;
       max-height: 100dvh;
       margin: ${$top}px 0 0;
+      padding: 0;
       background-color: ${theme.card.background};
       box-shadow:
         0px 1px 20px 0px #1018280f,


### PR DESCRIPTION
Most browsers have a default padding of `1em` but we are not currently setting a value on our internal `Dialog` component. This is a problem in environments without a css reset implemented.