### PR TITLE
order currency toggle by first plan's stored sorting

### DIFF
--- a/components/src/hooks/useAvailableCurrencies.test.ts
+++ b/components/src/hooks/useAvailableCurrencies.test.ts
@@ -1,0 +1,164 @@
+import { renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { DEFAULT_CURRENCY } from "../const";
+
+import {
+  useAvailableCurrencies,
+  useAvailableCurrenciesWithInvalid,
+} from "./useAvailableCurrencies";
+
+const mockUseEmbed = vi.fn();
+
+vi.mock("./useEmbed", () => ({
+  useEmbed: (...args: unknown[]) => mockUseEmbed(...args),
+}));
+
+type MockCp = { currency: string };
+type MockPlan = {
+  currencyPrices?: MockCp[];
+  monthlyPrice?: { currency: string };
+  yearlyPrice?: { currency: string };
+  oneTimePrice?: { currency: string };
+};
+
+function setupEmbed({
+  activePlans = [],
+  activeAddOns = [],
+  currencyFilter,
+}: {
+  activePlans?: MockPlan[];
+  activeAddOns?: MockPlan[];
+  currencyFilter?: string[];
+} = {}) {
+  mockUseEmbed.mockReturnValue({
+    data: { activePlans, activeAddOns },
+    currencyFilter,
+    debug: () => {},
+  });
+}
+
+beforeEach(() => {
+  mockUseEmbed.mockReset();
+});
+
+describe("useAvailableCurrencies", () => {
+  test("uses the first plan's stored order as the prefix", () => {
+    setupEmbed({
+      activePlans: [
+        {
+          currencyPrices: [
+            { currency: "JPY" },
+            { currency: "USD" },
+            { currency: "CAD" },
+          ],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAvailableCurrencies());
+    expect(result.current).toEqual(["JPY", "USD", "CAD"]);
+  });
+
+  test("alphabetizes leftover currencies from later plans and add-ons", () => {
+    setupEmbed({
+      activePlans: [
+        // First plan: prefix
+        { currencyPrices: [{ currency: "JPY" }, { currency: "USD" }] },
+        // Other plan: contributes EUR (new) and USD (already covered)
+        { currencyPrices: [{ currency: "EUR" }, { currency: "USD" }] },
+      ],
+      // Add-on: contributes CAD (new) and AUD (new)
+      activeAddOns: [
+        { currencyPrices: [{ currency: "CAD" }, { currency: "AUD" }] },
+      ],
+    });
+
+    const { result } = renderHook(() => useAvailableCurrencies());
+    // Prefix from plan 0, then leftovers alphabetically
+    expect(result.current).toEqual(["JPY", "USD", "AUD", "CAD", "EUR"]);
+  });
+
+  test("normalizes currency codes to upper case", () => {
+    setupEmbed({
+      activePlans: [
+        { currencyPrices: [{ currency: "jpy" }, { currency: "usd" }] },
+      ],
+      activeAddOns: [{ currencyPrices: [{ currency: "eur" }] }],
+    });
+
+    const { result } = renderHook(() => useAvailableCurrencies());
+    expect(result.current).toEqual(["JPY", "USD", "EUR"]);
+  });
+
+  test("falls back to legacy interval prices when first plan has no currencyPrices", () => {
+    setupEmbed({
+      activePlans: [
+        // Legacy single-currency plan
+        {
+          currencyPrices: [],
+          monthlyPrice: { currency: "EUR" },
+          yearlyPrice: { currency: "EUR" },
+        },
+        { currencyPrices: [{ currency: "USD" }, { currency: "CAD" }] },
+      ],
+    });
+
+    const { result } = renderHook(() => useAvailableCurrencies());
+    expect(result.current).toEqual(["EUR", "CAD", "USD"]);
+  });
+
+  test("does not pin DEFAULT_CURRENCY when other currencies are present", () => {
+    setupEmbed({
+      activePlans: [
+        { currencyPrices: [{ currency: "JPY" }, { currency: "CAD" }] },
+      ],
+    });
+
+    const { result } = renderHook(() => useAvailableCurrencies());
+    // Even though USD is the DEFAULT_CURRENCY, it doesn't appear because
+    // no plan offers it.
+    expect(result.current).toEqual(["JPY", "CAD"]);
+  });
+
+  test("falls back to DEFAULT_CURRENCY when nothing is hydrated", () => {
+    setupEmbed({});
+
+    const { result } = renderHook(() => useAvailableCurrencies());
+    expect(result.current).toEqual([DEFAULT_CURRENCY]);
+  });
+
+  test("preserves currencyFilter input order without re-sorting", () => {
+    setupEmbed({
+      activePlans: [
+        {
+          currencyPrices: [
+            { currency: "JPY" },
+            { currency: "USD" },
+            { currency: "EUR" },
+            { currency: "CAD" },
+          ],
+        },
+      ],
+      // Integrator picked a deliberate non-alphabetical order
+      currencyFilter: ["EUR", "JPY", "USD"],
+    });
+
+    const { result } = renderHook(() => useAvailableCurrencies());
+    expect(result.current).toEqual(["EUR", "JPY", "USD"]);
+  });
+
+  test("currencyFilter reports invalid entries", () => {
+    setupEmbed({
+      activePlans: [{ currencyPrices: [{ currency: "USD" }] }],
+      currencyFilter: ["USD", "ZZZ"],
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAvailableCurrenciesWithInvalid());
+    expect(result.current.currencies).toEqual(["USD"]);
+    expect(result.current.invalidFilterEntries).toEqual(["ZZZ"]);
+
+    consoleError.mockRestore();
+  });
+});

--- a/components/src/hooks/useAvailableCurrencies.test.ts
+++ b/components/src/hooks/useAvailableCurrencies.test.ts
@@ -148,6 +148,23 @@ describe("useAvailableCurrencies", () => {
     expect(result.current).toEqual(["EUR", "JPY", "USD"]);
   });
 
+  test("currencyFilter matches case-insensitively", () => {
+    // Currency codes round-trip through the API as lowercase. Lowercase ("usd") should 
+    // still match the hydrated uppercase set without falling into invalidFilterEntries.
+    setupEmbed({
+      activePlans: [
+        {
+          currencyPrices: [{ currency: "USD" }, { currency: "EUR" }],
+        },
+      ],
+      currencyFilter: ["eur", "usd"],
+    });
+
+    const { result } = renderHook(() => useAvailableCurrenciesWithInvalid());
+    expect(result.current.currencies).toEqual(["EUR", "USD"]);
+    expect(result.current.invalidFilterEntries).toEqual([]);
+  });
+
   test("currencyFilter reports invalid entries", () => {
     setupEmbed({
       activePlans: [{ currencyPrices: [{ currency: "USD" }] }],

--- a/components/src/hooks/useAvailableCurrencies.ts
+++ b/components/src/hooks/useAvailableCurrencies.ts
@@ -102,10 +102,15 @@ export function useAvailableCurrenciesWithInvalid(): AvailableCurrenciesResult {
     const invalid: string[] = [];
 
     // Walk the filter in user-input order so the toggle reflects the order
-    // the integrator configured rather than alphabetizing it back.
+    // the integrator configured rather than alphabetizing it back. Normalize
+    // each entry to uppercase before lookup — currency codes round-trip
+    // through the API as lowercase (the DB stores them that way), and while
+    // EmbedProvider already uppercases the filter at its boundary, doing it
+    // here too keeps the hook self-contained.
     for (const entry of currencyFilter) {
-      if (hydratedSet.has(entry)) {
-        matched.push(entry);
+      const code = entry.toUpperCase();
+      if (hydratedSet.has(code)) {
+        matched.push(code);
       } else {
         invalid.push(entry);
       }

--- a/components/src/hooks/useAvailableCurrencies.ts
+++ b/components/src/hooks/useAvailableCurrencies.ts
@@ -4,33 +4,66 @@ import { DEFAULT_CURRENCY } from "../const";
 
 import { useEmbed } from "./useEmbed";
 
-const sortCurrencies = (currencies: string[]): string[] =>
-  [...currencies].sort((a, b) => {
-    if (a === DEFAULT_CURRENCY) return -1;
-    if (b === DEFAULT_CURRENCY) return 1;
-    return a.localeCompare(b);
-  });
-
 /**
  * Returns the full, unfiltered set of currencies present in the hydrated
- * plan and add-on data, with DEFAULT_CURRENCY guaranteed to be included.
+ * plan and add-on data. The first plan's `currencyPrices` is used to derive
+ * the sort order. Any non-overlapping currencies beyond that are sorted
+ * alphabetically.
  */
 function useHydratedCurrencies(): string[] {
   const { data } = useEmbed();
 
   return useMemo(() => {
-    const currencySet = new Set<string>();
-    currencySet.add(DEFAULT_CURRENCY);
+    const ordered: string[] = [];
+    const seen = new Set<string>();
 
-    const plans = [...(data?.activePlans || []), ...(data?.activeAddOns || [])];
+    const push = (currency?: string | null) => {
+      if (!currency) return;
+      const code = currency.toUpperCase();
+      if (seen.has(code)) return;
+      seen.add(code);
+      ordered.push(code);
+    };
 
-    for (const plan of plans) {
-      for (const cp of plan.currencyPrices || []) {
-        currencySet.add(cp.currency.toUpperCase());
+    // Prefix: first plan's stored currency order wins. Position 0 of its
+    // `currencyPrices` is the plan's default; we want that to be the toggle's
+    // default too.
+    const firstPlan = data?.activePlans?.[0];
+    if (firstPlan) {
+      const prices = firstPlan.currencyPrices ?? [];
+      if (prices.length > 0) {
+        for (const cp of prices) {
+          push(cp.currency);
+        }
+      } else {
+        // Legacy single-currency plan: still seeds the prefix so the toggle
+        // default reflects the first plan.
+        push(firstPlan.monthlyPrice?.currency);
+        push(firstPlan.yearlyPrice?.currency);
+        push(firstPlan.oneTimePrice?.currency);
       }
     }
 
-    return sortCurrencies(Array.from(currencySet));
+    // Tail: every other currency across remaining plans + add-ons,
+    // alphabetized. Currencies already in the prefix are dropped via `seen`.
+    const leftover = new Set<string>();
+    const rest = [
+      ...(data?.activePlans ?? []).slice(1),
+      ...(data?.activeAddOns ?? []),
+    ];
+    for (const plan of rest) {
+      for (const cp of plan.currencyPrices ?? []) {
+        const code = cp.currency.toUpperCase();
+        if (!seen.has(code)) leftover.add(code);
+      }
+    }
+    [...leftover].sort().forEach((c) => push(c));
+
+    if (ordered.length === 0) {
+      ordered.push(DEFAULT_CURRENCY);
+    }
+
+    return ordered;
   }, [data?.activePlans, data?.activeAddOns]);
 }
 
@@ -68,6 +101,8 @@ export function useAvailableCurrenciesWithInvalid(): AvailableCurrenciesResult {
     const matched: string[] = [];
     const invalid: string[] = [];
 
+    // Walk the filter in user-input order so the toggle reflects the order
+    // the integrator configured rather than alphabetizing it back.
     for (const entry of currencyFilter) {
       if (hydratedSet.has(entry)) {
         matched.push(entry);
@@ -84,7 +119,7 @@ export function useAvailableCurrenciesWithInvalid(): AvailableCurrenciesResult {
     }
 
     return {
-      currencies: sortCurrencies(matched),
+      currencies: matched,
       invalidFilterEntries: invalid,
     };
   }, [currencyFilter, hydrated, debug]);


### PR DESCRIPTION
useHydratedCurrencies built a Set + alphabetical sort with USD pinned to
the front, dropping the per-plan currency ordering the API now persists.
The toggle in CheckoutDialog and PricingTable showed currencies in
arbitrary alphabetical order regardless of which currency the merchant
configured as their default.

Walk activePlans[0].currencyPrices in stored order to seed the prefix —
that plan's position-0 currency becomes the toggle default. Anything not
covered by the first plan (other plans, add-ons) tail-appends
alphabetically. When the first plan only has legacy single-currency
fields, fall back to those so the prefix still reflects the first plan.
Drop the alphabetical re-sort on currencyFilter matches; the integrator's
input order wins.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
