### PR TITLE
hide checkout add-ons that lack the in-play currency

### DIFF
--- a/components/src/components/elements/pricing-table/PricingTable.test.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.test.tsx
@@ -710,6 +710,100 @@ describe("`PricingTable`", () => {
       expect(secondPlanPrice).toHaveTextContent("€10.00/month");
     });
 
+    test("hides plans and add-ons that lack the selected currency", async () => {
+      server.use(
+        http.get("https://api.schematichq.com/public/plans", async () => {
+          const response = cloneDeep(plansJson);
+
+          const usdMonthly = (price: number) => ({
+            currency: "usd",
+            external_price_id: `price_usd_${price}_m`,
+            id: `bilpp_usd_${price}_m`,
+            interval: "month",
+            price,
+            price_decimal: String(price),
+            provider_type: "stripe",
+            scheme: "per_unit",
+          });
+          const usdYearly = (price: number) => ({
+            ...usdMonthly(price),
+            external_price_id: `price_usd_${price}_y`,
+            id: `bilpp_usd_${price}_y`,
+            interval: "year",
+          });
+          const jpyMonthly = (price: number) => ({
+            currency: "jpy",
+            external_price_id: `price_jpy_${price}_m`,
+            id: `bilpp_jpy_${price}_m`,
+            interval: "month",
+            price,
+            price_decimal: String(price),
+            provider_type: "stripe",
+            scheme: "per_unit",
+          });
+          const jpyYearly = (price: number) => ({
+            ...jpyMonthly(price),
+            external_price_id: `price_jpy_${price}_y`,
+            id: `bilpp_jpy_${price}_y`,
+            interval: "year",
+          });
+
+          // The inferred type from `plansJson` types `currency_prices` as
+          // `never[]`, so cast each entry list through `unknown` rather than
+          // sprinkling `@ts-expect-error` (which doesn't reach inside the
+          // multi-line literal).
+          // Plans 0/1 support both USD and JPY; plans 2/3 are USD only.
+          response.data.active_plans[0].currency_prices = [
+            { currency: "usd", monthly_price: usdMonthly(500), yearly_price: usdYearly(5000) },
+            { currency: "jpy", monthly_price: jpyMonthly(500), yearly_price: jpyYearly(5000) },
+          ] as unknown as never[];
+          response.data.active_plans[1].currency_prices = [
+            { currency: "usd", monthly_price: usdMonthly(1000), yearly_price: usdYearly(10000) },
+            { currency: "jpy", monthly_price: jpyMonthly(1000), yearly_price: jpyYearly(10000) },
+          ] as unknown as never[];
+
+          // Add-on 0 supports both; add-on 1 is USD only.
+          response.data.active_add_ons[0].currency_prices = [
+            { currency: "usd", monthly_price: usdMonthly(500), yearly_price: usdYearly(5000) },
+            { currency: "jpy", monthly_price: jpyMonthly(500), yearly_price: jpyYearly(5000) },
+          ] as unknown as never[];
+
+          return HttpResponse.json(response);
+        }),
+      );
+
+      render(<PricingTable callToActionUrl="/" />);
+
+      // Selector shows because more than one currency is hydrated.
+      const currencySelect = await screen.findByTestId("sch-currency-select");
+      expect(currencySelect).toHaveValue("USD");
+
+      // USD is selected initially: every plan and add-on renders.
+      let plans = screen.queryAllByTestId("sch-plan");
+      expect(plans).toHaveLength(4);
+      expect(screen.getByText("Basic")).toBeInTheDocument();
+      expect(screen.getByText("Standard")).toBeInTheDocument();
+      expect(screen.getByText("Professional")).toBeInTheDocument();
+      expect(screen.getByText("Enterprise")).toBeInTheDocument();
+      expect(screen.getByText("Simple Add-on")).toBeInTheDocument();
+      expect(screen.getByText("One-time Add-on")).toBeInTheDocument();
+
+      // Switch to JPY.
+      act(() => {
+        fireEvent.change(currencySelect, { target: { value: "JPY" } });
+      });
+
+      // Only the plans/add-ons that offer JPY remain.
+      plans = screen.queryAllByTestId("sch-plan");
+      expect(plans).toHaveLength(2);
+      expect(screen.getByText("Basic")).toBeInTheDocument();
+      expect(screen.getByText("Standard")).toBeInTheDocument();
+      expect(screen.queryByText("Professional")).not.toBeInTheDocument();
+      expect(screen.queryByText("Enterprise")).not.toBeInTheDocument();
+      expect(screen.getByText("Simple Add-on")).toBeInTheDocument();
+      expect(screen.queryByText("One-time Add-on")).not.toBeInTheDocument();
+    });
+
     test("renders plans with very large prices properly", async () => {
       server.use(
         http.get("https://api.schematichq.com/public/plans", async () => {

--- a/components/src/components/elements/pricing-table/PricingTable.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +26,7 @@ import {
   useEmbed,
 } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
-import { entitlementCountsReducer } from "../../../utils";
+import { entitlementCountsReducer, planSupportsCurrency } from "../../../utils";
 import { Container, FussyChild } from "../../layout";
 import {
   CurrencyToggle,
@@ -190,9 +191,38 @@ export const PricingTable = forwardRef<
   const showCurrencySelector = currencies.length > 1;
   const hasCurrency = currencies.length > 1 || hasCurrencyFilter;
   const hasNoUsableCurrency = currencies.length === 0;
-  const { plans, addOns, periods } = useAvailablePlans(selectedPeriod, {
+  const {
+    plans: allPlans,
+    addOns: allAddOns,
+    periods,
+  } = useAvailablePlans(selectedPeriod, {
     useSelectedPeriod: showPeriodToggle,
   });
+
+  // When a currency is in play (multi-currency data or an explicit
+  // currencyFilter), hide plans/add-ons that lack pricing in the selected
+  // currency rather than rendering them with a mismatched legacy fallback.
+  // Memoize so a stable reference is handed to the entitlement-count effect
+  // below — without this the filtered array would be a fresh value on every
+  // render and trigger an infinite update loop.
+  const plans = useMemo(
+    () =>
+      hasCurrency
+        ? allPlans.filter((plan) =>
+            planSupportsCurrency(plan, selectedCurrency),
+          )
+        : allPlans,
+    [allPlans, hasCurrency, selectedCurrency],
+  );
+  const addOns = useMemo(
+    () =>
+      hasCurrency
+        ? allAddOns.filter((addOn) =>
+            planSupportsCurrency(addOn, selectedCurrency),
+          )
+        : allAddOns,
+    [allAddOns, hasCurrency, selectedCurrency],
+  );
 
   const [entitlementCounts, setEntitlementCounts] = useState(() =>
     plans.reduce(entitlementCountsReducer, {}),

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -37,6 +37,7 @@ import {
   getPlanPrice,
   isError,
   isScheduledCheckoutConflictMessage,
+  planSupportsCurrency,
 } from "../../../utils";
 import {
   CurrencyToggle,
@@ -399,7 +400,9 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       });
     }
 
-    // addOns could be filtered by compatibility rules
+    // addOns is already filtered by plan compatibility and currency support
+    // (see the setAddOns effect below); skip the stage entirely when nothing
+    // remains.
     if (addOns.length > 0 && (!isSelectedPlanTrialable || !shouldTrial)) {
       stages.push({
         id: "addons",
@@ -994,6 +997,17 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
           return ourCompats?.compatiblePlanIds.includes(selectedPlan?.id);
         })
+        .filter((availAddOn) =>
+          // Drop add-ons that don't offer the in-play currency. The currency
+          // is pinned to lockedCurrency (the active subscription) when one
+          // exists, so this also hides add-ons incompatible with a fixed
+          // subscription currency. We only filter when there's a meaningful
+          // currency choice — otherwise legacy single-currency setups would
+          // disappear unexpectedly.
+          hasCurrency
+            ? planSupportsCurrency(availAddOn, selectedCurrency)
+            : true,
+        )
         .map((addOn) => {
           const prevAddOn = prevAddOns.find((prev) => prev.id === addOn.id);
 
@@ -1003,7 +1017,13 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           };
         });
     });
-  }, [data?.addOnCompatibilities, availableAddOns, selectedPlan]);
+  }, [
+    data?.addOnCompatibilities,
+    availableAddOns,
+    selectedPlan,
+    hasCurrency,
+    selectedCurrency,
+  ]);
 
   useLayoutEffect(() => {
     const element = dialogRef.current;

--- a/components/src/utils/api/billing.ts
+++ b/components/src/utils/api/billing.ts
@@ -100,6 +100,35 @@ export function getAddOnPrice(
   }
 }
 
+/**
+ * Returns true if the plan/add-on offers pricing in the given currency.
+ *
+ * - If `currency` is omitted, returns true (no filter).
+ * - If the plan has explicit `currencyPrices`, the currency must be present
+ *   there.
+ * - Otherwise we treat the legacy single-currency pricing fields as
+ *   authoritative and match against whichever interval price is set.
+ * - A plan with no pricing at all (e.g. a free plan) is currency-agnostic.
+ */
+export function planSupportsCurrency(plan: Plan, currency?: string): boolean {
+  if (!currency) return true;
+
+  const target = currency.toLowerCase();
+
+  if (plan.currencyPrices?.length) {
+    return plan.currencyPrices.some(
+      (cp) => cp.currency.toLowerCase() === target,
+    );
+  }
+
+  const legacyCurrency =
+    plan.monthlyPrice?.currency ??
+    plan.yearlyPrice?.currency ??
+    plan.oneTimePrice?.currency;
+
+  return !legacyCurrency || legacyCurrency.toLowerCase() === target;
+}
+
 export function getEntitlementPrice(
   entitlement: Entitlement,
   period = "month",


### PR DESCRIPTION
Extends the existing addon/plan compatibility filter so add-ons whose currencyPrices (or legacy interval prices) do not include the currency selected in the checkout dialog also drop out of the addons stage. The selectedCurrency is already pinned to the active subscription currency when one exists, so this single rule covers both the "subscription currency mismatch" and "selected plan locks the currency" cases. When no add-ons remain compatible the addons stage is skipped entirely.