### PR TITLE
chore(ci): authenticate npm publish via OIDC trusted publishers

### DIFF
--- a/.github/workflows/deploy_angular.yml
+++ b/.github/workflows/deploy_angular.yml
@@ -17,19 +17,7 @@ jobs:
 
   publish:
     name: NPM Publish
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
-    permissions:
-      packages: write
-      contents: read
     needs: [lint_test]
-    steps:
-      - uses: runs-on/action@v2.0.3
-      - uses: actions/checkout@v6
-      - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-      - name: Publish schematic-angular
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: TAG="${{ github.ref_name }}" ./scripts/publish-package.sh
+    uses: ./.github/workflows/npm_publish.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/.github/workflows/deploy_components.yml
+++ b/.github/workflows/deploy_components.yml
@@ -17,22 +17,10 @@ jobs:
 
   publish:
     name: NPM Publish
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
-    permissions:
-      packages: write
-      contents: read
     needs: [lint_test]
-    steps:
-      - uses: runs-on/action@v2.0.3
-      - uses: actions/checkout@v6
-      - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-      - name: Publish schematic-components
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: TAG="${{ github.ref_name }}" ./scripts/publish-package.sh
+    uses: ./.github/workflows/npm_publish.yml
+    with:
+      tag: ${{ github.ref_name }}
 
   update_example_app:
     name: Update Example App

--- a/.github/workflows/deploy_js.yml
+++ b/.github/workflows/deploy_js.yml
@@ -1,9 +1,5 @@
 name: Deploy schematic-js
 
-permissions:
-  id-token: write
-  contents: read
-
 on:
   push:
     tags:
@@ -23,6 +19,9 @@ jobs:
     name: Browser Deploy
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
     needs: [lint_test]
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: runs-on/action@v2.0.3
       - uses: actions/checkout@v6
@@ -66,22 +65,10 @@ jobs:
 
   publish:
     name: NPM Publish
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
-    permissions:
-      packages: write
-      contents: read
     needs: [lint_test]
-    steps:
-      - uses: runs-on/action@v2.0.3
-      - uses: actions/checkout@v6
-      - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-      - name: Publish schematic-js
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: TAG="${{ github.ref_name }}" ./scripts/publish-package.sh
+    uses: ./.github/workflows/npm_publish.yml
+    with:
+      tag: ${{ github.ref_name }}
 
   notify_slack:
     name: Notify Slack

--- a/.github/workflows/deploy_react.yml
+++ b/.github/workflows/deploy_react.yml
@@ -17,22 +17,10 @@ jobs:
 
   publish:
     name: NPM Publish
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
-    permissions:
-      packages: write
-      contents: read
     needs: [lint_test]
-    steps:
-      - uses: runs-on/action@v2.0.3
-      - uses: actions/checkout@v6
-      - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-      - name: Publish schematic-react
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: TAG="${{ github.ref_name }}" ./scripts/publish-package.sh
+    uses: ./.github/workflows/npm_publish.yml
+    with:
+      tag: ${{ github.ref_name }}
 
   update_example_app:
     name: Update Example App

--- a/.github/workflows/deploy_vue.yml
+++ b/.github/workflows/deploy_vue.yml
@@ -17,19 +17,7 @@ jobs:
 
   publish:
     name: NPM Publish
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
-    permissions:
-      packages: write
-      contents: read
     needs: [lint_test]
-    steps:
-      - uses: runs-on/action@v2.0.3
-      - uses: actions/checkout@v6
-      - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-      - name: Publish schematic-vue
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: TAG="${{ github.ref_name }}" ./scripts/publish-package.sh
+    uses: ./.github/workflows/npm_publish.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,37 @@
+name: NPM Publish
+
+# Reusable workflow that publishes a package to npm using Trusted Publishing
+# (OIDC). All deploy_*.yml and release_candidate.yml call into this so that
+# only this one filename needs to be registered as the trusted publisher for
+# each @schematichq/* package on npmjs.com.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. schematic-react@1.3.0 or schematic-react@1.3.0-rc.1)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: runs-on/action@v2.0.3
+      - uses: actions/checkout@v6
+
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
+      - name: Publish
+        run: TAG="${{ inputs.tag }}" ./scripts/publish-package.sh

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -60,24 +60,10 @@ jobs:
 
   publish:
     name: NPM Publish (RC)
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache
-    permissions:
-      packages: write
-      contents: read
     needs: [parse_tag, lint_test]
-    steps:
-      - uses: runs-on/action@v2.0.3
-      - uses: actions/checkout@v6
-
-      - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-
-      - name: Publish RC
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: TAG="${{ github.ref_name }}" ./scripts/publish-package.sh
+    uses: ./.github/workflows/npm_publish.yml
+    with:
+      tag: ${{ github.ref_name }}
 
   summary:
     name: Summary

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -14,8 +14,9 @@ set -euo pipefail
 #   TAG="schematic-react@1.3.0" ./scripts/publish-package.sh
 #   TAG="schematic-react@1.3.0-rc.1" ./scripts/publish-package.sh
 #
-# Environment variables:
-#   NPM_TOKEN - Required for publishing to NPM
+# In CI this runs under npm Trusted Publishing (OIDC); no NPM_TOKEN is needed.
+# If NPM_TOKEN is set in the environment, it is used as a fallback (useful for
+# local testing).
 
 if [[ -z "$TAG" ]]; then
     echo "Error: TAG env var required; should match git tag"
@@ -117,11 +118,11 @@ else
     PUBLISH_DIR="."
 fi
 
-# Set up npmrc if NPM_TOKEN is provided
-# Write to cwd (where npm publish runs); npm reads the project .npmrc from
-# cwd, not from the publish target directory.
+# Fallback for local/legacy use: if an NPM_TOKEN is provided, write an .npmrc
+# so npm publish can authenticate via token. In CI we rely on Trusted
+# Publishing (OIDC), so this block is a no-op there.
 if [[ -n "${NPM_TOKEN:-}" ]]; then
-    echo "Setting up .npmrc..."
+    echo "Setting up .npmrc with NPM_TOKEN..."
     echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
 fi
 


### PR DESCRIPTION
Replace static NPM_TOKEN auth with npm Trusted Publishing (OIDC). npm only
allows one trusted publisher entry per package, so the publish step is
consolidated into a single reusable workflow (`npm_publish.yml`) that all
five `deploy_*.yml` workflows and `release_candidate.yml` call into — npm
validates against `job_workflow_ref`, which points to the reusable workflow.

`--provenance` is intentionally omitted because npm provenance attestation
requires a GitHub-hosted runner and we use self-hosted RunsOn runners.
OIDC auth itself works fine on self-hosted (same pattern as `schematic-icons`).

Requires that each `@schematichq/*` package has `SchematicHQ/schematic-js`
`npm_publish.yml` configured as a trusted publisher on npmjs.com before
merging — recommend tagging an RC for one package first to validate.