### PR TITLE
Don't lock the currency selector for initial-plan subscriptions

### DIFF
--- a/components/src/hooks/useAvailableCurrencies.ts
+++ b/components/src/hooks/useAvailableCurrencies.ts
@@ -133,14 +133,9 @@ export function useAvailableCurrenciesWithInvalid(): AvailableCurrenciesResult {
 /**
  * Returns the currency of the company's active subscription, if any.
  * Stripe does not allow mixing currencies on a subscription, so when
- * this is set the currency selector should be locked.
- *
- * Exception (SCHY-408): a company auto-provisioned onto the initial (free, $0)
- * plan has a subscription bound to a single currency, but it can still switch
- * currencies at checkout — the backend cancels that throwaway subscription and
- * resubscribes in the chosen currency. So we treat the initial plan as
- * "no locked currency" and let the full currency suite (subject to
- * `currencyFilter`) remain selectable.
+ * this is set the currency selector should be locked. The initial (free,
+ * $0) plan is exempt: its subscription can be switched at checkout, so
+ * we treat it as having no locked currency.
  */
 export function useSubscriptionCurrency(): string | undefined {
   const { data } = useEmbed();

--- a/components/src/hooks/useAvailableCurrencies.ts
+++ b/components/src/hooks/useAvailableCurrencies.ts
@@ -134,8 +134,18 @@ export function useAvailableCurrenciesWithInvalid(): AvailableCurrenciesResult {
  * Returns the currency of the company's active subscription, if any.
  * Stripe does not allow mixing currencies on a subscription, so when
  * this is set the currency selector should be locked.
+ *
+ * Exception (SCHY-408): a company auto-provisioned onto the initial (free, $0)
+ * plan has a subscription bound to a single currency, but it can still switch
+ * currencies at checkout — the backend cancels that throwaway subscription and
+ * resubscribes in the chosen currency. So we treat the initial plan as
+ * "no locked currency" and let the full currency suite (subject to
+ * `currencyFilter`) remain selectable.
  */
 export function useSubscriptionCurrency(): string | undefined {
   const { data } = useEmbed();
+  if (data?.subscription?.isInitial) {
+    return undefined;
+  }
   return data?.subscription?.currency?.toUpperCase();
 }


### PR DESCRIPTION
A company on the initial (free) plan can switch currencies at checkout (the API cancels and resubscribes), so treat its subscription as having no locked currency and keep the full currency suite selectable.

Depends on the API exposing `subscription.is_initial` (SchematicHQ/schematic-api#5955). The generated `CompanySubscriptionResponseData` here was hand-updated to match and will reproduce on the next prod-spec regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)