### PR TITLE
`styled-components` v6.4.x + `components` breaks `next` rendering in React dev mode

### DIFF
--- a/components/src/components/ui/input/styles.ts
+++ b/components/src/components/ui/input/styles.ts
@@ -1,13 +1,13 @@
 import { css, styled } from "styled-components";
 
-import { useIsLightBackground } from "../../../hooks";
+import { isLightColor } from "../../../utils";
 
 export const Input = styled.input<{
   $size?: "xs" | "sm" | "md" | "lg" | "full";
   $color?: "primary" | "secondary" | "danger";
   $variant?: "filled" | "outline" | "ghost" | "text";
 }>(({ theme, $size = "md", $variant = "filled" }) => {
-  const isLightBackground = useIsLightBackground();
+  const isLightBackground = isLightColor(theme.card.background);
 
   return css`
     font-family: "Inter", sans-serif;


### PR DESCRIPTION
## Summary

Fixes [SCHY-333](https://linear.app/schematic/issue/SCHY-333/styled-components-v64x-components-breaks-next-rendering-in-react-dev): `styled-components` v6.4.x + `components` breaks `next` rendering in React dev mode.

The `Input` styled-component was calling the `useIsLightBackground` React hook from inside its `styled(...)` template callback. That callback is invoked by styled-components during style evaluation — it is not a component render or a custom hook — so calling a hook there violates the rules of hooks. With styled-components v6.4.x this surfaced as a Next.js rendering break in React dev mode.

Replaces the hook call with a direct `isLightColor(theme.card.background)` call using the `theme` already passed to the styled-components callback. This avoids the rules-of-hooks violation while preserving the same behavior (the underlying hook just memoizes the same `isLightColor` check against `settings.theme.card.background`).

## Changes

- `components/src/components/ui/input/styles.ts`: swap `useIsLightBackground()` for `isLightColor(theme.card.background)` inside the `Input` styled-component callback.

## Test plan

- [ ] Verify the affected `Input` component still renders with correct light/dark background styling across `primary`/`secondary`/`danger` colors and `filled`/`outline`/`ghost`/`text` variants.
- [ ] Run a consuming Next.js app in React dev mode and confirm the rendering break from SCHY-333 is gone.
- [ ] Audit other styled-components in `components/src` for similar hook-inside-callback patterns (out of scope for this PR, but worth a follow-up).