### PR TITLE
chore(ci): use correct per-package npm OIDC exchange endpoint

### DIFF
--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -137,11 +137,11 @@ if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" && -n "${ACTIONS_ID_TOKEN_REQUEST_T
     echo "Got GitHub OIDC token (length: ${#OIDC_TOKEN})"
 
     echo "Exchanging for npm publish token..."
+    NPM_PACKAGE_PATH="@schematichq%2F${PACKAGE}"
     NPM_EXCHANGE_RESPONSE=$(curl -fsSL --retry 3 -X POST \
-        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${OIDC_TOKEN}" \
         -H "Accept: application/json" \
-        -d "{\"id_token\":\"${OIDC_TOKEN}\"}" \
-        "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange") || { echo "Failed to exchange OIDC token with npm"; exit 1; }
+        "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${NPM_PACKAGE_PATH}") || { echo "Failed to exchange OIDC token with npm"; exit 1; }
     NPM_PUBLISH_TOKEN=$(echo "$NPM_EXCHANGE_RESPONSE" | node -e 'let d=""; process.stdin.on("data",c=>d+=c).on("end",()=>console.log(JSON.parse(d).token))')
     if [[ -z "$NPM_PUBLISH_TOKEN" || "$NPM_PUBLISH_TOKEN" == "undefined" ]]; then
         echo "npm exchange response did not contain a token: $NPM_EXCHANGE_RESPONSE"


### PR DESCRIPTION
Follow-up to #1254. The GitHub OIDC fetch now works (token of length
2056), but the npm exchange call returned `404`. The endpoint URL was
wrong.

Per the [npm Registry API docs](https://api-docs.npmjs.com/), the
exchange is **per-package**:

```
POST /-/npm/v1/oidc/token/exchange/package/{url-encoded-package-name}
```

and the OIDC token is passed as a `Bearer` header rather than a JSON
body. Scoped packages url-encode the `/` as `%2F`, so
`@schematichq/schematic-components` becomes
`@schematichq%2Fschematic-components`.