### PR TITLE
fix: correct checkout sidebar totals for pay-in-advance and one-off charges

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -78,7 +78,7 @@ export const createActiveUsageBasedEntitlementsReducer =
         featureUsage?.allocation ?? entitlement.valueNumeric ?? 0;
       const usage = featureUsage?.usage ?? 0;
       const quantity =
-        featureUsage?.priceBehavior === EntitlementPriceBehavior.PayInAdvance
+        entitlement.priceBehavior === EntitlementPriceBehavior.PayInAdvance
           ? allocation
           : 0;
 

--- a/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
+++ b/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
@@ -209,7 +209,9 @@ export const SubscriptionSidebar = forwardRef<
       }
 
       const addOnCost = addOns.reduce((sum, addOn) => {
-        if (addOn.isSelected) {
+        // One-time charges are billed once at checkout and do not recur; they
+        // should not contribute to the recurring monthly/yearly total.
+        if (addOn.isSelected && addOn.chargeType !== ChargeType.oneTime) {
           sum += getAddOnPrice(addOn, planPeriod, currency)?.price ?? 0;
         }
 


### PR DESCRIPTION
Two small bugs caused the checkout subscription sidebar to misreport
amounts on the preview screen (SCHY-322):

1. createActiveUsageBasedEntitlementsReducer keyed the quantity decision
   off featureUsage.priceBehavior (an optional field on the company's
   usage snapshot). When it was unset, quantity fell back to 0 even
   though the plan entitlement itself is pay-in-advance — so the
   Monthly total omitted add-on pay-in-advance costs on the initial
   screen. The outer guard already validates entitlement.priceBehavior;
   trust it for the quantity decision too.

2. The Monthly total sum iterated every selected add-on and pulled its
   price via getAddOnPrice, which for chargeType === "one_time" returns
   the one-time price. That one-off was being summed into a "recurring"
   total (e.g. a $15 one-off on a $112/mo subscription displayed as
   $127/mo). Skip one-time add-ons in the recurring total — they appear
   correctly under Due today via the proration preview.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
