### PR TITLE
chore(ci): grant id-token: write to reusable npm-publish caller jobs

### DIFF
--- a/.github/workflows/deploy_angular.yml
+++ b/.github/workflows/deploy_angular.yml
@@ -18,6 +18,9 @@ jobs:
   publish:
     name: NPM Publish
     needs: [lint_test]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/npm_publish.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/deploy_components.yml
+++ b/.github/workflows/deploy_components.yml
@@ -18,6 +18,9 @@ jobs:
   publish:
     name: NPM Publish
     needs: [lint_test]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/npm_publish.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/deploy_js.yml
+++ b/.github/workflows/deploy_js.yml
@@ -66,6 +66,9 @@ jobs:
   publish:
     name: NPM Publish
     needs: [lint_test]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/npm_publish.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/deploy_react.yml
+++ b/.github/workflows/deploy_react.yml
@@ -18,6 +18,9 @@ jobs:
   publish:
     name: NPM Publish
     needs: [lint_test]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/npm_publish.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/deploy_vue.yml
+++ b/.github/workflows/deploy_vue.yml
@@ -18,6 +18,9 @@ jobs:
   publish:
     name: NPM Publish
     needs: [lint_test]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/npm_publish.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -61,6 +61,9 @@ jobs:
   publish:
     name: NPM Publish (RC)
     needs: [parse_tag, lint_test]
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/npm_publish.yml
     with:
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
Follow-up to #1250. The `schematic-components@2.11.0` deploy failed at
startup ([run 25765216304](https://github.com/SchematicHQ/schematic-js/actions/runs/25765216304))
because a reusable workflow can only request permissions the caller already
grants — `npm_publish.yml` needs `id-token: write` for OIDC, and the
caller jobs didn't declare it.

Add `permissions: id-token: write, contents: read` to each calling job in
`deploy_{js,react,components,vue,angular}.yml` and `release_candidate.yml`.