### PR TITLE
DEV-262 Add host-provided checkout field prepopulation

### DIFF
--- a/components/src/components/shared/payment-form/PaymentForm.test.tsx
+++ b/components/src/components/shared/payment-form/PaymentForm.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { render } from "../../../test/setup";
+
+import { PaymentForm } from "./PaymentForm";
+
+const { mockUseEmbed, mockConfirmSetup, addressElementSpy } = vi.hoisted(
+  () => ({
+    mockUseEmbed: vi.fn(),
+    mockConfirmSetup: vi.fn(),
+    addressElementSpy: vi.fn(),
+  }),
+);
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../../../hooks", () => ({
+  useEmbed: (...args: unknown[]) => mockUseEmbed(...args),
+}));
+
+vi.mock("@stripe/react-stripe-js", () => ({
+  useStripe: () => ({ confirmSetup: mockConfirmSetup }),
+  useElements: () => ({}),
+  PaymentElement: () => <div data-testid="payment-element" />,
+  AddressElement: (props: { options?: Record<string, unknown> }) => {
+    addressElementSpy(props.options);
+    return <div data-testid="address-element" />;
+  },
+}));
+
+interface SetupOptions {
+  collectEmail?: boolean;
+  collectAddress?: boolean;
+  collectPhone?: boolean;
+  prefill?: { email?: string; name?: string };
+}
+
+function setupMocks({
+  collectEmail = false,
+  collectAddress = false,
+  collectPhone = false,
+  prefill,
+}: SetupOptions = {}) {
+  mockUseEmbed.mockReturnValue({
+    data: {
+      checkoutSettings: { collectEmail, collectAddress, collectPhone },
+    },
+    checkoutPrefill: prefill ? { billingDetails: prefill } : undefined,
+  });
+}
+
+const getBillingDetails = () =>
+  mockConfirmSetup.mock.calls[0][0].confirmParams.payment_method_data
+    .billing_details;
+
+describe("`PaymentForm` prefill", () => {
+  beforeEach(() => {
+    mockConfirmSetup.mockReset();
+    mockConfirmSetup.mockResolvedValue({
+      setupIntent: { payment_method: "pm_123" },
+      error: undefined,
+    });
+    addressElementSpy.mockReset();
+  });
+
+  test("pre-fills the email input from host-provided prefill", () => {
+    setupMocks({ collectEmail: true, prefill: { email: "a@b.com" } });
+
+    render(<PaymentForm />);
+
+    expect(screen.getByLabelText("Email")).toHaveValue("a@b.com");
+  });
+
+  test("passes the prefilled name to AddressElement defaultValues", () => {
+    setupMocks({ collectAddress: true, prefill: { name: "Ada Lovelace" } });
+
+    render(<PaymentForm />);
+
+    const calls = addressElementSpy.mock.calls;
+    const lastOptions = calls[calls.length - 1]?.[0];
+    expect(lastOptions?.defaultValues).toEqual({ name: "Ada Lovelace" });
+  });
+
+  test("attaches prefilled email + name on submit when collected", async () => {
+    setupMocks({
+      collectEmail: true,
+      collectAddress: true,
+      prefill: { email: "a@b.com", name: "Ada Lovelace" },
+    });
+
+    render(<PaymentForm />);
+    fireEvent.submit(document.getElementById("payment-form")!);
+
+    await waitFor(() => expect(mockConfirmSetup).toHaveBeenCalled());
+    expect(getBillingDetails()).toEqual({
+      email: "a@b.com",
+      name: "Ada Lovelace",
+    });
+  });
+
+  test("does not attach email when collectEmail is disabled", async () => {
+    setupMocks({ collectEmail: false, prefill: { email: "a@b.com" } });
+
+    render(<PaymentForm />);
+    fireEvent.submit(document.getElementById("payment-form")!);
+
+    await waitFor(() => expect(mockConfirmSetup).toHaveBeenCalled());
+    expect(getBillingDetails()).toEqual({});
+  });
+
+  test("does not attach name when billing address is not collected", async () => {
+    setupMocks({
+      collectEmail: true,
+      collectAddress: false,
+      collectPhone: false,
+      prefill: { email: "a@b.com", name: "Ada Lovelace" },
+    });
+
+    render(<PaymentForm />);
+    fireEvent.submit(document.getElementById("payment-form")!);
+
+    await waitFor(() => expect(mockConfirmSetup).toHaveBeenCalled());
+    expect(getBillingDetails()).toEqual({ email: "a@b.com" });
+  });
+
+  test("syncs a late-arriving prefill email but never clobbers user input", () => {
+    setupMocks({ collectEmail: true });
+
+    const { rerender } = render(<PaymentForm />);
+    expect(screen.getByLabelText("Email")).toHaveValue("");
+
+    // Prefill arrives after mount -> input updates.
+    setupMocks({ collectEmail: true, prefill: { email: "a@b.com" } });
+    rerender(<PaymentForm />);
+    expect(screen.getByLabelText("Email")).toHaveValue("a@b.com");
+
+    // User edits the field.
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "typed@me.com" },
+    });
+    expect(screen.getByLabelText("Email")).toHaveValue("typed@me.com");
+
+    // A later prefill change must not overwrite the user's input.
+    setupMocks({ collectEmail: true, prefill: { email: "other@b.com" } });
+    rerender(<PaymentForm />);
+    expect(screen.getByLabelText("Email")).toHaveValue("typed@me.com");
+  });
+});

--- a/components/src/components/shared/payment-form/PaymentForm.tsx
+++ b/components/src/components/shared/payment-form/PaymentForm.tsx
@@ -4,7 +4,7 @@ import {
   useElements,
   useStripe,
 } from "@stripe/react-stripe-js";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { PreviewSubscriptionFinanceResponseData } from "../../../api/checkoutexternal";
@@ -25,13 +25,28 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
   const stripe = useStripe();
   const elements = useElements();
 
-  const { data } = useEmbed();
+  const { data, checkoutPrefill } = useEmbed();
+  const billing = checkoutPrefill?.billingDetails;
+
+  const collectEmail = data?.checkoutSettings.collectEmail ?? false;
+  const collectPhone = data?.checkoutSettings.collectPhone ?? false;
+  // Check if billing address collection is needed (either configured or required for tax)
+  const shouldCollectAddress = shouldCollectBillingAddress(
+    data?.checkoutSettings.collectAddress ?? false,
+    financeData,
+  );
+  // The AddressElement (which also collects the billing name) is shown whenever
+  // address or phone collection is active.
+  const showBillingAddress = shouldCollectAddress || collectPhone;
 
   const loadTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
 
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(() => billing?.email ?? "");
+  // Tracks whether the user has edited the email so a late-arriving prefill
+  // value never clobbers their input.
+  const userEditedEmailRef = useRef(false);
   const [message, setMessage] = useState<string | undefined>();
   const [isLoading, setIsLoading] = useState(false);
   const [isConfirmed, setIsConfirmed] = useState(false);
@@ -39,15 +54,24 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
   const [isPaymentReady, setIsPaymentReady] = useState(false);
   const [loadError, setLoadError] = useState<string | undefined>();
 
-  const [isAddressComplete, setIsAddressComplete] = useState(() => {
-    // Check if billing address collection is needed (either configured or required for tax)
-    const shouldCollectAddress = shouldCollectBillingAddress(
-      data?.checkoutSettings.collectAddress ?? false,
-      financeData,
-    );
+  const [isAddressComplete, setIsAddressComplete] = useState(
+    () => !shouldCollectAddress,
+  );
 
-    return !shouldCollectAddress;
-  });
+  // Stripe only reads AddressElement `defaultValues` on mount. Key the element
+  // by the prefill identity so a prefill that arrives after mount remounts it.
+  const addressDefaultsKey = useMemo(
+    () => JSON.stringify(billing ?? {}),
+    [billing],
+  );
+
+  // Keep the email input in sync with host-provided prefill until the user
+  // edits it themselves.
+  useEffect(() => {
+    if (!userEditedEmailRef.current && billing?.email) {
+      setEmail(billing.email);
+    }
+  }, [billing?.email]);
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (
     event,
@@ -62,14 +86,23 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
     setIsConfirmed(false);
     setMessage(undefined);
 
+    // Only attach fields the merchant actually collects. The email input is
+    // shown when `collectEmail` is set; the name comes from the AddressElement,
+    // which is shown when billing address/phone collection is active.
+    const billingDetails: { email?: string; name?: string } = {};
+    if (collectEmail && email) {
+      billingDetails.email = email;
+    }
+    if (showBillingAddress && billing?.name) {
+      billingDetails.name = billing.name;
+    }
+
     try {
       const { setupIntent, error } = await stripe.confirmSetup({
         elements,
         confirmParams: {
           payment_method_data: {
-            billing_details: {
-              email,
-            },
+            billing_details: billingDetails,
           },
           return_url: window.location.href,
         },
@@ -149,7 +182,7 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
         )}
       </Box>
 
-      {stripe && data?.checkoutSettings.collectEmail && (
+      {stripe && collectEmail && (
         <Box data-field="name" $marginBottom="1.5rem" $verticalAlign="top">
           <Label htmlFor="email">Email</Label>
           <Input
@@ -158,23 +191,26 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
             value={email}
             autoComplete="email"
             placeholder="Enter email address"
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => {
+              userEditedEmailRef.current = true;
+              setEmail(e.target.value);
+            }}
           />
         </Box>
       )}
 
-      {(shouldCollectBillingAddress(
-        data?.checkoutSettings.collectAddress ?? false,
-        financeData,
-      ) ||
-        data?.checkoutSettings.collectPhone) && (
+      {showBillingAddress && (
         <Box $marginBottom="3.5rem">
           <AddressElement
+            key={addressDefaultsKey}
             options={{
               mode: "billing",
               fields: {
-                phone: data?.checkoutSettings.collectPhone ? "always" : "never",
+                phone: collectPhone ? "always" : "never",
               },
+              ...(billing?.name && {
+                defaultValues: { name: billing.name },
+              }),
             }}
             id="address-element"
             onChange={(event) => {

--- a/components/src/components/shared/payment-form/PaymentForm.tsx
+++ b/components/src/components/shared/payment-form/PaymentForm.tsx
@@ -30,13 +30,10 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
 
   const collectEmail = data?.checkoutSettings.collectEmail ?? false;
   const collectPhone = data?.checkoutSettings.collectPhone ?? false;
-  // Check if billing address collection is needed (either configured or required for tax)
   const shouldCollectAddress = shouldCollectBillingAddress(
     data?.checkoutSettings.collectAddress ?? false,
     financeData,
   );
-  // The AddressElement (which also collects the billing name) is shown whenever
-  // address or phone collection is active.
   const showBillingAddress = shouldCollectAddress || collectPhone;
 
   const loadTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -44,8 +41,6 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
   );
 
   const [email, setEmail] = useState(() => billing?.email ?? "");
-  // Tracks whether the user has edited the email so a late-arriving prefill
-  // value never clobbers their input.
   const userEditedEmailRef = useRef(false);
   const [message, setMessage] = useState<string | undefined>();
   const [isLoading, setIsLoading] = useState(false);
@@ -65,8 +60,6 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
     [billing],
   );
 
-  // Keep the email input in sync with host-provided prefill until the user
-  // edits it themselves.
   useEffect(() => {
     if (!userEditedEmailRef.current && billing?.email) {
       setEmail(billing.email);
@@ -86,9 +79,6 @@ export const PaymentForm = ({ onConfirm, financeData }: PaymentFormProps) => {
     setIsConfirmed(false);
     setMessage(undefined);
 
-    // Only attach fields the merchant actually collects. The email input is
-    // shown when `collectEmail` is set; the name comes from the AddressElement,
-    // which is shown when billing address/phone collection is active.
     const billingDetails: { email?: string; name?: string } = {};
     if (collectEmail && email) {
       billingDetails.email = email;

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -51,12 +51,6 @@ export interface EmbedProviderProps {
    * ISO-4217 codes; case-insensitive. Omit to disable filtering.
    */
   currencyFilter?: string[];
-  /**
-   * Initial values supplied by the host application to pre-populate the
-   * checkout payment form (currently billing email + name). These are never
-   * auto-detected from backend data. Memoize the object so it keeps a stable
-   * reference across renders (same as `settings`).
-   */
   checkoutPrefill?: CheckoutPrefill;
 }
 
@@ -72,8 +66,6 @@ const normalizeString = (value: string | undefined): string | undefined => {
   return trimmed ? trimmed : undefined;
 };
 
-// Trim string values and drop empty ones so downstream consumers only ever see
-// meaningful prefill values. Returns undefined when nothing usable remains.
 const normalizeCheckoutPrefill = (
   prefill: CheckoutPrefill | undefined,
 ): CheckoutPrefill | undefined => {

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -27,6 +27,7 @@ import { reducer } from "./embedReducer";
 import {
   initialState,
   type BypassConfig,
+  type CheckoutPrefill,
   type CheckoutState,
   type EmbedLayout,
   type EmbedSettings,
@@ -50,6 +51,13 @@ export interface EmbedProviderProps {
    * ISO-4217 codes; case-insensitive. Omit to disable filtering.
    */
   currencyFilter?: string[];
+  /**
+   * Initial values supplied by the host application to pre-populate the
+   * checkout payment form (currently billing email + name). These are never
+   * auto-detected from backend data. Memoize the object so it keeps a stable
+   * reference across renders (same as `settings`).
+   */
+  checkoutPrefill?: CheckoutPrefill;
 }
 
 const normalizeCurrencyFilter = (
@@ -59,11 +67,33 @@ const normalizeCurrencyFilter = (
   return Array.from(new Set(filter.map((c) => c.toUpperCase())));
 };
 
+const normalizeString = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+// Trim string values and drop empty ones so downstream consumers only ever see
+// meaningful prefill values. Returns undefined when nothing usable remains.
+const normalizeCheckoutPrefill = (
+  prefill: CheckoutPrefill | undefined,
+): CheckoutPrefill | undefined => {
+  if (!prefill) return undefined;
+
+  const billingDetails = prefill.billingDetails;
+  const email = normalizeString(billingDetails?.email);
+  const name = normalizeString(billingDetails?.name);
+
+  if (!email && !name) return undefined;
+
+  return { billingDetails: { email, name } };
+};
+
 export const EmbedProvider = ({
   children,
   apiKey,
   apiConfig,
   currencyFilter,
+  checkoutPrefill,
   ...options
 }: EmbedProviderProps) => {
   const sessionId = useMemo(() => uuidv4(), []);
@@ -73,6 +103,7 @@ export const EmbedProvider = ({
     const providedState = {
       settings: opts.settings || {},
       currencyFilter: normalizeCurrencyFilter(currencyFilter),
+      checkoutPrefill: normalizeCheckoutPrefill(checkoutPrefill),
     };
     const resolvedState = merge({}, initialState, providedState);
 
@@ -550,6 +581,13 @@ export const EmbedProvider = ({
   }, [currencyFilter]);
 
   useEffect(() => {
+    dispatch({
+      type: "SET_CHECKOUT_PREFILL",
+      checkoutPrefill: normalizeCheckoutPrefill(checkoutPrefill),
+    });
+  }, [checkoutPrefill]);
+
+  useEffect(() => {
     function planChangedHandler(event: Event) {
       if (event instanceof CustomEvent) {
         debug("plan changed", event.detail);
@@ -575,6 +613,7 @@ export const EmbedProvider = ({
         layout: state.layout,
         checkoutState: state.checkoutState,
         currencyFilter: state.currencyFilter,
+        checkoutPrefill: state.checkoutPrefill,
         hydratePublic: debouncedHydratePublic,
         hydrate: debouncedHydrate,
         hydrateComponent: debouncedHydrateComponent,

--- a/components/src/context/embedReducer.test.ts
+++ b/components/src/context/embedReducer.test.ts
@@ -293,3 +293,48 @@ describe("embedReducer - SET_PLANID_BYPASS", () => {
     });
   });
 });
+
+describe("embedReducer - SET_CHECKOUT_PREFILL", () => {
+  it("should set the checkout prefill", () => {
+    const result = reducer(initialState, {
+      type: "SET_CHECKOUT_PREFILL",
+      checkoutPrefill: {
+        billingDetails: { email: "a@b.com", name: "Ada Lovelace" },
+      },
+    });
+
+    expect(result.checkoutPrefill).toEqual({
+      billingDetails: { email: "a@b.com", name: "Ada Lovelace" },
+    });
+  });
+
+  it("should replace an existing prefill", () => {
+    const seeded = reducer(initialState, {
+      type: "SET_CHECKOUT_PREFILL",
+      checkoutPrefill: { billingDetails: { email: "a@b.com" } },
+    });
+
+    const result = reducer(seeded, {
+      type: "SET_CHECKOUT_PREFILL",
+      checkoutPrefill: { billingDetails: { name: "Grace Hopper" } },
+    });
+
+    expect(result.checkoutPrefill).toEqual({
+      billingDetails: { name: "Grace Hopper" },
+    });
+  });
+
+  it("should clear the prefill when set to undefined", () => {
+    const seeded = reducer(initialState, {
+      type: "SET_CHECKOUT_PREFILL",
+      checkoutPrefill: { billingDetails: { email: "a@b.com" } },
+    });
+
+    const result = reducer(seeded, {
+      type: "SET_CHECKOUT_PREFILL",
+      checkoutPrefill: undefined,
+    });
+
+    expect(result.checkoutPrefill).toBeUndefined();
+  });
+});

--- a/components/src/context/embedReducer.ts
+++ b/components/src/context/embedReducer.ts
@@ -15,6 +15,7 @@ import type {
 import {
   defaultSettings,
   type BypassConfig,
+  type CheckoutPrefill,
   type CheckoutState,
   type EmbedLayout,
   type EmbedSettings,
@@ -55,7 +56,8 @@ type EmbedAction =
   | { type: "SET_CHECKOUT_STATE"; state: CheckoutState }
   | { type: "SET_PLANID_BYPASS"; config: string | BypassConfig }
   | { type: "CLEAR_CHECKOUT_STATE" }
-  | { type: "SET_CURRENCY_FILTER"; currencyFilter?: string[] };
+  | { type: "SET_CURRENCY_FILTER"; currencyFilter?: string[] }
+  | { type: "SET_CHECKOUT_PREFILL"; checkoutPrefill?: CheckoutPrefill };
 
 function normalize(data?: HydrateData): HydrateDataWithCompanyContext {
   return merge({}, data, {
@@ -296,6 +298,13 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
       return {
         ...state,
         currencyFilter: action.currencyFilter,
+      };
+    }
+
+    case "SET_CHECKOUT_PREFILL": {
+      return {
+        ...state,
+        checkoutPrefill: action.checkoutPrefill,
       };
     }
   }

--- a/components/src/context/embedState.ts
+++ b/components/src/context/embedState.ts
@@ -286,6 +286,32 @@ export interface BypassConfig {
   startTrialIfAvailable?: boolean;
 }
 
+/**
+ * Host-provided initial values used to pre-populate the checkout payment form.
+ * Values come exclusively from the host application; nothing here is
+ * auto-detected from backend/hydrate data.
+ *
+ * Only the fields we currently consume are present. Additional fields (e.g.
+ * address, phone) can be added here as they are wired up.
+ */
+export interface CheckoutBillingDetails {
+  email?: string;
+  name?: string;
+}
+
+/**
+ * Configuration for pre-populating the checkout flow with host-provided values.
+ *
+ * @example
+ * <EmbedProvider
+ *   apiKey={apiKey}
+ *   checkoutPrefill={{ billingDetails: { email: "a@b.com", name: "Ada Lovelace" } }}
+ * >
+ */
+export interface CheckoutPrefill {
+  billingDetails?: CheckoutBillingDetails;
+}
+
 export type CheckoutState = {
   period?: string;
   planId?: string | null;
@@ -314,6 +340,7 @@ export interface EmbedState {
   layout: EmbedLayout;
   checkoutState?: CheckoutState;
   currencyFilter?: string[];
+  checkoutPrefill?: CheckoutPrefill;
 }
 
 export const initialState: EmbedState = {


### PR DESCRIPTION
https://linear.app/schematic/issue/DEV-262/prepopulate-checkout-email-for-signed-in-users

## Context

A customer asked whether they could pre-populate the embedded checkout payment form with values they already have (the user's email, name) so the user doesn't have to retype them. Today the checkout collects these fresh every time: the email input starts empty and Stripe's `AddressElement` has no defaults.

## What this does

Adds a `checkoutPrefill` prop to `EmbedProvider`. Values come **only from the host app** (never auto-detected from backend data). Scope is **email + name**, the two most common fields.

```tsx
<EmbedProvider
  apiKey={apiKey}
  checkoutPrefill={{ billingDetails: { email: "a@b.com", name: "Ada Lovelace" } }}
>
```

The config is a nested object so address/phone can be added later as an additive change, but only the fields actually wired up are in the type.

## Implementation

Plumbed through reducer → context exactly like the existing `currencyFilter` prop, then consumed by `PaymentForm` (which reads context via `useEmbed()`, so no prop drilling).

- **`embedState.ts`** — `CheckoutBillingDetails` + `CheckoutPrefill` types; `checkoutPrefill?` on `EmbedState`.
- **`embedReducer.ts`** — `SET_CHECKOUT_PREFILL` action + case.
- **`EmbedProvider.tsx`** — new prop, `normalizeCheckoutPrefill` helper (trims/drops empties), initializer seed, sync `useEffect`, context value. `EmbedContext` inherits the type via `EmbedContextProps extends EmbedState`.
- **`PaymentForm.tsx`** — email state seeds from prefill with a `userEditedEmailRef` guard so a late-arriving value never clobbers typing; name flows to `AddressElement` `defaultValues` (with a `key` to remount on late prefill) and is attached to `confirmSetup` billing_details. Fields are only attached when the merchant collects them (email gated on `collectEmail`, name on the billing-address condition).

### Note on gating
Prefill only fills fields whose collection is enabled (deliberate default). Easy to flip if we want prefill attached even when an input is hidden.

## Testing

- `tsc`, `eslint`, prettier all clean.
- Full suite: 310 passing / 4 skipped across 22 files.
- Added 3 reducer tests (set/replace/clear) and 6 `PaymentForm` tests: prefilled email input, name → `AddressElement.defaultValues`, submit payload, gating when collection disabled, and async-arrival + don't-clobber-user-input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)