### PR TITLE
surface scheduled-checkout 409 in checkout dialog and sidebar

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -36,6 +36,7 @@ import {
   buildPayInAdvanceRequestBody,
   getPlanPrice,
   isError,
+  isScheduledCheckoutConflictMessage,
 } from "../../../utils";
 import {
   CurrencyToggle,
@@ -678,12 +679,12 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
             }
           }
 
-          if (err.response.status === 409) {
-            switch (data.error) {
-              case "cannot purchase pay-in-advance entitlements while a scheduled downgrade is pending; cancel the scheduled downgrade first":
-                setError(t("Downgrade pending."));
-                return;
-            }
+          if (
+            err.response.status === 409 &&
+            isScheduledCheckoutConflictMessage(data?.error)
+          ) {
+            setError(t("Downgrade pending."));
+            return;
           }
 
           setError(

--- a/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
+++ b/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 
 import {
   EntitlementPriceBehavior,
+  ResponseError,
   type PreviewSubscriptionFinanceResponseData,
 } from "../../../api/checkoutexternal";
 import { useEmbed, useIsLightBackground } from "../../../hooks";
@@ -34,6 +35,7 @@ import {
   getFeatureName,
   getMonthName,
   getPlanPrice,
+  isScheduledCheckoutConflictMessage,
   shortenPeriod,
   toPrettyDate,
 } from "../../../utils";
@@ -505,9 +507,43 @@ export const SubscriptionSidebar = forwardRef<
           setIsLoading(false);
           setLayout("portal");
         }
-      } catch {
+      } catch (err) {
         setIsLoading(false);
         setLayout("checkout");
+
+        if (err instanceof ResponseError) {
+          if (err.response.status === 401) {
+            setError(t("Session expired. Please refresh and try again."));
+            return;
+          }
+
+          // Read the body once; the `data.error` string is what the API
+          // helpers in lib/web/helpers.go put under the top-level error key.
+          let data: { error?: unknown } | undefined;
+          try {
+            data = await err.response.json();
+          } catch {
+            data = undefined;
+          }
+
+          if (
+            err.response.status === 409 &&
+            isScheduledCheckoutConflictMessage(data?.error)
+          ) {
+            setError(
+              t(
+                "Downgrade pending. Cancel the scheduled downgrade before making another change.",
+              ),
+            );
+            return;
+          }
+        }
+
+        // Default fallback. The original copy assumed every checkout error
+        // was a payment-method problem; that's right for Stripe-rejection
+        // failures (handled in the confirmPaymentIntent callback above), but
+        // misleading for transport / API errors. Keep the "try a different
+        // payment method" hint for now — broader copy review is out of scope.
         setError(
           t("Error processing payment. Please try a different payment method."),
         );

--- a/components/src/utils/api/checkout.test.ts
+++ b/components/src/utils/api/checkout.test.ts
@@ -9,6 +9,7 @@ import {
   buildAddOnRequestBody,
   buildCreditBundlesRequestBody,
   buildPayInAdvanceRequestBody,
+  isScheduledCheckoutConflictMessage,
 } from "./checkout";
 
 function makeUsageBasedEntitlement(
@@ -547,5 +548,52 @@ describe("buildCreditBundlesRequestBody", () => {
     expect(result[0]).toHaveProperty("quantity", 42);
     expect(result[0]).not.toHaveProperty("id");
     expect(result[0]).not.toHaveProperty("count");
+  });
+});
+
+describe("isScheduledCheckoutConflictMessage", () => {
+  // Mirror the four 409 messages the API can emit (api/apps/errors/errors.go).
+  // All four must trip the matcher so the UI shows the friendly "downgrade
+  // pending" copy instead of the generic fallback.
+  it.each([
+    "a scheduled checkout already exists for this company",
+    "cannot purchase add-ons while a scheduled downgrade is pending; cancel the scheduled downgrade first",
+    "cannot purchase pay-in-advance entitlements while a scheduled downgrade is pending; cancel the scheduled downgrade first",
+    "cannot purchase credits while a scheduled downgrade is pending; cancel the scheduled downgrade first",
+  ])("matches the API conflict message: %s", (msg) => {
+    expect(isScheduledCheckoutConflictMessage(msg)).toBe(true);
+  });
+
+  it("matches when the backend tweaks casing or surrounding wording", () => {
+    expect(
+      isScheduledCheckoutConflictMessage(
+        "A Scheduled Checkout already exists.",
+      ),
+    ).toBe(true);
+    expect(
+      isScheduledCheckoutConflictMessage(
+        "request blocked: scheduled downgrade pending",
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    "Invalid promo code",
+    "self-service downgrade not permitted",
+    "internal server error",
+    "",
+  ])("does not match unrelated message: %s", (msg) => {
+    expect(isScheduledCheckoutConflictMessage(msg)).toBe(false);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(isScheduledCheckoutConflictMessage(undefined)).toBe(false);
+    expect(isScheduledCheckoutConflictMessage(null)).toBe(false);
+    expect(isScheduledCheckoutConflictMessage(409)).toBe(false);
+    expect(
+      isScheduledCheckoutConflictMessage({
+        message: "scheduled downgrade pending",
+      }),
+    ).toBe(false);
   });
 });

--- a/components/src/utils/api/checkout.ts
+++ b/components/src/utils/api/checkout.ts
@@ -58,6 +58,20 @@ export function buildAddOnRequestBody(options: {
   }, []);
 }
 
+// Recognizes 409 responses from POST /checkout(/preview) where a pending
+// scheduled checkout is blocking the action. The backend currently emits
+// four variants of this conflict (already-exists, blocks add-ons, blocks
+// pay-in-advance, blocks credits) — see api/apps/errors/errors.go. Match on
+// the shared phrasing rather than exact strings so a wording tweak on the
+// backend doesn't silently regress the friendly UI message.
+export function isScheduledCheckoutConflictMessage(message: unknown): boolean {
+  if (typeof message !== "string") {
+    return false;
+  }
+  const m = message.toLowerCase();
+  return m.includes("scheduled downgrade") || m.includes("scheduled checkout");
+}
+
 export function buildCreditBundlesRequestBody(
   creditBundles: CreditBundle[],
 ): UpdateCreditBundleRequestBody[] {


### PR DESCRIPTION
The API returns four 409 messages from POST /checkout(/preview) when a
pending scheduled checkout blocks the next action. CheckoutDialog only
mapped one of the four to a friendly string (BlocksPayInAdvance);
SubscriptionSidebar caught the entire commit-checkout failure with a
bare `catch {}` and showed "Error processing payment. Please try a
different payment method." for any error — actively misleading when the
real cause is a pending downgrade.

- Add isScheduledCheckoutConflictMessage() in utils/api/checkout.ts
  that case-insensitively matches "scheduled downgrade" or "scheduled
  checkout" so backend wording tweaks don't silently regress the UI.
- CheckoutDialog: replace the single-string switch with the matcher.
- SubscriptionSidebar: bind the catch error, inspect ResponseError for
  401 (session expired) and 409 (scheduled-checkout conflict) before
  falling back to the existing payment-method message.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
