### PR TITLE
Remove custom enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 
 .idea
 .claude/settings.local.json
+.claude/worktrees/
 /yarn.lock

--- a/js/src/index.spec.ts
+++ b/js/src/index.spec.ts
@@ -702,7 +702,7 @@ describe("Fallback Values", () => {
             flag: "advanced-feature",
             value: true,
             reason: "Company has premium plan",
-            ruleType: RuleType.PLAN_ENTITLEMENT,
+            ruleType: RuleType.PlanEntitlement,
             featureAllocation: 1000,
             featureUsage: 250,
             featureUsageEvent: "api_call",
@@ -722,7 +722,7 @@ describe("Fallback Values", () => {
             flag: "complex-fallback",
             value: false,
             reason: "Usage limit exceeded",
-            ruleType: RuleType.PLAN_ENTITLEMENT_USAGE_EXCEEDED,
+            ruleType: RuleType.PlanEntitlementUsageExceeded,
             featureUsageExceeded: true,
           },
         },
@@ -976,7 +976,7 @@ describe("Fallback Values", () => {
             flag: "priority-flag",
             value: false, // Rich default with different value
             reason: "Rich default takes priority",
-            ruleType: RuleType.PLAN_ENTITLEMENT,
+            ruleType: RuleType.PlanEntitlement,
             featureAllocation: 100,
           },
         },
@@ -992,7 +992,7 @@ describe("Fallback Values", () => {
       // Should use flagCheckDefaults, not construct from flagValueDefaults
       expect(result.value).toBe(false); // From flagCheckDefaults, not flagValueDefaults
       expect(result.reason).toBe("Rich default takes priority"); // From flagCheckDefaults
-      expect(result.ruleType).toBe(RuleType.PLAN_ENTITLEMENT); // Rich metadata preserved
+      expect(result.ruleType).toBe(RuleType.PlanEntitlement); // Rich metadata preserved
       expect(result.featureAllocation).toBe(100);
     });
   });
@@ -1020,7 +1020,7 @@ describe("Fallback Values", () => {
             flag: "sync-check-flag",
             value: true,
             reason: "Has premium plan",
-            ruleType: RuleType.PLAN_ENTITLEMENT,
+            ruleType: RuleType.PlanEntitlement,
             featureAllocation: 500,
             featureUsage: 100,
           },

--- a/js/src/types/index.ts
+++ b/js/src/types/index.ts
@@ -3,6 +3,8 @@ import {
   DatastreamCompanyPlanFromJSON,
 } from "./api/models";
 import { EventBodyFlagCheck } from "./api/models/EventBodyFlagCheck";
+import { MetricPeriod } from "./api/models/MetricPeriod";
+import { RuleType } from "./api/models/RuleType";
 import { type TrialStatus } from "./api/models/TrialStatus";
 
 export type EventType = "identify" | "track" | "flag_check";
@@ -53,30 +55,6 @@ export type Event = {
   next_retry_at?: number;
 };
 
-export enum RuleType {
-  /** A global rule that, if present, will override all other rules for a flag */
-  GLOBAL_OVERRIDE = "global_override",
-  /** Rule type indicating feature access provisioned to a company via an override */
-  COMPANY_OVERRIDE = "company_override",
-  /** Rule type indicating that feature access has been provisione to a company via an override, but the usage limit has been reached or exceeded */
-  COMPANY_OVERRIDE_USAGE_EXCEEDED = "company_override_usage_exceeded",
-  /** Rule type indicating feature access provisioned to a company via its base plan or add-ons */
-  PLAN_ENTITLEMENT = "plan_entitlement",
-  /** Rule type indicating that feature access has been provisione to a company via base plan or add-ons, but the usage limit has been reached or exceeded */
-  PLAN_ENTITLEMENT_USAGE_EXCEEDED = "plan_entitlement_usage_exceeded",
-  /** General-purpose targeting rule */
-  STANDARD = "standard",
-  /** Default rule type that will be used if no other rules are matched */
-  DEFAULT = "default",
-}
-
-export enum UsagePeriod {
-  ALL_TIME = "all_time",
-  CURRENT_DAY = "current_day",
-  CURRENT_MONTH = "current_month",
-  CURRENT_WEEK = "current_week",
-}
-
 export type CheckFlagReturn = {
   /** The company has access to the feature, but has exceeded the usage limit */
   featureUsageExceeded?: boolean;
@@ -93,7 +71,7 @@ export type CheckFlagReturn = {
   /** Event representing the feature usage */
   featureUsageEvent?: string;
   /** For event-based feature entitlement rules, the period over which usage is tracked (current_month, current_day, current_week, all_time) */
-  featureUsagePeriod?: UsagePeriod;
+  featureUsagePeriod?: MetricPeriod;
   /** For event-based feature entitlement rules, when the usage period will reset */
   featureUsageResetAt?: Date;
   /** The key used to check the flag */
@@ -231,8 +209,8 @@ export const CheckFlagReturnFromJSON = (
 
   const featureUsageExceeded =
     !value && // if flag is not false, then we haven't exceeded usage
-    (ruleType == RuleType.COMPANY_OVERRIDE_USAGE_EXCEEDED || // if the rule type is one of these, then we have exceeded usage
-      ruleType == RuleType.PLAN_ENTITLEMENT_USAGE_EXCEEDED);
+    (ruleType == RuleType.CompanyOverrideUsageExceeded || // if the rule type is one of these, then we have exceeded usage
+      ruleType == RuleType.PlanEntitlementUsageExceeded);
 
   // Prefer entitlement object fields over deprecated flat fields
   const resolvedAllocation = entitlement?.allocation ?? featureAllocation;
@@ -255,7 +233,7 @@ export const CheckFlagReturnFromJSON = (
     featureUsage: resolvedUsage == null ? undefined : resolvedUsage,
     featureUsageEvent: resolvedEvent == null ? undefined : resolvedEvent,
     featureUsagePeriod:
-      resolvedPeriod == null ? undefined : (resolvedPeriod as UsagePeriod),
+      resolvedPeriod == null ? undefined : (resolvedPeriod as MetricPeriod),
     featureUsageResetAt:
       resolvedResetAt == null ? undefined : resolvedResetAt,
     flag,
@@ -292,4 +270,6 @@ export type { CheckFlagResponseData } from "./api/models/CheckFlagResponseData";
 export { CheckFlagResponseFromJSON } from "./api/models/CheckFlagResponse";
 export { CheckFlagsResponseFromJSON } from "./api/models/CheckFlagsResponse";
 export { DatastreamCompanyPlanFromJSON } from "./api/models/DatastreamCompanyPlan";
+export { MetricPeriod } from "./api/models/MetricPeriod";
+export { RuleType } from "./api/models/RuleType";
 export { TrialStatus } from "./api/models/TrialStatus";


### PR DESCRIPTION
Replace custom enums with generated enums that are now available via OpenAPI generated code.

This is a breaking changes since we export these types, however I think these enums are unlikely to be used by cuistomer code. They may be used by our own clients, I think (schematic-react, schematic-vue, schematic-angular). We may want to bundle this with other breaking changes, such as generating types with only undefined or null rather than both.