### PR TITLE
chore(ci): drop registry-url from setup-node so OIDC handles auth

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
-          registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm for Trusted Publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
Follow-up to #1251. The publish step ran but got `404 Not Found` from npm,
which is the standard "auth failed" response.

Root cause: `actions/setup-node` with `registry-url:` writes an `.npmrc`
of the form `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}`. Since
we don't pass `NODE_AUTH_TOKEN`, npm sees empty credentials and uses
those instead of falling back to OIDC trusted publishing. Removing
`registry-url:` lets npm detect the GH Actions environment and mint a
token itself.

Will also need to confirm the trusted publisher entry on npmjs.com is set
to `npm_publish.yml` (not the old `deploy_*.yml`) for each of the five
packages, otherwise auth will still fail.