### PR TITLE
NPM publish path explicitly

### DIFF
--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -125,4 +125,4 @@ fi
 
 # Publish
 echo "Publishing $VERSION to NPM with '$NPM_TAG' tag..."
-npm publish "$PUBLISH_DIR" --access public --tag "$NPM_TAG"
+npm publish "./$PUBLISH_DIR" --access public --tag "$NPM_TAG"


### PR DESCRIPTION
using "dist" causes npm to treat that string as an npm package rather than a path; "./dist" makes it explicit as a path

other packages used "." which works as a special case for npm, I think