### PR TITLE
fix: show "session expired" on any 401 from checkout preview

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -654,15 +654,12 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         }
       } catch (err) {
         if (err instanceof ResponseError) {
-          const data = await err.response.json();
-
-          if (
-            err.response.status === 401 &&
-            data.error === "Access Token Invalid"
-          ) {
+          if (err.response.status === 401) {
             setError(t("Session expired. Please refresh and try again."));
             return;
           }
+
+          const data = await err.response.json();
 
           if (err.response.status === 400) {
             switch (data.error) {


### PR DESCRIPTION
## Summary

The checkout dialog's catch block matched the response body on `data.error === "Access Token Invalid"` to detect expired temporary access tokens, but the API returns `"Invalid access token"` (different word order). The 401 branch never fired, so expired tokens fell through to the generic *"Error retrieving plan details. Please try again in a moment."* fallback — confusing for users, who actually just needed to refresh.

This swap also closes the loop for a customer report: an Appy.AI user hit `/checkout/preview` 6 minutes after their temp token's 15-minute TTL elapsed; the API correctly returned `401 {"error":"Invalid access token"}`; the dialog showed "Error retrieving plan details" instead of "Session expired."

## Why drop the body match entirely

`/checkout/preview` configures only the `TemporaryAccessTokenStrategy`. Auditing all 401 paths from that route:

| Path | API response | Refresh helps? |
|---|---|---|
| No header | `401 Unauthorized` | ✅ re-hydrate |
| Wrong key type (e.g. publishable) | `401 Unauthorized` | ❌ — but unreachable for a properly configured SDK |
| Token expired / row gone | `401 Invalid access token` | ✅ **the case we're fixing** |
| Account / api_key lookup fails | `401 Invalid access token` | ⚠️ rare; user escalates to support |

For the common cases, refresh is the right action. For the rare config/revocation cases, refresh produces the same error and the user escalates — also correct. Body-match was brittle and offered no benefit over a status-only check.

The 400/409 string switches in the same catch are unaffected.

## Repro / evidence

- DD: 4 × 401 on `POST /checkout/preview` in the last 7 days, all with `temporary_access_token_error: temporary access token not found`
- Confirmed correlation by joining `temporary_access_token_key` from spans against `temporary_access_tokens` in prod: every failing token's `expired_at` was before the request timestamp
- Slack: https://schematichq.slack.com/archives/C08PAV2DMGW/p1777498569585539