### PR TITLE
chore(ci): perform OIDC token exchange manually in publish script

### DIFF
--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -118,10 +118,21 @@ else
     PUBLISH_DIR="."
 fi
 
-# Fallback for local/legacy use: if an NPM_TOKEN is provided, write an .npmrc
-# so npm publish can authenticate via token. In CI we rely on Trusted
-# Publishing (OIDC), so this block is a no-op there.
-if [[ -n "${NPM_TOKEN:-}" ]]; then
+# Authenticate to npm. In CI, exchange the GitHub OIDC token for a short-lived
+# npm publish token (Trusted Publishing). For local use, fall back to NPM_TOKEN.
+if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" && -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+    echo "Exchanging GitHub OIDC token for npm publish token..."
+    OIDC_TOKEN=$(curl -fsSL \
+        -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+        "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" \
+        | node -e 'let d=""; process.stdin.on("data",c=>d+=c).on("end",()=>console.log(JSON.parse(d).value))')
+    NPM_PUBLISH_TOKEN=$(curl -fsSL -X POST \
+        -H "Content-Type: application/json" \
+        -d "{\"id_token\":\"${OIDC_TOKEN}\"}" \
+        "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange" \
+        | node -e 'let d=""; process.stdin.on("data",c=>d+=c).on("end",()=>console.log(JSON.parse(d).token))')
+    echo "//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}" > .npmrc
+elif [[ -n "${NPM_TOKEN:-}" ]]; then
     echo "Setting up .npmrc with NPM_TOKEN..."
     echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
 fi


### PR DESCRIPTION
Follow-up to #1252. The publish still fails with `ENEEDAUTH` even though
npm 11.12.1 is running with `id-token: write` granted and the trusted
publisher correctly configured on npmjs.com. Best theory: npm CLI gates
the auto-detected OIDC flow behind `--provenance`, which can't be used
on self-hosted RunsOn runners.

Do the OIDC exchange explicitly in `publish-package.sh` instead — request
a GitHub OIDC token, swap it with npm's `/-/npm/v1/oidc/token/exchange`
endpoint for a short-lived publish token, write that to `.npmrc`. This
is the same flow `@semantic-release/npm@13` performs internally and is
what `schematic-icons` uses successfully.

If the trusted publisher config is right, the npm exchange call returns
a token and publish succeeds. If config is wrong, the exchange call
returns a clear error (much more useful than ENEEDAUTH).