### PR TITLE
fix: disable checkout button when entitlement quantity is below usage

### DIFF
--- a/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
+++ b/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
@@ -540,7 +540,11 @@ export const SubscriptionSidebar = forwardRef<
       selectedPlan?.isTrialable === true;
 
     const button = useMemo(() => {
-      const canCheckout = error !== t("Downgrade not permitted.");
+      const hasEntitlementDowngrade =
+        payInAdvanceEntitlements.some((e) => e.quantity < e.usage) ||
+        addOnPayInAdvanceEntitlements.some((e) => e.quantity < e.usage);
+      const canCheckout =
+        error !== t("Downgrade not permitted.") && !hasEntitlementDowngrade;
       const isSticky = !isButtonInView;
 
       switch (layout) {
@@ -606,6 +610,8 @@ export const SubscriptionSidebar = forwardRef<
       paymentMethodId,
       handleCheckout,
       handleUnsubscribe,
+      payInAdvanceEntitlements,
+      addOnPayInAdvanceEntitlements,
     ]);
 
     useLayoutEffect(() => {

--- a/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
+++ b/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
@@ -227,6 +227,16 @@ export const SubscriptionSidebar = forwardRef<
       );
       total += payInAdvanceCost;
 
+      const addOnPayInAdvanceCost = addOnPayInAdvanceEntitlements.reduce(
+        (sum, entitlement) =>
+          sum +
+          entitlement.quantity *
+            (getEntitlementPrice(entitlement, planPeriod, currency)?.price ??
+              0),
+        0,
+      );
+      total += addOnPayInAdvanceCost;
+
       return formatCurrency(total, resolvedCurrency);
     }, [
       selectedPlan,
@@ -234,6 +244,7 @@ export const SubscriptionSidebar = forwardRef<
       planPeriod,
       addOns,
       payInAdvanceEntitlements,
+      addOnPayInAdvanceEntitlements,
       currency,
     ]);
 


### PR DESCRIPTION
The "Next: Checkout" button remained enabled even when a quantity
downgrade error was displayed. Now canCheckout also checks whether any
pay-in-advance entitlement has quantity < usage.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
