### PR TITLE
feat(checkout): support multi-currency config in plan-skip bypass

### DIFF
--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -50,9 +50,11 @@ import {
   isError,
   isScheduledCheckoutConflictMessage,
   mergeCompanyGrants,
+  planOffersCurrencyForPeriod,
   planSupportsCurrency,
 } from "../../../utils";
 import {
+  CurrencyPeriodMismatchNotice,
   CurrencyToggle,
   InvalidCurrencyNotice,
   PeriodToggle,
@@ -241,17 +243,30 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     hasCurrencyFilter &&
     !!lockedCurrency &&
     !currencyFilter!.includes(lockedCurrency);
+  // Host-provided prefill (via initializeWithPlan's `currency`). Normalized to
+  // uppercase to match the hydrated currency codes, which are uppercased.
+  const prefilledCurrency = checkoutState?.selectedCurrency?.toUpperCase();
   const [selectedCurrency, setSelectedCurrency] = useState(
-    () =>
-      (checkoutState?.selectedCurrency &&
-      currencies.includes(checkoutState.selectedCurrency)
-        ? checkoutState.selectedCurrency
-        : undefined) ??
-      currencies[0] ??
-      DEFAULT_CURRENCY,
+    () => prefilledCurrency ?? currencies[0] ?? DEFAULT_CURRENCY,
   );
+
+  // Snap to a valid currency when the available set changes and the current
+  // selection is no longer offered (e.g. an invalid prefill, or `currencies`
+  // hydrating after mount). Done during render — not in an effect — to avoid a
+  // cascading re-render; the guard converges because the new value is always a
+  // member of `currencies`. Mirrors the PricingTable reconcile.
+  if (currencies.length > 0 && !currencies.includes(selectedCurrency)) {
+    setSelectedCurrency(currencies[0]);
+  }
+
   const effectiveCurrency = lockedCurrency ?? selectedCurrency;
-  const showCurrencySelector = currencies.length > 1 && !lockedCurrency;
+  // Host can force-hide the dropdown via initializeWithPlan's
+  // `showCurrencySelector: false` (e.g. to pin a single currency). Defaults to
+  // shown. The selector still requires a real choice (>1 currency, unlocked).
+  const currencySelectorEnabled =
+    checkoutState?.showCurrencySelector ?? true;
+  const canSelectCurrency =
+    currencies.length > 1 && !lockedCurrency && currencySelectorEnabled;
   const hasCurrency =
     !!lockedCurrency || currencies.length > 1 || hasCurrencyFilter;
   const hasNoUsableCurrency = !lockedCurrency && currencies.length === 0;
@@ -741,6 +756,62 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
   // this guard, whichever response resolves last wins and the dialog can
   // display charges for a quantity the user is no longer requesting.
   const previewRequestIdRef = useRef(0);
+
+  // Whether the plan stage is actually presented to the user. When the plan
+  // stage is absent or bypassed, the user never sees its currency toggle, so
+  // we surface the selector on the checkout stage instead.
+  const planStageVisible =
+    checkoutStages.some((stage) => stage.id === "plan") &&
+    !checkoutState?.bypassPlanSelection;
+
+  // In a plan-skipping flow the billing period is fixed (the period toggle
+  // lives on the plan stage), so only currencies that actually price that
+  // period belong in the checkout-stage selector. Filtering them out keeps the
+  // user from toggling into an incoherent combo we'd otherwise have to reject.
+  const checkoutStageCurrencies = useMemo(() => {
+    if (!selectedPlan) return currencies;
+    return currencies.filter((currency) =>
+      planOffersCurrencyForPeriod(selectedPlan, planPeriod, currency),
+    );
+  }, [currencies, selectedPlan, planPeriod]);
+
+  // Plan stage keeps the toggle when it's shown; otherwise the checkout stage
+  // hosts it so a plan-skipping flow can still choose a currency — but only
+  // when more than one currency actually offers the fixed period.
+  const showPlanCurrencySelector = canSelectCurrency && planStageVisible;
+  const showCheckoutCurrencySelector =
+    canSelectCurrency && !planStageVisible && checkoutStageCurrencies.length > 1;
+
+  // Incoherent host config: the effective currency does not price the fixed
+  // period on the selected plan. getPlanPrice would silently fall back to the
+  // plan's default-currency price; we refuse that and fail loudly instead.
+  // Scoped to plan-skipping flows — on the plan stage the user can correct the
+  // currency/period themselves via the toggles.
+  const currencyPeriodMismatch =
+    hasCurrency &&
+    !lockedCurrency &&
+    !planStageVisible &&
+    !!selectedPlan &&
+    !planOffersCurrencyForPeriod(selectedPlan, planPeriod, effectiveCurrency);
+
+  useEffect(() => {
+    if (currencyPeriodMismatch) {
+      console.error(
+        `[Schematic] No ${effectiveCurrency} price for the "${planPeriod}" billing period on the selected plan; refusing to fall back to the default currency.`,
+      );
+      debug("currency/period mismatch in checkout bypass config", {
+        currency: effectiveCurrency,
+        period: planPeriod,
+        planId: selectedPlan?.id,
+      });
+    }
+  }, [
+    currencyPeriodMismatch,
+    effectiveCurrency,
+    planPeriod,
+    selectedPlan?.id,
+    debug,
+  ]);
 
   const handlePreviewCheckout = useCallback(
     async (updates: PreviewCheckoutUpdates) => {
@@ -1444,6 +1515,33 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     );
   }
 
+  if (currencyPeriodMismatch) {
+    return (
+      <Dialog
+        ref={setDialog}
+        isModal={isModal}
+        size="lg"
+        top={top}
+        onClose={handleClose}
+        {...(!isModal && { open: layout === "checkout" })}
+      >
+        <DialogContent>
+          <Flex
+            $flexGrow={1}
+            $alignItems="center"
+            $justifyContent="center"
+            $padding="2rem"
+          >
+            <CurrencyPeriodMismatchNotice
+              currency={effectiveCurrency}
+              period={planPeriod}
+            />
+          </Flex>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   return (
     <Dialog
       ref={setDialog}
@@ -1546,7 +1644,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
             {effectiveCheckoutStage === "plan" && (
               <Flex $alignItems="center" $gap="0.75rem">
-                {showCurrencySelector && (
+                {showPlanCurrencySelector && (
                   <CurrencyToggle
                     currencies={currencies}
                     selectedCurrency={effectiveCurrency}
@@ -1565,6 +1663,17 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
                 )}
               </Flex>
             )}
+
+            {effectiveCheckoutStage === "checkout" &&
+              showCheckoutCurrencySelector && (
+                <Flex $alignItems="center" $gap="0.75rem">
+                  <CurrencyToggle
+                    currencies={checkoutStageCurrencies}
+                    selectedCurrency={effectiveCurrency}
+                    onSelect={setSelectedCurrency}
+                  />
+                </Flex>
+              )}
           </Flex>
 
           {isPending ? (

--- a/components/src/components/shared/currency-period-mismatch-notice/CurrencyPeriodMismatchNotice.tsx
+++ b/components/src/components/shared/currency-period-mismatch-notice/CurrencyPeriodMismatchNotice.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from "react-i18next";
+
+import { useEmbed } from "../../../hooks";
+import { Flex, Icon, Text } from "../../ui";
+
+interface CurrencyPeriodMismatchNoticeProps {
+  currency: string;
+  period: string;
+}
+
+/**
+ * Shown when the checkout is pinned (via the bypass config) to a currency and
+ * billing period the selected plan does not price together. We surface a hard,
+ * visible error rather than silently charging in the plan's default currency.
+ */
+export const CurrencyPeriodMismatchNotice = ({
+  currency,
+  period,
+}: CurrencyPeriodMismatchNoticeProps) => {
+  const { settings } = useEmbed();
+  const { t } = useTranslation();
+
+  return (
+    <Flex
+      data-testid="sch-currency-period-mismatch-notice"
+      $flexDirection="column"
+      $alignItems="center"
+      $gap="0.75rem"
+      $padding="1.5rem 2rem"
+      $maxWidth="28rem"
+      $borderWidth="1px"
+      $borderStyle="solid"
+      $borderColor={settings.theme.danger}
+      $borderRadius="0.5rem"
+    >
+      <Icon name="info-rounded" color={settings.theme.danger} size="lg" />
+
+      <Text $weight={600} $size={16} $color={settings.theme.danger}>
+        {t("This plan is not available in the selected currency and period.")}
+      </Text>
+
+      <Text
+        $size={13}
+        $color={settings.theme.danger}
+        style={{ opacity: 0.85, textAlign: "center" }}
+      >
+        {t("No {{currency}} price for the {{period}} billing period.", {
+          currency: currency.toUpperCase(),
+          period,
+        })}
+      </Text>
+    </Flex>
+  );
+};

--- a/components/src/components/shared/currency-period-mismatch-notice/index.ts
+++ b/components/src/components/shared/currency-period-mismatch-notice/index.ts
@@ -1,0 +1,1 @@
+export * from "./CurrencyPeriodMismatchNotice";

--- a/components/src/components/shared/index.ts
+++ b/components/src/components/shared/index.ts
@@ -1,6 +1,7 @@
 export * from "./auto-topup-notice";
 export * from "./billing-threshold-tooltip";
 export * from "./checkout-dialog";
+export * from "./currency-period-mismatch-notice";
 export * from "./currency-toggle";
 export * from "./hard-limit-tooltip";
 export * from "./invalid-currency-notice";

--- a/components/src/context/embedReducer.test.ts
+++ b/components/src/context/embedReducer.test.ts
@@ -292,6 +292,66 @@ describe("embedReducer - SET_PLANID_BYPASS", () => {
       expect(result.checkoutState?.period).toBeUndefined();
     });
   });
+
+  describe("Currency Configuration", () => {
+    it("should pre-select the currency, uppercased", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+        currency: "eur",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.selectedCurrency).toBe("EUR");
+    });
+
+    it("should not set selectedCurrency when currency is not provided", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.selectedCurrency).toBeUndefined();
+    });
+
+    it("should carry showCurrencySelector through when set to false", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+        currency: "EUR",
+        showCurrencySelector: false,
+        skipped: { planStage: true },
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.showCurrencySelector).toBe(false);
+      expect(result.checkoutState?.selectedCurrency).toBe("EUR");
+      expect(result.checkoutState?.bypassPlanSelection).toBe(true);
+    });
+
+    it("should leave showCurrencySelector undefined when not provided", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.showCurrencySelector).toBeUndefined();
+    });
+  });
 });
 
 describe("embedReducer - SET_CHECKOUT_PREFILL", () => {

--- a/components/src/context/embedReducer.ts
+++ b/components/src/context/embedReducer.ts
@@ -279,6 +279,12 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
           bypassAddOnSelection,
           bypassCreditsSelection,
           ...(config.addOnIds && { addOnIds: config.addOnIds }),
+          ...(config.currency && {
+            selectedCurrency: config.currency.toUpperCase(),
+          }),
+          ...(config.showCurrencySelector !== undefined && {
+            showCurrencySelector: config.showCurrencySelector,
+          }),
           hideSkippedStages: config.hideSkipped ?? false,
           startTrialIfAvailable:
             isStringFormat || config.startTrialIfAvailable === undefined

--- a/components/src/context/embedState.ts
+++ b/components/src/context/embedState.ts
@@ -284,6 +284,25 @@ export interface BypassConfig {
    * is not eligible for a trial.
    */
   startTrialIfAvailable?: boolean;
+  /**
+   * Currency to pre-select (e.g. "EUR"). Case-insensitive.
+   *
+   * Useful for flows that skip the plan stage: the host can pin the checkout
+   * to a currency the customer never had a chance to choose. Ignored when the
+   * company already has an active subscription (its currency is locked), or
+   * when the value is not among the available currencies — in which case the
+   * checkout falls back to the first available currency.
+   */
+  currency?: string;
+  /**
+   * Whether to show the currency selector dropdown in checkout. Default: true.
+   *
+   * Set to false to hide the dropdown entirely — combine with `currency` to
+   * pin checkout to a single currency the customer cannot change. Has no
+   * effect when there is only one available currency or the subscription
+   * currency is locked (the selector is already hidden in those cases).
+   */
+  showCurrencySelector?: boolean;
 }
 
 /**
@@ -325,6 +344,7 @@ export type CheckoutState = {
   addOnIds?: string[];
   hideSkippedStages?: boolean;
   selectedCurrency?: string;
+  showCurrencySelector?: boolean;
   startTrialIfAvailable?: boolean;
 };
 

--- a/components/src/utils/api/billing.test.ts
+++ b/components/src/utils/api/billing.test.ts
@@ -8,7 +8,57 @@ import {
   EntitlementValueType,
 } from "../../api/checkoutexternal";
 
-import { getEntitlementPrice } from "./billing";
+import type { Plan } from "../../types";
+
+import { getEntitlementPrice, planOffersCurrencyForPeriod } from "./billing";
+
+// Minimal plan priced monthly+yearly in USD (legacy fields) but only yearly in
+// EUR (currencyPrices). Exercises the silent-fallback path getPlanPrice takes
+// when a currency lacks the requested period.
+function makeCurrencyPlan(): Plan {
+  const usd = (price: number) => ({ currency: "USD", price });
+  const eur = (price: number) => ({ currency: "EUR", price });
+
+  return {
+    id: "plan-1",
+    monthlyPrice: usd(1000),
+    yearlyPrice: usd(10000),
+    currencyPrices: [
+      { currency: "EUR", yearlyPrice: eur(9000) },
+      { currency: "USD", monthlyPrice: usd(1000), yearlyPrice: usd(10000) },
+    ],
+  } as unknown as Plan;
+}
+
+describe("planOffersCurrencyForPeriod", () => {
+  it("returns true when no currency is requested", () => {
+    expect(planOffersCurrencyForPeriod(makeCurrencyPlan(), "month")).toBe(true);
+  });
+
+  it("returns true when the currency prices the requested period", () => {
+    expect(planOffersCurrencyForPeriod(makeCurrencyPlan(), "year", "EUR")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the currency lacks the requested period (would fall back)", () => {
+    // EUR has no monthly price; getPlanPrice would return the USD monthly price.
+    expect(
+      planOffersCurrencyForPeriod(makeCurrencyPlan(), "month", "EUR"),
+    ).toBe(false);
+  });
+
+  it("is case-insensitive about the currency code", () => {
+    expect(planOffersCurrencyForPeriod(makeCurrencyPlan(), "year", "eur")).toBe(
+      true,
+    );
+  });
+
+  it("returns true for a free/unpriced plan (nothing to mischarge)", () => {
+    const freePlan = { id: "free", currencyPrices: [] } as unknown as Plan;
+    expect(planOffersCurrencyForPeriod(freePlan, "month", "EUR")).toBe(true);
+  });
+});
 
 // Build a tiered Overage BillingPriceView whose parent `price` is 0 and the
 // per-unit cost lives in the highest priceTier entry. This mirrors what the

--- a/components/src/utils/api/billing.ts
+++ b/components/src/utils/api/billing.ts
@@ -123,6 +123,38 @@ export function getPlanPrice(
   }
 }
 
+/**
+ * Whether the plan prices the given period in the given currency *specifically*
+ * — i.e. `getPlanPrice` would return a real currency price rather than silently
+ * falling back to the plan's default-currency price for that period.
+ *
+ * - Returns true when no currency is requested (nothing to mismatch).
+ * - Returns true for a free/unpriced plan (no price to mischarge).
+ * - Returns false only when a currency is requested and the resolved price
+ *   belongs to a different currency (the silent-fallback case).
+ *
+ * Use this to detect incoherent currency/period combinations passed via the
+ * checkout bypass config before they reach checkout.
+ */
+export function planOffersCurrencyForPeriod(
+  plan: Plan,
+  period = "month",
+  currency?: string,
+): boolean {
+  if (!currency) return true;
+
+  const price = getPlanPrice(
+    plan,
+    period,
+    { useSelectedPeriod: true },
+    currency,
+  );
+  // No price at all: free/unpriced plan — nothing to mischarge.
+  if (!price) return true;
+
+  return price.currency.toUpperCase() === currency.toUpperCase();
+}
+
 export function getAddOnPrice(
   addOn: Plan,
   period = "month",


### PR DESCRIPTION
Extend initializeWithPlan's BypassConfig with `currency` (prefill the
checkout currency) and `showCurrencySelector` (control the dropdown), and
surface the currency selector on the checkout stage for flows that skip
plan selection. When a pinned currency/period combination isn't priced,
fail loudly with a visible notice instead of silently falling back to the
plan's default-currency price.

- embedState: add currency + showCurrencySelector to BypassConfig, and
  showCurrencySelector to CheckoutState
- embedReducer: map bypass currency -> selectedCurrency (uppercased) and
  pass showCurrencySelector through
- CheckoutDialog: render the selector on the checkout stage when the plan
  stage is skipped, normalize + reconcile the prefilled currency, and
  detect currency/period mismatches (filtering toggle options to the
  fixed period)
- billing: add planOffersCurrencyForPeriod helper
- add CurrencyPeriodMismatchNotice and log loudly on mismatch
- tests for the reducer and the helper

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
