### PR TITLE
hide pricing-table plans and add-ons that lack the selected currency

### DIFF
--- a/components/src/components/elements/pricing-table/PricingTable.test.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.test.tsx
@@ -710,6 +710,100 @@ describe("`PricingTable`", () => {
       expect(secondPlanPrice).toHaveTextContent("€10.00/month");
     });
 
+    test("hides plans and add-ons that lack the selected currency", async () => {
+      server.use(
+        http.get("https://api.schematichq.com/public/plans", async () => {
+          const response = cloneDeep(plansJson);
+
+          const usdMonthly = (price: number) => ({
+            currency: "usd",
+            external_price_id: `price_usd_${price}_m`,
+            id: `bilpp_usd_${price}_m`,
+            interval: "month",
+            price,
+            price_decimal: String(price),
+            provider_type: "stripe",
+            scheme: "per_unit",
+          });
+          const usdYearly = (price: number) => ({
+            ...usdMonthly(price),
+            external_price_id: `price_usd_${price}_y`,
+            id: `bilpp_usd_${price}_y`,
+            interval: "year",
+          });
+          const jpyMonthly = (price: number) => ({
+            currency: "jpy",
+            external_price_id: `price_jpy_${price}_m`,
+            id: `bilpp_jpy_${price}_m`,
+            interval: "month",
+            price,
+            price_decimal: String(price),
+            provider_type: "stripe",
+            scheme: "per_unit",
+          });
+          const jpyYearly = (price: number) => ({
+            ...jpyMonthly(price),
+            external_price_id: `price_jpy_${price}_y`,
+            id: `bilpp_jpy_${price}_y`,
+            interval: "year",
+          });
+
+          // The inferred type from `plansJson` types `currency_prices` as
+          // `never[]`, so cast each entry list through `unknown` rather than
+          // sprinkling `@ts-expect-error` (which doesn't reach inside the
+          // multi-line literal).
+          // Plans 0/1 support both USD and JPY; plans 2/3 are USD only.
+          response.data.active_plans[0].currency_prices = [
+            { currency: "usd", monthly_price: usdMonthly(500), yearly_price: usdYearly(5000) },
+            { currency: "jpy", monthly_price: jpyMonthly(500), yearly_price: jpyYearly(5000) },
+          ] as unknown as never[];
+          response.data.active_plans[1].currency_prices = [
+            { currency: "usd", monthly_price: usdMonthly(1000), yearly_price: usdYearly(10000) },
+            { currency: "jpy", monthly_price: jpyMonthly(1000), yearly_price: jpyYearly(10000) },
+          ] as unknown as never[];
+
+          // Add-on 0 supports both; add-on 1 is USD only.
+          response.data.active_add_ons[0].currency_prices = [
+            { currency: "usd", monthly_price: usdMonthly(500), yearly_price: usdYearly(5000) },
+            { currency: "jpy", monthly_price: jpyMonthly(500), yearly_price: jpyYearly(5000) },
+          ] as unknown as never[];
+
+          return HttpResponse.json(response);
+        }),
+      );
+
+      render(<PricingTable callToActionUrl="/" />);
+
+      // Selector shows because more than one currency is hydrated.
+      const currencySelect = await screen.findByTestId("sch-currency-select");
+      expect(currencySelect).toHaveValue("USD");
+
+      // USD is selected initially: every plan and add-on renders.
+      let plans = screen.queryAllByTestId("sch-plan");
+      expect(plans).toHaveLength(4);
+      expect(screen.getByText("Basic")).toBeInTheDocument();
+      expect(screen.getByText("Standard")).toBeInTheDocument();
+      expect(screen.getByText("Professional")).toBeInTheDocument();
+      expect(screen.getByText("Enterprise")).toBeInTheDocument();
+      expect(screen.getByText("Simple Add-on")).toBeInTheDocument();
+      expect(screen.getByText("One-time Add-on")).toBeInTheDocument();
+
+      // Switch to JPY.
+      act(() => {
+        fireEvent.change(currencySelect, { target: { value: "JPY" } });
+      });
+
+      // Only the plans/add-ons that offer JPY remain.
+      plans = screen.queryAllByTestId("sch-plan");
+      expect(plans).toHaveLength(2);
+      expect(screen.getByText("Basic")).toBeInTheDocument();
+      expect(screen.getByText("Standard")).toBeInTheDocument();
+      expect(screen.queryByText("Professional")).not.toBeInTheDocument();
+      expect(screen.queryByText("Enterprise")).not.toBeInTheDocument();
+      expect(screen.getByText("Simple Add-on")).toBeInTheDocument();
+      expect(screen.queryByText("One-time Add-on")).not.toBeInTheDocument();
+    });
+
     test("renders plans with very large prices properly", async () => {
       server.use(
         http.get("https://api.schematichq.com/public/plans", async () => {

--- a/components/src/components/elements/pricing-table/PricingTable.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +26,7 @@ import {
   useEmbed,
 } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
-import { entitlementCountsReducer } from "../../../utils";
+import { entitlementCountsReducer, planSupportsCurrency } from "../../../utils";
 import { Container, FussyChild } from "../../layout";
 import {
   CurrencyToggle,
@@ -190,9 +191,38 @@ export const PricingTable = forwardRef<
   const showCurrencySelector = currencies.length > 1;
   const hasCurrency = currencies.length > 1 || hasCurrencyFilter;
   const hasNoUsableCurrency = currencies.length === 0;
-  const { plans, addOns, periods } = useAvailablePlans(selectedPeriod, {
+  const {
+    plans: allPlans,
+    addOns: allAddOns,
+    periods,
+  } = useAvailablePlans(selectedPeriod, {
     useSelectedPeriod: showPeriodToggle,
   });
+
+  // When a currency is in play (multi-currency data or an explicit
+  // currencyFilter), hide plans/add-ons that lack pricing in the selected
+  // currency rather than rendering them with a mismatched legacy fallback.
+  // Memoize so a stable reference is handed to the entitlement-count effect
+  // below — without this the filtered array would be a fresh value on every
+  // render and trigger an infinite update loop.
+  const plans = useMemo(
+    () =>
+      hasCurrency
+        ? allPlans.filter((plan) =>
+            planSupportsCurrency(plan, selectedCurrency),
+          )
+        : allPlans,
+    [allPlans, hasCurrency, selectedCurrency],
+  );
+  const addOns = useMemo(
+    () =>
+      hasCurrency
+        ? allAddOns.filter((addOn) =>
+            planSupportsCurrency(addOn, selectedCurrency),
+          )
+        : allAddOns,
+    [allAddOns, hasCurrency, selectedCurrency],
+  );
 
   const [entitlementCounts, setEntitlementCounts] = useState(() =>
     plans.reduce(entitlementCountsReducer, {}),

--- a/components/src/utils/api/billing.ts
+++ b/components/src/utils/api/billing.ts
@@ -100,6 +100,35 @@ export function getAddOnPrice(
   }
 }
 
+/**
+ * Returns true if the plan/add-on offers pricing in the given currency.
+ *
+ * - If `currency` is omitted, returns true (no filter).
+ * - If the plan has explicit `currencyPrices`, the currency must be present
+ *   there.
+ * - Otherwise we treat the legacy single-currency pricing fields as
+ *   authoritative and match against whichever interval price is set.
+ * - A plan with no pricing at all (e.g. a free plan) is currency-agnostic.
+ */
+export function planSupportsCurrency(plan: Plan, currency?: string): boolean {
+  if (!currency) return true;
+
+  const target = currency.toLowerCase();
+
+  if (plan.currencyPrices?.length) {
+    return plan.currencyPrices.some(
+      (cp) => cp.currency.toLowerCase() === target,
+    );
+  }
+
+  const legacyCurrency =
+    plan.monthlyPrice?.currency ??
+    plan.yearlyPrice?.currency ??
+    plan.oneTimePrice?.currency;
+
+  return !legacyCurrency || legacyCurrency.toLowerCase() === target;
+}
+
 export function getEntitlementPrice(
   entitlement: Entitlement,
   period = "month",


### PR DESCRIPTION
Plans and add-ons whose currencyPrices (or legacy interval prices) do not
match the currency selected in the toggle now drop out of the rendered
table instead of falling back to a price quoted in a different currency.
Filtering only kicks in when there is a meaningful currency choice
(multiple hydrated currencies or an explicit currencyFilter) so the
existing single-currency behavior is preserved.

SCHY-335

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
