### PR TITLE
DEV-263 Fix angular requiring -js as well

### DIFF
--- a/angular/ng-package.json
+++ b/angular/ng-package.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
   "dest": "dist",
+  "allowedNonPeerDependencies": ["@schematichq/schematic-js"],
   "lib": {
     "entryFile": "src/index.ts"
   }

--- a/angular/package.json
+++ b/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-angular",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Schematic <engineering@schematichq.com>",
   "license": "MIT",
   "repository": {
@@ -16,8 +16,10 @@
     "test:watch": "vitest",
     "prepare": "husky"
   },
+  "dependencies": {
+    "@schematichq/schematic-js": "^1.4.0"
+  },
   "devDependencies": {
-    "@schematichq/schematic-js": "^1.4.0",
     "@angular/compiler": "^21.2.0",
     "@angular/compiler-cli": "^21.2.0",
     "@angular/core": "^21.2.0",

--- a/angular/src/version.ts
+++ b/angular/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.4.0";
+export const version = "1.4.1";


### PR DESCRIPTION
https://linear.app/schematic/issue/DEV-263/angular-sdk-requires-schematichqschematic-js-to-compile

## Problem

A customer reported that installing `@schematichq/schematic-angular` still required them to **separately install `@schematichq/schematic-js`**. The goal was for the framework wrappers to bring `-js` along automatically, the way `schematic-react` and `schematic-vue` already do.

## Root cause

It's a build-tool difference:

- **React / Vue** build with `esbuild --bundle` and mark only the framework (`react`/`vue`) as `--external`. Everything else, including `@schematichq/schematic-js`, gets **inlined into the bundle**. Their published packages have zero runtime deps and `-js` is baked in.
- **Angular** builds with **`ng-packagr`**, which produces an Angular Package Format library. Unlike esbuild, ng-packagr **externalizes every bare-module import and never inlines third-party code**. Since `-js` was only a `devDependency`, it was stripped from the published manifest, leaving a dangling `import ... from '@schematichq/schematic-js'` in the FESM that's declared nowhere.

Confirmed against the published package:

```
@schematichq/schematic-angular@1.4.0
  dependencies: { tslib }          ← no schematic-js
  fesm2022/*.mjs: import * as SchematicJS from '@schematichq/schematic-js'   ← external, undeclared

npm install @schematichq/schematic-angular@1.4.0
  → node_modules/@schematichq/ contains ONLY schematic-angular   (THE BUG)
```

## Fix

ng-packagr won't inline `-js` the way esbuild does, so the idiomatic Angular fix is to declare it as a **runtime dependency** that gets installed transitively. This needs two coordinated changes (ng-packagr errors if only one is present):

1. `package.json`: move `@schematichq/schematic-js` from `devDependencies` into `dependencies`.
2. `ng-package.json`: add `allowedNonPeerDependencies: ["@schematichq/schematic-js"]`.

Also bumps the package to `1.4.1`.

## Verification

Rebuilt the package, packed it, and installed into a clean consumer project:

```
fixed build → dependencies: { @schematichq/schematic-js: ^1.4.0, tslib }
npm install <fixed tgz> → node_modules/@schematichq/ contains schematic-angular AND schematic-js@1.4.0  ✓
```

## Note on parity

This makes the customer's install work (they never install `-js` manually), but it is **not byte-identical to React/Vue**: React/Vue physically inline `-js` into one bundle with zero extra packages, whereas Angular auto-installs `-js` as a separate transitive package. That's the standard Angular library convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)