### PR TITLE
collapse checkout add-on currency filter into the compatibility filter

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -989,6 +989,19 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     setAddOns((prevAddOns) => {
       return availableAddOns
         .filter((availAddOn) => {
+          // Drop add-ons that don't offer the in-play currency. The currency
+          // is pinned to lockedCurrency (the active subscription) when one
+          // exists, so this also hides add-ons incompatible with a fixed
+          // subscription currency. We only filter when there's a meaningful
+          // currency choice — otherwise legacy single-currency setups would
+          // disappear unexpectedly.
+          if (
+            hasCurrency &&
+            !planSupportsCurrency(availAddOn, selectedCurrency)
+          ) {
+            return false;
+          }
+
           if (!selectedPlan) {
             return true;
           }
@@ -1003,17 +1016,6 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
           return ourCompats?.compatiblePlanIds.includes(selectedPlan?.id);
         })
-        .filter((availAddOn) =>
-          // Drop add-ons that don't offer the in-play currency. The currency
-          // is pinned to lockedCurrency (the active subscription) when one
-          // exists, so this also hides add-ons incompatible with a fixed
-          // subscription currency. We only filter when there's a meaningful
-          // currency choice — otherwise legacy single-currency setups would
-          // disappear unexpectedly.
-          hasCurrency
-            ? planSupportsCurrency(availAddOn, selectedCurrency)
-            : true,
-        )
         .map((addOn) => {
           const prevAddOn = prevAddOns.find((prev) => prev.id === addOn.id);
 


### PR DESCRIPTION
Code review follow-up to #1215: the currency check was a second `.filter`
chained after the plan-compatibility filter. Move it inside the existing
filter as an early-return so we make a single pass over availableAddOns
and keep the related logic in one place.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
