### PR TITLE
chore(ci): disable npm provenance attestation on self-hosted runners

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -33,4 +33,10 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish
+        env:
+          # Disable provenance attestation: it requires a GitHub-hosted
+          # runner and we use self-hosted RunsOn runners. Without this,
+          # publish fails with E422 "Unsupported GitHub Actions runner
+          # environment: self-hosted". OIDC auth still works regardless.
+          NPM_CONFIG_PROVENANCE: "false"
         run: TAG="${{ inputs.tag }}" ./scripts/publish-package.sh


### PR DESCRIPTION
Follow-up to #1256. With the trusted publisher set to the caller
workflow filename, the OIDC token exchange now works end-to-end (got a
publish token of length 396), but npm CLI auto-enables provenance when
it detects OIDC env vars and fails with:

> E422 Unsupported GitHub Actions runner environment: \"self-hosted\".
> Only \"github-hosted\" runners are supported when publishing with
> provenance.

Set `NPM_CONFIG_PROVENANCE=false` to keep OIDC auth but skip provenance
— same workaround `schematic-icons` uses.

---

Also worth noting for follow-up: we now know npm validates the OIDC
token against the **calling** workflow filename (per
[npm docs](https://docs.npmjs.com/trusted-publishers/)), not the
reusable workflow that runs `npm publish`. This means each package's
trusted publisher on npmjs.com needs to point at its own
`deploy_*.yml` (not `npm_publish.yml`), and packages published from
both stable and RC workflows (`release_candidate.yml`) will need their
RC paths consolidated into the stable workflow before RC trusted
publishing can work. Out of scope for this PR — just unblocking the
current tag.