### PR TITLE
Guard async element fetches against out-of-order responses

### DIFF
--- a/components/src/components/elements/invoices/Invoices.tsx
+++ b/components/src/components/elements/invoices/Invoices.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../../api/checkoutexternal";
 import { MAX_VISIBLE_INVOICE_COUNT } from "../../../const";
 import { type FontStyle } from "../../../context";
-import { useEmbed } from "../../../hooks";
+import { useEmbed, useLatestRequestGuard } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
 import {
   ERROR_UNKNOWN,
@@ -150,22 +150,32 @@ export const Invoices = forwardRef<
   );
   const [listSize, setListSize] = useState(props.limit.number);
 
+  // Guard against an earlier fetch resolving after a later one (or after the
+  // list has been refreshed via props/shared data) and clobbering newer data.
+  const beginInvoicesRequest = useLatestRequestGuard();
+
   const getInvoices = useCallback(async () => {
+    const isStale = beginInvoicesRequest();
+
     try {
       setError(undefined);
       setIsLoading(true);
 
       const response = await listInvoices();
 
-      if (response) {
+      if (response && !isStale()) {
         setInvoices(formatInvoices(response.data));
       }
     } catch (err) {
-      setError(isError(err) ? err : ERROR_UNKNOWN);
+      if (!isStale()) {
+        setError(isError(err) ? err : ERROR_UNKNOWN);
+      }
     } finally {
-      setIsLoading(false);
+      if (!isStale()) {
+        setIsLoading(false);
+      }
     }
-  }, [listInvoices]);
+  }, [beginInvoicesRequest, listInvoices]);
 
   const toggleListSize = () => {
     setListSize((prev) =>

--- a/components/src/components/elements/payment-method/PaymentMethodDetails.tsx
+++ b/components/src/components/elements/payment-method/PaymentMethodDetails.tsx
@@ -16,6 +16,7 @@ import { type FontStyle } from "../../../context";
 import {
   useEmbed,
   useIsLightBackground,
+  useLatestRequestGuard,
   usePaymentConfirmation,
 } from "../../../hooks";
 import type {
@@ -198,25 +199,35 @@ export const PaymentMethodDetails = ({
       });
   }, [t, stripe, setupIntent]);
 
+  // The effect below can re-run while a setup intent is still being created
+  // (its deps include `showPaymentForm`/`currentPaymentMethod`); guard so a
+  // superseded request's response can't overwrite the latest setup intent.
+  const beginSetupIntentRequest = useLatestRequestGuard();
+
   const initializePaymentMethod = useCallback(() => {
+    const isStale = beginSetupIntentRequest();
     const pending = createSetupIntent() ?? Promise.resolve(undefined);
 
     return pending
       .then((response) => {
-        if (response) {
+        if (response && !isStale()) {
           setSetupIntent(response.data);
         }
       })
       .catch(() => {
-        setError(
-          t("Error initializing payment method change. Please try again."),
-        );
+        if (!isStale()) {
+          setError(
+            t("Error initializing payment method change. Please try again."),
+          );
+        }
       })
       .finally(() => {
-        setShowPaymentForm(true);
-        setIsLoading(false);
+        if (!isStale()) {
+          setShowPaymentForm(true);
+          setIsLoading(false);
+        }
       });
-  }, [t, createSetupIntent]);
+  }, [t, beginSetupIntentRequest, createSetupIntent]);
 
   const handleUpdatePaymentMethod = useCallback(
     async (paymentMethodId: string) => {

--- a/components/src/components/elements/upcoming-bill/UpcomingBill.tsx
+++ b/components/src/components/elements/upcoming-bill/UpcomingBill.tsx
@@ -6,7 +6,11 @@ import {
   type InvoiceResponseData,
 } from "../../../api/checkoutexternal";
 import { type FontStyle } from "../../../context";
-import { useEmbed, useIsLightBackground } from "../../../hooks";
+import {
+  useEmbed,
+  useIsLightBackground,
+  useLatestRequestGuard,
+} from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
 import {
   ERROR_UNKNOWN,
@@ -86,40 +90,63 @@ export const UpcomingBill = forwardRef<
     }));
   }, [data?.subscription?.discounts]);
 
+  // `getInvoice` refetches whenever `data.subscription` changes identity
+  // (i.e. on every hydrate/preview), so multiple requests can be in flight at
+  // once; guard against an earlier response resolving after a later one.
+  const beginInvoiceRequest = useLatestRequestGuard();
+  const beginBalancesRequest = useLatestRequestGuard();
+
   const getInvoice = useCallback(async () => {
     if (
       data?.component?.id &&
       data?.subscription &&
       !data.subscription.cancelAt
     ) {
+      const isStale = beginInvoiceRequest();
+
       try {
         setError(undefined);
         setIsLoading(true);
 
         const response = await getUpcomingInvoice(data.component.id);
 
+        if (isStale()) {
+          return;
+        }
+
         if (response) {
           setUpcomingInvoice(response.data);
         }
       } catch (err) {
-        setError(isError(err) ? err : ERROR_UNKNOWN);
+        if (!isStale()) {
+          setError(isError(err) ? err : ERROR_UNKNOWN);
+        }
       } finally {
-        setIsLoading(false);
+        if (!isStale()) {
+          setIsLoading(false);
+        }
       }
     }
-  }, [data?.component?.id, data?.subscription, getUpcomingInvoice]);
+  }, [
+    beginInvoiceRequest,
+    data?.component?.id,
+    data?.subscription,
+    getUpcomingInvoice,
+  ]);
 
   const getBalances = useCallback(async () => {
+    const isStale = beginBalancesRequest();
+
     try {
       const response = await getCustomerBalance();
 
-      if (response) {
+      if (response && !isStale()) {
         setBalances(response.data.balances);
       }
     } catch (err) {
       debug("Failed to fetch customer balance.", err);
     }
-  }, [debug, getCustomerBalance]);
+  }, [beginBalancesRequest, debug, getCustomerBalance]);
 
   useEffect(() => {
     getInvoice();

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -30,6 +30,7 @@ import {
   useAvailablePlans,
   useEmbed,
   useIsLightBackground,
+  useLatestRequestGuard,
   useSubscriptionCurrency,
 } from "../../../hooks";
 import type {
@@ -735,12 +736,12 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     return id;
   }, [checkoutStage, checkoutStages, checkoutState, isBypassLoading]);
 
-  // Monotonically increasing id used to discard stale preview responses.
-  // Multiple previews can be in flight at once (e.g. typing "11" into a
-  // quantity input fires a preview for "1" and another for "11"); without
-  // this guard, whichever response resolves last wins and the dialog can
-  // display charges for a quantity the user is no longer requesting.
-  const previewRequestIdRef = useRef(0);
+  // Discards stale preview responses. Multiple previews can be in flight at
+  // once (e.g. typing "11" into a quantity input fires a preview for "1" and
+  // another for "11"); without this guard, whichever response resolves last
+  // wins and the dialog can display charges for a quantity the user is no
+  // longer requesting.
+  const beginPreviewRequest = useLatestRequestGuard();
 
   const handlePreviewCheckout = useCallback(
     async (updates: PreviewCheckoutUpdates) => {
@@ -790,8 +791,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         return;
       }
 
-      const requestId = ++previewRequestIdRef.current;
-      const isStale = () => requestId !== previewRequestIdRef.current;
+      const isStale = beginPreviewRequest();
 
       setError(undefined);
       setCharges(undefined);
@@ -927,6 +927,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     },
     [
       t,
+      beginPreviewRequest,
       data?.company?.plan?.includedCreditGrants,
       data?.company?.billingSubscription,
       previewCheckout,

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -1,3 +1,5 @@
+import type { DebouncedFunc } from "lodash";
+import debounce from "lodash/debounce";
 import {
   useCallback,
   useEffect,
@@ -17,7 +19,12 @@ import {
   type PlanEntitlementResponseData,
   type PreviewSubscriptionFinanceResponseData,
 } from "../../../api/checkoutexternal";
-import { DEFAULT_CURRENCY, TEXT_BASE_SIZE } from "../../../const";
+import {
+  DEFAULT_CURRENCY,
+  FETCH_DEBOUNCE_TIMEOUT,
+  TEXT_BASE_SIZE,
+  TRAILING_DEBOUNCE_SETTINGS,
+} from "../../../const";
 import {
   useAvailableCurrenciesWithInvalid,
   useAvailablePlans,
@@ -108,6 +115,18 @@ export interface CheckoutStage {
   name: string;
   label?: string;
   description?: string;
+}
+
+interface PreviewCheckoutUpdates {
+  period?: string;
+  plan?: SelectedPlan;
+  shouldTrial?: boolean;
+  autoTopupConfigs?: Map<string, AutoTopupConfig>;
+  addOns?: SelectedPlan[];
+  payInAdvanceEntitlements?: UsageBasedEntitlement[];
+  addOnPayInAdvanceEntitlements?: UsageBasedEntitlement[];
+  creditBundles?: CreditBundle[];
+  promoCode?: string | null;
 }
 
 interface CheckoutDialogProps {
@@ -716,18 +735,15 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     return id;
   }, [checkoutStage, checkoutStages, checkoutState, isBypassLoading]);
 
+  // Monotonically increasing id used to discard stale preview responses.
+  // Multiple previews can be in flight at once (e.g. typing "11" into a
+  // quantity input fires a preview for "1" and another for "11"); without
+  // this guard, whichever response resolves last wins and the dialog can
+  // display charges for a quantity the user is no longer requesting.
+  const previewRequestIdRef = useRef(0);
+
   const handlePreviewCheckout = useCallback(
-    async (updates: {
-      period?: string;
-      plan?: SelectedPlan;
-      shouldTrial?: boolean;
-      autoTopupConfigs?: Map<string, AutoTopupConfig>;
-      addOns?: SelectedPlan[];
-      payInAdvanceEntitlements?: UsageBasedEntitlement[];
-      addOnPayInAdvanceEntitlements?: UsageBasedEntitlement[];
-      creditBundles?: CreditBundle[];
-      promoCode?: string | null;
-    }) => {
+    async (updates: PreviewCheckoutUpdates) => {
       const period = updates.period || planPeriod;
       const plan = updates.plan || selectedPlan;
       const resolvedCurrency = hasCurrency ? effectiveCurrency : undefined;
@@ -773,6 +789,9 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         setSelectedPlanId(null);
         return;
       }
+
+      const requestId = ++previewRequestIdRef.current;
+      const isStale = () => requestId !== previewRequestIdRef.current;
 
       setError(undefined);
       setCharges(undefined);
@@ -833,6 +852,12 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           ...(code && { promoCode: code }),
         });
 
+        // A newer preview superseded this one while it was in flight; let the
+        // newer request's response drive the UI.
+        if (isStale()) {
+          return;
+        }
+
         if (response) {
           setCharges(response.data.finance);
           setIsPaymentMethodRequired(response.data.paymentMethodRequired);
@@ -843,6 +868,10 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           setPromoCode(code);
         }
       } catch (err) {
+        if (isStale()) {
+          return;
+        }
+
         if (err instanceof ResponseError) {
           if (err.response.status === 401) {
             setError(t("Session expired. Please refresh and try again."));
@@ -885,10 +914,14 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         const { message: msg } = isError(err) ? err : ERROR_UNKNOWN;
         setError(msg);
       } finally {
-        setIsLoading(false);
-        // Turn off bypass loading after first API call completes
-        if (isBypassLoading) {
-          setIsBypassLoading(false);
+        // Loading state is owned by the latest request; a stale request must
+        // not clear the spinner while a newer one is still in flight.
+        if (!isStale()) {
+          setIsLoading(false);
+          // Turn off bypass loading after first API call completes
+          if (isBypassLoading) {
+            setIsBypassLoading(false);
+          }
         }
       }
     },
@@ -910,6 +943,44 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       promoCode,
       isBypassLoading,
     ],
+  );
+
+  // Debounced preview for rapid-fire inputs (quantity fields, credit bundle
+  // counts, auto top-up amounts). Typing a multi-digit quantity fires
+  // `onChange` per keystroke; previewing each intermediate value both spams
+  // the API and (before the request-id guard above) raced responses. The
+  // debounced instance must survive re-renders — `handlePreviewCheckout` gets
+  // a new identity on every state change, so debouncing it directly would
+  // reset the timer's instance each keystroke — hence the ref indirection,
+  // wired up in an effect to keep refs out of render.
+  const handlePreviewCheckoutRef = useRef(handlePreviewCheckout);
+  useEffect(() => {
+    handlePreviewCheckoutRef.current = handlePreviewCheckout;
+  }, [handlePreviewCheckout]);
+
+  const debouncedPreviewCheckoutRef = useRef<DebouncedFunc<
+    (updates: PreviewCheckoutUpdates) => void
+  > | null>(null);
+  useEffect(() => {
+    const debounced = debounce(
+      (updates: PreviewCheckoutUpdates) =>
+        handlePreviewCheckoutRef.current(updates),
+      FETCH_DEBOUNCE_TIMEOUT,
+      TRAILING_DEBOUNCE_SETTINGS,
+    );
+    debouncedPreviewCheckoutRef.current = debounced;
+
+    return () => {
+      debounced.cancel();
+      debouncedPreviewCheckoutRef.current = null;
+    };
+  }, []);
+
+  const debouncedPreviewCheckout = useCallback(
+    (updates: PreviewCheckoutUpdates) => {
+      debouncedPreviewCheckoutRef.current?.(updates);
+    },
+    [],
   );
 
   const selectPlan = useCallback(
@@ -1147,12 +1218,12 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
         nextMap.set(id, updatedConfig);
 
-        handlePreviewCheckout({ autoTopupConfigs: nextMap });
+        debouncedPreviewCheckout({ autoTopupConfigs: nextMap });
 
         return nextMap;
       });
     },
-    [handlePreviewCheckout, planCreditGrants],
+    [debouncedPreviewCheckout, planCreditGrants],
   );
 
   const updateUsageBasedEntitlementQuantity = useCallback(
@@ -1167,7 +1238,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
             : entitlement,
         );
 
-        handlePreviewCheckout({
+        debouncedPreviewCheckout({
           payInAdvanceEntitlements: updated.filter(
             ({ priceBehavior }) =>
               priceBehavior === EntitlementPriceBehavior.PayInAdvance,
@@ -1177,7 +1248,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         return updated;
       });
     },
-    [handlePreviewCheckout],
+    [debouncedPreviewCheckout],
   );
 
   const updateCreditBundleCount = useCallback(
@@ -1192,12 +1263,12 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
             : bundle,
         );
 
-        handlePreviewCheckout({ creditBundles: updated });
+        debouncedPreviewCheckout({ creditBundles: updated });
 
         return updated;
       });
     },
-    [handlePreviewCheckout],
+    [debouncedPreviewCheckout],
   );
 
   const updateAddOnEntitlementQuantity = useCallback(
@@ -1216,14 +1287,14 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           (entitlement) =>
             entitlement.priceBehavior === EntitlementPriceBehavior.PayInAdvance,
         );
-        handlePreviewCheckout({
+        debouncedPreviewCheckout({
           addOnPayInAdvanceEntitlements: updatedAddOnPayInAdvanceEntitlements,
         });
 
         return updated;
       });
     },
-    [handlePreviewCheckout],
+    [debouncedPreviewCheckout],
   );
 
   const updatePromoCode = useCallback(

--- a/components/src/hooks/index.ts
+++ b/components/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from "./useAvailablePlans";
 export * from "./useCustomPlanBilling";
 export * from "./useEmbed";
 export * from "./useIsLightBackground";
+export * from "./useLatestRequestGuard";
 export * from "./usePaymentConfirmation";
 export * from "./useRequest";
 export * from "./useTrialEnd";

--- a/components/src/hooks/useLatestRequestGuard.test.ts
+++ b/components/src/hooks/useLatestRequestGuard.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+
+import { useLatestRequestGuard } from "./useLatestRequestGuard";
+
+describe("useLatestRequestGuard", () => {
+  test("a request is not stale while it is the latest", () => {
+    const { result } = renderHook(() => useLatestRequestGuard());
+
+    const isStale = result.current();
+
+    expect(isStale()).toBe(false);
+  });
+
+  test("an earlier request becomes stale when a newer one begins", () => {
+    const { result } = renderHook(() => useLatestRequestGuard());
+
+    const firstIsStale = result.current();
+    const secondIsStale = result.current();
+
+    expect(firstIsStale()).toBe(true);
+    expect(secondIsStale()).toBe(false);
+  });
+
+  test("staleness is preserved across re-renders", () => {
+    const { result, rerender } = renderHook(() => useLatestRequestGuard());
+
+    const firstIsStale = result.current();
+    rerender();
+    const secondIsStale = result.current();
+    rerender();
+
+    expect(firstIsStale()).toBe(true);
+    expect(secondIsStale()).toBe(false);
+  });
+
+  test("discards out-of-order async resolutions", async () => {
+    const { result } = renderHook(() => useLatestRequestGuard());
+
+    let resolveSlow: (value: string) => void = () => {};
+    const slow = new Promise<string>((resolve) => {
+      resolveSlow = resolve;
+    });
+    const fast = Promise.resolve("fast");
+
+    let applied: string | undefined;
+    const request = (promise: Promise<string>) => {
+      const isStale = result.current();
+      return promise.then((value) => {
+        if (!isStale()) {
+          applied = value;
+        }
+      });
+    };
+
+    const slowRequest = request(slow); // starts first
+    const fastRequest = request(fast); // supersedes it
+
+    await fastRequest;
+    resolveSlow("slow");
+    await slowRequest;
+
+    expect(applied).toBe("fast");
+  });
+});

--- a/components/src/hooks/useLatestRequestGuard.ts
+++ b/components/src/hooks/useLatestRequestGuard.ts
@@ -1,0 +1,40 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * Guards against out-of-order async responses ("last response wins" races).
+ *
+ * Components that fetch on user input or rapidly changing deps can have
+ * multiple requests in flight at once; without a guard, whichever response
+ * resolves last drives the UI, even if it belongs to a superseded request.
+ *
+ * Call the returned `beginRequest` when starting a request; it returns an
+ * `isStale` function that reports whether a newer request has started since.
+ * Skip all state updates (including loading-state resets in `finally`) when
+ * `isStale()` is true — the newer request's handlers own the state.
+ *
+ * ```ts
+ * const beginRequest = useLatestRequestGuard();
+ *
+ * const fetchThing = useCallback(async () => {
+ *   const isStale = beginRequest();
+ *   setIsLoading(true);
+ *   try {
+ *     const response = await getThing();
+ *     if (isStale()) return;
+ *     setThing(response.data);
+ *   } finally {
+ *     if (!isStale()) {
+ *       setIsLoading(false);
+ *     }
+ *   }
+ * }, [beginRequest, getThing]);
+ * ```
+ */
+export function useLatestRequestGuard() {
+  const requestIdRef = useRef(0);
+
+  return useCallback(() => {
+    const requestId = ++requestIdRef.current;
+    return () => requestId !== requestIdRef.current;
+  }, []);
+}


### PR DESCRIPTION
Stacked on #1313. Applies the same "last request wins" approach to UpcomingBill, Invoices, PaymentMethodDetails