### PR TITLE
feat(react): roll out composable layer to remaining components

### DIFF
--- a/react/CLAUDE.md
+++ b/react/CLAUDE.md
@@ -158,6 +158,13 @@ live in `src/components/test/`.
   classNames, and `data-testid`s unchanged. The dot-notation namespace
   lives only on the (non-lazy) `/composable` export — never bolt statics
   onto the lazy styled export.
+- Composable coverage: `PricingTable`, `PaymentMethod`, `IncludedFeatures`,
+  `Invoices`, `UpcomingBill`, `UnsubscribeButton`, `MeteredFeatures`,
+  `PlanManager` are fully decomposed. `CheckoutDialog` exposes only a
+  minimal open/close seam (`useCheckoutDialog` → `{ isOpen, close }` +
+  `CheckoutDialog.Close`); its checkout state machine stays in the styled
+  wrapper. `SchematicEmbed` is intentionally NOT decomposed (AST renderer +
+  styled-components `ThemeContext` guard make a headless split low-value).
 - When adding a new adapter slot or prop, update `pickWsProps` /
   `pickEmbedProps` in `provider.tsx` so each adapter only sees what it
   consumes.

--- a/react/src/components/components/elements/included-features/IncludedFeatures.tsx
+++ b/react/src/components/components/elements/included-features/IncludedFeatures.tsx
@@ -1,8 +1,10 @@
-import { Fragment, forwardRef, useMemo, useState } from "react";
+import { Fragment, forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { type FeatureUsageResponseData } from "../../../api/checkoutexternal";
-import { VISIBLE_ENTITLEMENT_COUNT } from "../../../const";
+import {
+  IncludedFeatures as IncludedFeaturesPrimitive,
+  useIncludedFeatures,
+} from "../../../composable/included-features";
 import { type FontStyle } from "../../../embed";
 import { useEmbed, useIsLightBackground } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
@@ -81,74 +83,44 @@ export const IncludedFeatures = forwardRef<
   HTMLDivElement | null,
   ElementProps & DeepPartial<DesignProps> & React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...rest }, ref) => {
-  const props = resolveDesignProps(rest);
+  const design = resolveDesignProps(rest);
 
+  return (
+    <IncludedFeaturesPrimitive.Root visibleFeatures={design.visibleFeatures}>
+      <IncludedFeaturesBody ref={ref} design={design} className={className} />
+    </IncludedFeaturesPrimitive.Root>
+  );
+});
+
+IncludedFeatures.displayName = "IncludedFeatures";
+
+interface IncludedFeaturesBodyProps {
+  design: DesignProps;
+  className?: string;
+}
+
+const IncludedFeaturesBody = forwardRef<
+  HTMLDivElement | null,
+  IncludedFeaturesBodyProps
+>(({ design, className }, ref) => {
   const { t } = useTranslation();
 
-  const { data, settings } = useEmbed();
+  const { settings } = useEmbed();
 
   const isLightBackground = useIsLightBackground();
 
-  const [showCount, setShowCount] = useState(VISIBLE_ENTITLEMENT_COUNT);
+  const { shouldShow, displayedFeatures, hasMore, expanded, toggle } =
+    useIncludedFeatures();
 
-  const { plan, addOns, featureUsage } = useMemo(() => {
-    const orderedFeatureUsage = props.visibleFeatures?.reduce(
-      (acc: FeatureUsageResponseData[], id) => {
-        const mappedFeatureUsage = data?.featureUsage?.features.find(
-          (usage) => usage.feature?.id === id,
-        );
-
-        if (mappedFeatureUsage) {
-          acc.push(mappedFeatureUsage);
-        }
-
-        return acc;
-      },
-      [],
-    );
-
-    return {
-      plan: data?.company?.plan,
-      addOns: data?.company?.addOns || [],
-      featureUsage: orderedFeatureUsage || data?.featureUsage?.features || [],
-    };
-  }, [
-    props.visibleFeatures,
-    data?.company?.plan,
-    data?.company?.addOns,
-    data?.featureUsage?.features,
-  ]);
-
-  const featureListSize = featureUsage.length;
-
-  const handleToggleShowAll = () => {
-    setShowCount((prev) =>
-      prev > VISIBLE_ENTITLEMENT_COUNT
-        ? VISIBLE_ENTITLEMENT_COUNT
-        : featureListSize,
-    );
-  };
-
-  // Check if we should render this component at all:
-  // * If there are any plans or addons, render it, even if the list is empty.
-  // * If there are any features, show it (e.g., there could be features available via company overrides
-  //  even if the company has no plan or add-ons).
-  // * If none of the above, don't render the component.
-  const shouldShowFeatures =
-    featureUsage.length > 0 || plan || addOns.length > 0 || false;
-
-  if (!shouldShowFeatures) {
+  if (!shouldShow) {
     return null;
   }
 
-  const shouldShowExpand = featureListSize > VISIBLE_ENTITLEMENT_COUNT;
-  const isExpanded = showCount > VISIBLE_ENTITLEMENT_COUNT;
-
   return (
     <Element ref={ref} className={className} $containerType="inline-size">
-      {props.header.isVisible && (
+      {design.header.isVisible && (
         <Box $marginBottom="1.5rem">
-          <Text display={props.header.fontStyle}>{props.header.text}</Text>
+          <Text display={design.header.fontStyle}>{design.header.text}</Text>
         </Box>
       )}
 
@@ -163,10 +135,10 @@ export const IncludedFeatures = forwardRef<
           },
         }}
       >
-        {featureUsage.slice(0, showCount).map((entitlement, index) => {
+        {displayedFeatures.map((entitlement, index) => {
           return (
             <Fragment key={index}>
-              {props.icons.isVisible && entitlement.feature?.icon && (
+              {design.icons.isVisible && entitlement.feature?.icon && (
                 <Icon
                   name={entitlement.feature.icon}
                   color={settings.theme.primary}
@@ -186,23 +158,23 @@ export const IncludedFeatures = forwardRef<
                 $gap="0.25rem"
               >
                 {entitlement.feature?.name && (
-                  <Text display={props.icons.fontStyle}>
+                  <Text display={design.icons.fontStyle}>
                     {entitlement.feature.name}
                   </Text>
                 )}
 
-                {props.description.isVisible &&
+                {design.description.isVisible &&
                   entitlement.feature?.description && (
-                    <Text display={props.description.fontStyle}>
+                    <Text display={design.description.fontStyle}>
                       {entitlement.feature.description}
                     </Text>
                   )}
 
-                {props.entitlementExpiration.isVisible &&
+                {design.entitlementExpiration.isVisible &&
                   entitlement.entitlementExpirationDate && (
                     <Text
                       as="em"
-                      display={props.entitlementExpiration.fontStyle}
+                      display={design.entitlementExpiration.fontStyle}
                     >
                       {t("Expires", {
                         date: toPrettyDate(
@@ -232,26 +204,26 @@ export const IncludedFeatures = forwardRef<
                   },
                 }}
               >
-                <UsageDetails entitlement={entitlement} layout={props} />
+                <UsageDetails entitlement={entitlement} layout={design} />
               </Flex>
             </Fragment>
           );
         })}
       </Box>
 
-      {shouldShowExpand && (
+      {hasMore && (
         <Flex $alignItems="center" $marginTop="1rem">
           <Icon
-            name={isExpanded ? "chevron-up" : "chevron-down"}
+            name={expanded ? "chevron-up" : "chevron-down"}
             color="#D0D0D0"
           />
 
           <Text
-            onClick={handleToggleShowAll}
-            onKeyDown={createKeyboardExecutionHandler(handleToggleShowAll)}
+            onClick={toggle}
+            onKeyDown={createKeyboardExecutionHandler(toggle)}
             display="link"
           >
-            {isExpanded ? t("Hide all") : t("See all")}
+            {expanded ? t("Hide all") : t("See all")}
           </Text>
         </Flex>
       )}
@@ -259,4 +231,4 @@ export const IncludedFeatures = forwardRef<
   );
 });
 
-IncludedFeatures.displayName = "IncludedFeatures";
+IncludedFeaturesBody.displayName = "IncludedFeaturesBody";

--- a/react/src/components/components/elements/invoices/Invoices.tsx
+++ b/react/src/components/components/elements/invoices/Invoices.tsx
@@ -1,21 +1,15 @@
-import { forwardRef, useCallback, useEffect, useState } from "react";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 
+import { type InvoiceResponseData } from "../../../api/checkoutexternal";
 import {
-  InvoiceStatus,
-  type InvoiceResponseData,
-} from "../../../api/checkoutexternal";
-import { MAX_VISIBLE_INVOICE_COUNT } from "../../../const";
+  Invoices as InvoicesPrimitive,
+  useInvoices,
+} from "../../../composable/invoices";
 import { type FontStyle } from "../../../embed";
 import { useEmbed } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
-import {
-  ERROR_UNKNOWN,
-  createKeyboardExecutionHandler,
-  formatCurrency,
-  isError,
-  toPrettyDate,
-} from "../../../utils";
+import { createKeyboardExecutionHandler } from "../../../utils";
 import { Element } from "../../layout";
 import {
   Button,
@@ -26,6 +20,10 @@ import {
   Tooltip,
   TransitionBox,
 } from "../../ui";
+
+// Re-exported for backward compatibility; the implementation now lives in the
+// headless layer (`composable/invoices`).
+export { formatInvoices } from "../../../composable/invoices";
 
 export interface DesignProps {
   header: {
@@ -75,53 +73,6 @@ function resolveDesignProps(props: DeepPartial<DesignProps>): DesignProps {
   };
 }
 
-interface FormatInvoiceOptions {
-  hideUpcoming?: boolean;
-}
-
-export function formatInvoices(
-  invoices?: InvoiceResponseData[],
-  options?: FormatInvoiceOptions,
-) {
-  const { hideUpcoming = true } = options || {};
-  const now = new Date();
-
-  const excludedStatuses: InvoiceStatus[] = [
-    InvoiceStatus.Void,
-    InvoiceStatus.Draft,
-    InvoiceStatus.Uncollectible,
-  ];
-
-  return (invoices || [])
-    .filter(({ amountDue, dueDate, externalId, status }) => {
-      if (amountDue === 0) return false;
-      if (externalId?.startsWith("upcoming_")) return false;
-      if (status && excludedStatuses.includes(status as InvoiceStatus))
-        return false;
-      if (
-        hideUpcoming &&
-        status !== InvoiceStatus.Paid &&
-        !(dueDate && +dueDate <= +now)
-      )
-        return false;
-      return true;
-    })
-    .sort((a, b) => {
-      const dateA = a.dueDate ?? a.createdAt;
-      const dateB = b.dueDate ?? b.createdAt;
-      return +dateB - +dateA;
-    })
-    .map(({ amountDue, dueDate, createdAt, url, currency }) => {
-      const formatted = formatCurrency(Math.abs(amountDue), currency);
-      return {
-        amount: amountDue < 0 ? `(${formatted})` : formatted,
-        amountDue,
-        date: toPrettyDate(dueDate ?? createdAt),
-        url: url || undefined,
-      };
-    });
-}
-
 export type InvoicesProps = DesignProps & {
   data?: InvoiceResponseData[];
 };
@@ -132,193 +83,155 @@ export const Invoices = forwardRef<
     DeepPartial<DesignProps> & {
       data?: InvoiceResponseData[];
     } & React.HTMLAttributes<HTMLDivElement>
->(({ className, ...rest }, ref) => {
-  const props = resolveDesignProps(rest);
-
-  const { t } = useTranslation();
-
-  const { data, listInvoices, settings } = useEmbed();
-
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error>();
-  const [invoices, setInvoices] = useState(() =>
-    formatInvoices(
-      data && "invoices" in data
-        ? (data.invoices as InvoiceResponseData[])
-        : rest.data,
-    ),
-  );
-  const [listSize, setListSize] = useState(props.limit.number);
-
-  const getInvoices = useCallback(async () => {
-    try {
-      setError(undefined);
-      setIsLoading(true);
-
-      const response = await listInvoices();
-
-      if (response) {
-        setInvoices(formatInvoices(response.data));
-      }
-    } catch (err) {
-      setError(isError(err) ? err : ERROR_UNKNOWN);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [listInvoices]);
-
-  const toggleListSize = () => {
-    setListSize((prev) =>
-      prev !== props.limit.number
-        ? props.limit.number
-        : MAX_VISIBLE_INVOICE_COUNT,
-    );
-  };
-
-  useEffect(() => {
-    getInvoices();
-  }, [getInvoices]);
-
-  // this should be how the below TODO will set invoices
-  useEffect(() => {
-    if (rest.data) {
-      setInvoices(formatInvoices(rest.data));
-    }
-  }, [rest.data]);
-
-  // ensure shared data updates are tracked
-  // used to keep in sync with preview data
-  // TODO: move this logic outside of components
-  useEffect(() => {
-    if (data && "invoices" in data) {
-      const invoicesPreviewData = data.invoices as InvoiceResponseData[];
-      setInvoices(formatInvoices(invoicesPreviewData));
-    }
-  }, [data]);
-
-  if (invoices.length === 0) {
-    return null;
-  }
+>(({ className, data, ...rest }, ref) => {
+  const design = resolveDesignProps(rest);
 
   return (
-    <Element ref={ref} className={className}>
-      <Flex as={TransitionBox} $justifyContent="center" $alignItems="center">
-        <Loader $color={settings.theme.primary} $isLoading={isLoading} />
-      </Flex>
-
-      {error ? (
-        <Flex
-          as={TransitionBox}
-          $flexDirection="column"
-          $justifyContent="center"
-          $alignItems="center"
-          $gap="1rem"
-        >
-          <Text $weight={500} $color="#DB6669">
-            {t("There was a problem retrieving your invoices.")}
-          </Text>
-
-          <Button
-            type="button"
-            onClick={() => getInvoices()}
-            $size="sm"
-            $variant="ghost"
-            $fullWidth={false}
-          >
-            {t("Try again")}
-          </Button>
-        </Flex>
-      ) : (
-        !isLoading && (
-          <TransitionBox>
-            <Flex $flexDirection="column" $gap="1rem">
-              {props.header.isVisible && (
-                <Flex $justifyContent="space-between" $alignItems="center">
-                  <Text display={props.header.fontStyle}>{t("Invoices")}</Text>
-                </Flex>
-              )}
-
-              {invoices.length > 0 ? (
-                <>
-                  <Flex $flexDirection="column" $gap="0.5rem">
-                    {invoices
-                      .slice(0, listSize)
-                      .map(({ date, amount, amountDue, url }, index) => {
-                        return (
-                          <Flex
-                            key={index}
-                            $justifyContent="space-between"
-                            $alignItems="center"
-                          >
-                            {props.date.isVisible && (
-                              <Text
-                                display={props.date.fontStyle}
-                                {...(url && {
-                                  as: "a",
-                                  href: url,
-                                  target: "_blank",
-                                  rel: "noreferrer",
-                                })}
-                                $color={
-                                  url
-                                    ? settings.theme.typography.link.color
-                                    : settings.theme.typography.text.color
-                                }
-                              >
-                                {date}
-                              </Text>
-                            )}
-
-                            {props.amount.isVisible && (
-                              <Tooltip
-                                trigger={
-                                  <Text display={props.amount.fontStyle}>
-                                    {amount}
-                                  </Text>
-                                }
-                                content={
-                                  amountDue < 0
-                                    ? t("Invoice credit tooltip")
-                                    : t("Invoice charge tooltip")
-                                }
-                              />
-                            )}
-                          </Flex>
-                        );
-                      })}
-                  </Flex>
-
-                  {props.collapse.isVisible &&
-                    invoices.length > props.limit.number && (
-                      <Flex $alignItems="center" $gap="0.5rem">
-                        <Icon
-                          name={`chevron-${listSize === props.limit.number ? "down" : "up"}`}
-                          color="#D0D0D0"
-                        />
-
-                        <Text
-                          onClick={toggleListSize}
-                          onKeyDown={createKeyboardExecutionHandler(
-                            toggleListSize,
-                          )}
-                          display={props.collapse.fontStyle}
-                        >
-                          {listSize === props.limit.number
-                            ? t("See more")
-                            : t("See less")}
-                        </Text>
-                      </Flex>
-                    )}
-                </>
-              ) : (
-                <Text display="heading2">{t("No invoices created yet")}</Text>
-              )}
-            </Flex>
-          </TransitionBox>
-        )
-      )}
-    </Element>
+    <InvoicesPrimitive.Root limit={design.limit.number} data={data}>
+      <InvoicesBody ref={ref} design={design} className={className} />
+    </InvoicesPrimitive.Root>
   );
 });
 
 Invoices.displayName = "Invoices";
+
+interface InvoicesBodyProps {
+  design: DesignProps;
+  className?: string;
+}
+
+const InvoicesBody = forwardRef<HTMLDivElement | null, InvoicesBodyProps>(
+  ({ design, className }, ref) => {
+    const { t } = useTranslation();
+
+    const { settings } = useEmbed();
+
+    const {
+      visibleInvoices,
+      isLoading,
+      error,
+      retry: getInvoices,
+      hasMore,
+      expanded,
+      toggle,
+      isEmpty,
+    } = useInvoices();
+
+    if (isEmpty) {
+      return null;
+    }
+
+    return (
+      <Element ref={ref} className={className}>
+        <Flex as={TransitionBox} $justifyContent="center" $alignItems="center">
+          <Loader $color={settings.theme.primary} $isLoading={isLoading} />
+        </Flex>
+
+        {error ? (
+          <Flex
+            as={TransitionBox}
+            $flexDirection="column"
+            $justifyContent="center"
+            $alignItems="center"
+            $gap="1rem"
+          >
+            <Text $weight={500} $color="#DB6669">
+              {t("There was a problem retrieving your invoices.")}
+            </Text>
+
+            <Button
+              type="button"
+              onClick={() => getInvoices()}
+              $size="sm"
+              $variant="ghost"
+              $fullWidth={false}
+            >
+              {t("Try again")}
+            </Button>
+          </Flex>
+        ) : (
+          !isLoading && (
+            <TransitionBox>
+              <Flex $flexDirection="column" $gap="1rem">
+                {design.header.isVisible && (
+                  <Flex $justifyContent="space-between" $alignItems="center">
+                    <Text display={design.header.fontStyle}>
+                      {t("Invoices")}
+                    </Text>
+                  </Flex>
+                )}
+
+                <Flex $flexDirection="column" $gap="0.5rem">
+                  {visibleInvoices.map(
+                    ({ date, amount, amountDue, url }, index) => {
+                      return (
+                        <Flex
+                          key={index}
+                          $justifyContent="space-between"
+                          $alignItems="center"
+                        >
+                          {design.date.isVisible && (
+                            <Text
+                              display={design.date.fontStyle}
+                              {...(url && {
+                                as: "a",
+                                href: url,
+                                target: "_blank",
+                                rel: "noreferrer",
+                              })}
+                              $color={
+                                url
+                                  ? settings.theme.typography.link.color
+                                  : settings.theme.typography.text.color
+                              }
+                            >
+                              {date}
+                            </Text>
+                          )}
+
+                          {design.amount.isVisible && (
+                            <Tooltip
+                              trigger={
+                                <Text display={design.amount.fontStyle}>
+                                  {amount}
+                                </Text>
+                              }
+                              content={
+                                amountDue < 0
+                                  ? t("Invoice credit tooltip")
+                                  : t("Invoice charge tooltip")
+                              }
+                            />
+                          )}
+                        </Flex>
+                      );
+                    },
+                  )}
+                </Flex>
+
+                {design.collapse.isVisible && hasMore && (
+                  <Flex $alignItems="center" $gap="0.5rem">
+                    <Icon
+                      name={`chevron-${expanded ? "up" : "down"}`}
+                      color="#D0D0D0"
+                    />
+
+                    <Text
+                      onClick={toggle}
+                      onKeyDown={createKeyboardExecutionHandler(toggle)}
+                      display={design.collapse.fontStyle}
+                    >
+                      {expanded ? t("See less") : t("See more")}
+                    </Text>
+                  </Flex>
+                )}
+              </Flex>
+            </TransitionBox>
+          )
+        )}
+      </Element>
+    );
+  },
+);
+
+InvoicesBody.displayName = "InvoicesBody";

--- a/react/src/components/components/elements/metered-features/MeteredFeatures.tsx
+++ b/react/src/components/components/elements/metered-features/MeteredFeatures.tsx
@@ -1,13 +1,16 @@
-import { forwardRef, useCallback, useMemo, useRef, useState } from "react";
+import { forwardRef, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
   BillingCreditGrantReason,
   EntitlementPriceBehavior,
   EntitlementValueType,
-  FeatureType,
   type FeatureUsageResponseData,
 } from "../../../api/checkoutexternal";
+import {
+  MeteredFeatures as MeteredFeaturesPrimitive,
+  useMeteredFeatures,
+} from "../../../composable/metered-features";
 import { TEXT_BASE_SIZE } from "../../../const";
 import { type FontStyle } from "../../../embed";
 import {
@@ -21,9 +24,7 @@ import {
   formatCurrency,
   formatNumber,
   getFeatureName,
-  getSubscriptionPeriod,
   getUsageDetails,
-  groupCreditGrants,
   modifyDate,
   toPrettyDate,
   type UsageDetails,
@@ -197,69 +198,51 @@ export const MeteredFeatures = forwardRef<
   HTMLDivElement | null,
   ElementProps & DeepPartial<DesignProps> & React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...rest }, ref) => {
-  const props = resolveDesignProps(rest);
+  const design = resolveDesignProps(rest);
 
+  return (
+    <MeteredFeaturesPrimitive.Root visibleFeatures={design.visibleFeatures}>
+      <MeteredFeaturesBody ref={ref} design={design} className={className} />
+    </MeteredFeaturesPrimitive.Root>
+  );
+});
+
+MeteredFeatures.displayName = "MeteredFeatures";
+
+interface MeteredFeaturesBodyProps {
+  design: DesignProps;
+  className?: string;
+}
+
+const MeteredFeaturesBody = forwardRef<
+  HTMLDivElement | null,
+  MeteredFeaturesBodyProps
+>(({ design, className }, ref) => {
   const elementsRef = useRef<HTMLElement[]>([]);
   const shouldWrapChildren = useWrapChildren(elementsRef);
 
   const { t } = useTranslation();
 
-  const { data, settings, setCheckoutState } = useEmbed();
+  const { settings } = useEmbed();
 
   const isLightBackground = useIsLightBackground();
 
-  const meteredFeatures = useMemo(() => {
-    const orderedFeatureUsage = props.visibleFeatures?.reduce(
-      (acc: FeatureUsageResponseData[], id) => {
-        const mappedFeatureUsage = data?.featureUsage?.features.find(
-          (usage) => usage.feature?.id === id,
-        );
+  const {
+    meteredFeatures,
+    creditGroups,
+    shouldShow,
+    period,
+    canCheckout,
+    showCredits,
+    isCreditExpanded,
+    toggleBalanceDetails,
+    addUsage,
+    buyCredits,
+  } = useMeteredFeatures();
 
-        if (mappedFeatureUsage) {
-          acc.push(mappedFeatureUsage);
-        }
-
-        return acc;
-      },
-      [],
-    );
-
-    return (orderedFeatureUsage || data?.featureUsage?.features || []).filter(
-      ({ feature }) =>
-        feature?.featureType === FeatureType.Event ||
-        feature?.featureType === FeatureType.Trait,
-    );
-  }, [props.visibleFeatures, data?.featureUsage?.features]);
-
-  const creditGroups = groupCreditGrants(data?.creditGrants || [], {
-    groupBy: "credit",
-  });
-  const [creditVisibility, setCreditVisibility] = useState(
-    creditGroups.map(({ id }) => ({ id, isExpanded: false })),
-  );
-
-  const toggleBalanceDetails = useCallback((id: string) => {
-    setCreditVisibility((prev) =>
-      prev.map((item) =>
-        item.id === id ? { ...item, isExpanded: !item.isExpanded } : item,
-      ),
-    );
-  }, []);
-
-  const shouldShowFeatures =
-    meteredFeatures.length > 0 || creditGroups.length > 0;
-  if (!shouldShowFeatures) {
+  if (!shouldShow) {
     return null;
   }
-
-  const period =
-    getSubscriptionPeriod(data?.company?.billingSubscription) ??
-    (typeof data?.company?.plan?.planPeriod === "string"
-      ? data.company?.plan?.planPeriod
-      : undefined);
-
-  const canCheckout = data?.capabilities?.checkout ?? false;
-  const showCredits = data?.displaySettings?.showCredits ?? true;
 
   return (
     <styles.Container ref={ref} className={className}>
@@ -275,7 +258,7 @@ export const MeteredFeatures = forwardRef<
         acc.push(
           <Element key={index} as={Flex} $flexDirection="column" $gap="1.5rem">
             <Flex $gap="1.5rem">
-              {props.icon.isVisible && (
+              {design.icon.isVisible && (
                 <Icon
                   name={feature.icon}
                   color={settings.theme.primary}
@@ -300,14 +283,14 @@ export const MeteredFeatures = forwardRef<
                 >
                   <Flex $flexDirection="column" $gap="0.5rem" $flexGrow={1}>
                     <Box>
-                      <Text display={props.header.fontStyle}>
+                      <Text display={design.header.fontStyle}>
                         {feature.name}
                       </Text>
                     </Box>
 
-                    {props.description.isVisible && feature.description && (
+                    {design.description.isVisible && feature.description && (
                       <Box>
-                        <Text display={props.description.fontStyle}>
+                        <Text display={design.description.fontStyle}>
                           {feature.description}
                         </Text>
                       </Box>
@@ -319,9 +302,9 @@ export const MeteredFeatures = forwardRef<
                     $flexGrow={1}
                     $textAlign={shouldWrapChildren ? "left" : "right"}
                   >
-                    {props.usage.isVisible && (
+                    {design.usage.isVisible && (
                       <Box $whiteSpace="nowrap">
-                        <Text display={props.usage.fontStyle}>
+                        <Text display={design.usage.fontStyle}>
                           {priceBehavior ===
                           EntitlementPriceBehavior.PayInAdvance ? (
                             <>
@@ -342,17 +325,17 @@ export const MeteredFeatures = forwardRef<
                       </Box>
                     )}
 
-                    {props.allocation.isVisible && (
+                    {design.allocation.isVisible && (
                       <Limit
                         entitlement={entitlement}
                         usageDetails={usageDetails}
-                        fontStyle={props.allocation.fontStyle}
+                        fontStyle={design.allocation.fontStyle}
                       />
                     )}
                   </Box>
                 </Flex>
 
-                {props.isVisible &&
+                {design.isVisible &&
                   priceBehavior !== EntitlementPriceBehavior.PayAsYouGo &&
                   priceBehavior !== EntitlementPriceBehavior.CreditBurndown && (
                     <Meter entitlement={entitlement} />
@@ -362,9 +345,7 @@ export const MeteredFeatures = forwardRef<
                   priceBehavior === EntitlementPriceBehavior.PayInAdvance && (
                     <Button
                       type="button"
-                      onClick={() => {
-                        setCheckoutState({ usage: true });
-                      }}
+                      onClick={addUsage}
                       style={{ whiteSpace: "nowrap" }}
                     >
                       {t("Add More")}
@@ -389,14 +370,12 @@ export const MeteredFeatures = forwardRef<
 
       {showCredits &&
         creditGroups.map((credit, index) => {
-          const isExpanded =
-            creditVisibility.find(({ id }) => credit.id === id)?.isExpanded ??
-            false;
+          const isExpanded = isCreditExpanded(credit.id);
 
           return (
             <Element key={index} as={Flex} $flexDirection="column" $gap="1rem">
               <Flex $gap="1.5rem">
-                {props.icon.isVisible && (
+                {design.icon.isVisible && (
                   <Icon
                     // if `icon` is `undefined` this will render as a blank circle
                     name={credit.icon as string}
@@ -414,14 +393,14 @@ export const MeteredFeatures = forwardRef<
                   <Flex $flexWrap="wrap" $gap="1rem">
                     <Flex $flexDirection="column" $gap="0.5rem" $flexGrow={1}>
                       <Box>
-                        <Text display={props.header.fontStyle}>
+                        <Text display={design.header.fontStyle}>
                           {credit.name}
                         </Text>
                       </Box>
 
-                      {props.description.isVisible && credit.description && (
+                      {design.description.isVisible && credit.description && (
                         <Box>
-                          <Text display={props.description.fontStyle}>
+                          <Text display={design.description.fontStyle}>
                             {credit.description}
                           </Text>
                         </Box>
@@ -447,9 +426,7 @@ export const MeteredFeatures = forwardRef<
                     {canCheckout && (
                       <Button
                         type="button"
-                        onClick={() => {
-                          setCheckoutState({ credits: true });
-                        }}
+                        onClick={buyCredits}
                         style={{ whiteSpace: "nowrap" }}
                         $size="sm"
                       >
@@ -625,4 +602,4 @@ export const MeteredFeatures = forwardRef<
   );
 });
 
-MeteredFeatures.displayName = "MeteredFeatures";
+MeteredFeaturesBody.displayName = "MeteredFeaturesBody";

--- a/react/src/components/components/elements/plan-manager/PlanManager.tsx
+++ b/react/src/components/components/elements/plan-manager/PlanManager.tsx
@@ -1,27 +1,19 @@
-import { forwardRef, useMemo } from "react";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { BillingCreditGrantReason } from "../../../api/checkoutexternal";
-import { type FontStyle } from "../../../embed";
 import {
-  useCustomPlanBilling,
-  useEmbed,
-  useIsLightBackground,
-  useTrialEnd,
-} from "../../../hooks";
-import type {
-  CreditWithCompanyContext,
-  DeepPartial,
-  ElementProps,
-} from "../../../types";
+  PlanManager as PlanManagerPrimitive,
+  usePlanManager,
+} from "../../../composable/plan-manager";
+import { type FontStyle } from "../../../embed";
+import { useEmbed, useIsLightBackground } from "../../../hooks";
+import type { DeepPartial, ElementProps } from "../../../types";
 import {
   darken,
   formatCurrency,
   getAutoTopupAmount,
   getAutoTopupThresholdCredits,
   getFeatureName,
-  getSubscriptionPeriod,
-  groupCreditGrants,
   isAutoTopupEnabled,
   lighten,
   shortenPeriod,
@@ -99,137 +91,60 @@ export const PlanManager = forwardRef<
     React.HTMLAttributes<HTMLDivElement> & {
       portal?: HTMLElement | null;
     }
->(({ children, className, portal, ...rest }, ref) => {
-  const props = resolveDesignProps(rest);
-
-  const { t } = useTranslation();
-
-  const { data, settings, setCheckoutState, setLayout } = useEmbed();
-
-  const isLightBackground = useIsLightBackground();
-
-  const trialEnd = useTrialEnd();
-
-  const customPlanBilling = useCustomPlanBilling();
-
-  /**
-   * Can change plan if there is:
-   * - a publishable key
-   * - a current plan with a billing association
-   * - any active plans
-   */
-  const {
-    currentPlan,
-    currentAddOns,
-    creditBundles,
-    creditGroups,
-    billingSubscription,
-    canCheckout,
-    postTrialPlan,
-    featureUsage,
-    showCredits,
-    showZeroPriceAsFree,
-    trialPaymentMethodRequired,
-  } = useMemo(() => {
-    return {
-      currentPlan: data?.company?.plan,
-      currentAddOns: data?.company?.addOns || [],
-      creditBundles: data?.creditBundles || [],
-      creditGroups: groupCreditGrants(data?.creditGrants || [], {
-        groupBy: "bundle",
-      }).reduce(
-        (
-          acc: {
-            plan: CreditWithCompanyContext[];
-            bundles: CreditWithCompanyContext[];
-            promotional: CreditWithCompanyContext[];
-          },
-          grant,
-        ) => {
-          switch (grant.grantReason) {
-            case BillingCreditGrantReason.Plan:
-              acc.plan.push(grant);
-              break;
-            case BillingCreditGrantReason.Purchased:
-              acc.bundles.push(grant);
-              break;
-            case BillingCreditGrantReason.Free:
-              acc.promotional.push(grant);
-          }
-
-          return acc;
-        },
-        { plan: [], bundles: [], promotional: [] },
-      ),
-      billingSubscription: data?.company?.billingSubscription,
-      canCheckout: data?.capabilities?.checkout ?? false,
-      postTrialPlan: data?.postTrialPlan,
-      featureUsage: data?.featureUsage?.features || [],
-      trialPaymentMethodRequired: data?.trialPaymentMethodRequired ?? false,
-      showCredits: data?.displaySettings?.showCredits ?? true,
-      showZeroPriceAsFree: data?.displaySettings?.showZeroPriceAsFree ?? false,
-    };
-  }, [
-    data?.capabilities?.checkout,
-    data?.company?.addOns,
-    data?.company?.billingSubscription,
-    data?.company?.plan,
-    data?.creditBundles,
-    data?.creditGrants,
-    data?.featureUsage?.features,
-    data?.postTrialPlan,
-    data?.displaySettings?.showCredits,
-    data?.displaySettings?.showZeroPriceAsFree,
-    data?.trialPaymentMethodRequired,
-  ]);
-
-  const usageBasedEntitlements = useMemo(
-    () =>
-      featureUsage.filter((usage) => typeof usage.priceBehavior === "string"),
-    [featureUsage],
-  );
-
-  const {
-    subscriptionInterval,
-    subscriptionCurrency,
-    willSubscriptionCancel,
-    isTrialSubscription,
-  } = useMemo(() => {
-    const subscriptionInterval =
-      getSubscriptionPeriod(billingSubscription) ??
-      billingSubscription?.interval;
-    const subscriptionCurrency = billingSubscription?.currency;
-    const isTrialSubscription = billingSubscription?.status === "trialing";
-    const willSubscriptionCancel =
-      typeof billingSubscription?.cancelAt === "number" &&
-      billingSubscription?.cancelAtPeriodEnd === true;
-
-    return {
-      subscriptionInterval,
-      subscriptionCurrency,
-      isTrialSubscription,
-      willSubscriptionCancel,
-    };
-  }, [billingSubscription]);
-
-  const currentPlanPeriod =
-    getSubscriptionPeriod(billingSubscription) ??
-    currentPlan?.planPeriod ??
-    undefined;
-
-  const { isFreePlan, isUsageBasedPlan } = useMemo(() => {
-    const isFreePlan = currentPlan?.planPrice === 0;
-    const isUsageBasedPlan = isFreePlan && usageBasedEntitlements.length > 0;
-    return { isFreePlan, isUsageBasedPlan };
-  }, [currentPlan, usageBasedEntitlements]);
-
-  const hasAutoTopupSelfService =
-    currentPlan?.includedCreditGrants.some((grant) => {
-      return grant.billingCreditAutoTopupSelfService;
-    }) ?? false;
+>(({ className, ...rest }, ref) => {
+  const design = resolveDesignProps(rest);
 
   return (
-    <>
+    <PlanManagerPrimitive.Root>
+      <PlanManagerBody ref={ref} design={design} className={className} />
+    </PlanManagerPrimitive.Root>
+  );
+});
+
+PlanManager.displayName = "PlanManager";
+
+interface PlanManagerBodyProps {
+  design: DesignProps;
+  className?: string;
+}
+
+const PlanManagerBody = forwardRef<HTMLDivElement | null, PlanManagerBodyProps>(
+  ({ design, className }, ref) => {
+    const { t } = useTranslation();
+
+    const { settings } = useEmbed();
+
+    const isLightBackground = useIsLightBackground();
+
+    const {
+      currentPlan,
+      currentAddOns,
+      creditBundles,
+      creditGroups,
+      billingSubscription,
+      canCheckout,
+      postTrialPlan,
+      usageBasedEntitlements,
+      showCredits,
+      showZeroPriceAsFree,
+      trialPaymentMethodRequired,
+      scheduledDowngrade,
+      subscriptionInterval,
+      subscriptionCurrency,
+      willSubscriptionCancel,
+      isTrialSubscription,
+      currentPlanPeriod,
+      isFreePlan,
+      isUsageBasedPlan,
+      hasAutoTopupSelfService,
+      customPlanBilling,
+      trialEnd,
+      changePlan,
+      editAutoTopup,
+    } = usePlanManager();
+
+    return (
+      <>
       {isTrialSubscription && !willSubscriptionCancel ? (
         <Notice
           as={Flex}
@@ -356,7 +271,7 @@ export const PlanManager = forwardRef<
           )}
         </Notice>
       ) : (
-        data?.company?.scheduledDowngrade?.toPlanName && (
+        scheduledDowngrade?.toPlanName && (
           <Notice
             as={Flex}
             $flexDirection="column"
@@ -371,7 +286,7 @@ export const PlanManager = forwardRef<
           >
             <Text as="h3" display="heading3">
               {t("Downgrade to plan scheduled", {
-                plan: data.company.scheduledDowngrade.toPlanName,
+                plan: scheduledDowngrade.toPlanName,
               })}
             </Text>
 
@@ -381,7 +296,7 @@ export const PlanManager = forwardRef<
                 $size={0.8125 * settings.theme.typography.text.fontSize}
               >
                 {t("Access to plan will end.", {
-                  plan: data.company.scheduledDowngrade.fromPlanName,
+                  plan: scheduledDowngrade.fromPlanName,
                   date: toPrettyDate(
                     new Date(billingSubscription.periodEnd * 1000),
                     {
@@ -402,33 +317,33 @@ export const PlanManager = forwardRef<
         $flexDirection="column"
         $gap="2rem"
       >
-        {props.header.isVisible && currentPlan && (
+        {design.header.isVisible && currentPlan && (
           <Flex
             $justifyContent="space-between"
             $alignItems="center"
             $gap="1rem"
           >
             <Flex $flexDirection="column" $gap="1rem">
-              <Text display={props.header.title.fontStyle} $leading="none">
+              <Text display={design.header.title.fontStyle} $leading="none">
                 {currentPlan.name}
               </Text>
 
-              {props.header.description.isVisible &&
+              {design.header.description.isVisible &&
                 currentPlan.description && (
-                  <Text display={props.header.description.fontStyle}>
+                  <Text display={design.header.description.fontStyle}>
                     {currentPlan.description}
                   </Text>
                 )}
             </Flex>
 
-            {props.header.price.isVisible &&
+            {design.header.price.isVisible &&
               typeof currentPlan.planPrice === "number" && (
                 <Box>
                   <Text
                     display={
                       isUsageBasedPlan
                         ? "heading3"
-                        : props.header.price.fontStyle
+                        : design.header.price.fontStyle
                     }
                   >
                     {isUsageBasedPlan
@@ -442,7 +357,7 @@ export const PlanManager = forwardRef<
                   </Text>
 
                   {!isFreePlan && currentPlanPeriod && (
-                    <Text display={props.header.price.fontStyle}>
+                    <Text display={design.header.price.fontStyle}>
                       <sub>/{shortenPeriod(currentPlanPeriod)}</sub>
                     </Text>
                   )}
@@ -451,9 +366,9 @@ export const PlanManager = forwardRef<
           </Flex>
         )}
 
-        {props.addOns.isVisible && currentAddOns.length > 0 && (
+        {design.addOns.isVisible && currentAddOns.length > 0 && (
           <Flex $flexDirection="column" $gap="0.5rem">
-            {props.addOns.showLabel && (
+            {design.addOns.showLabel && (
               <Text
                 $color={
                   isLightBackground
@@ -473,16 +388,16 @@ export const PlanManager = forwardRef<
                   addOn={addOn}
                   currency={subscriptionCurrency}
                   period={currentPlanPeriod}
-                  layout={props}
+                  layout={design}
                 />
               ))}
             </Flex>
           </Flex>
         )}
 
-        {props.addOns.isVisible && usageBasedEntitlements.length > 0 && (
+        {design.addOns.isVisible && usageBasedEntitlements.length > 0 && (
           <Flex $flexDirection="column" $gap="0.5rem">
-            {props.addOns.showLabel && (
+            {design.addOns.showLabel && (
               <Text
                 $color={
                   isLightBackground
@@ -504,7 +419,7 @@ export const PlanManager = forwardRef<
                     period={currentPlanPeriod || "month"}
                     currency={subscriptionCurrency}
                     showCredits={showCredits}
-                    layout={props}
+                    layout={design}
                   />
                 );
               })}
@@ -512,11 +427,11 @@ export const PlanManager = forwardRef<
           </Flex>
         )}
 
-        {props.addOns.isVisible &&
+        {design.addOns.isVisible &&
           showCredits &&
           creditGroups.plan.length > 0 && (
             <Flex $flexDirection="column" $gap="0.5rem">
-              {props.addOns.showLabel && (
+              {design.addOns.showLabel && (
                 <Text
                   $color={
                     isLightBackground
@@ -552,7 +467,7 @@ export const PlanManager = forwardRef<
                         $flexWrap="wrap"
                         $gap="0.5rem"
                       >
-                        <Text display={props.addOns.fontStyle}>
+                        <Text display={design.addOns.fontStyle}>
                           {group.quantity}{" "}
                           {getFeatureName(group, group.quantity)}{" "}
                           {subscriptionInterval && (
@@ -601,7 +516,7 @@ export const PlanManager = forwardRef<
                   $borderRadius="0.5rem"
                 >
                   <Flex $flexDirection="column" $gap="0.5rem">
-                    <Text display={props.addOns.fontStyle}>
+                    <Text display={design.addOns.fontStyle}>
                       {t("Auto top-up")}
                     </Text>
                     {currentPlan?.includedCreditGrants.reduce(
@@ -658,10 +573,7 @@ export const PlanManager = forwardRef<
 
                   <Button
                     type="button"
-                    onClick={() => {
-                      setCheckoutState({ bypassPlanSelection: true });
-                      setLayout("checkout");
-                    }}
+                    onClick={editAutoTopup}
                     $size="sm"
                     $variant="ghost"
                   >
@@ -672,9 +584,9 @@ export const PlanManager = forwardRef<
             </Flex>
           )}
 
-        {props.addOns.isVisible && creditGroups.bundles.length > 0 && (
+        {design.addOns.isVisible && creditGroups.bundles.length > 0 && (
           <Flex $flexDirection="column" $gap="0.5rem">
-            {props.addOns.showLabel && (
+            {design.addOns.showLabel && (
               <Text
                 $color={
                   isLightBackground
@@ -702,7 +614,7 @@ export const PlanManager = forwardRef<
                     $gap="0.5rem"
                   >
                     {bundle ? (
-                      <Text display={props.addOns.fontStyle}>
+                      <Text display={design.addOns.fontStyle}>
                         {group.grants.length > 1 && (
                           <Text style={{ opacity: 0.5 }}>
                             ({group.grants.length}){" "}
@@ -712,7 +624,7 @@ export const PlanManager = forwardRef<
                         {getFeatureName(group, group.quantity)})
                       </Text>
                     ) : (
-                      <Text display={props.addOns.fontStyle}>
+                      <Text display={design.addOns.fontStyle}>
                         {group.quantity} {getFeatureName(group, group.quantity)}
                       </Text>
                     )}
@@ -733,9 +645,9 @@ export const PlanManager = forwardRef<
           </Flex>
         )}
 
-        {props.addOns.isVisible && creditGroups.promotional.length > 0 && (
+        {design.addOns.isVisible && creditGroups.promotional.length > 0 && (
           <Flex $flexDirection="column" $gap="0.5rem">
-            {props.addOns.showLabel && (
+            {design.addOns.showLabel && (
               <Text
                 $color={
                   isLightBackground
@@ -758,7 +670,7 @@ export const PlanManager = forwardRef<
                     $flexWrap="wrap"
                     $gap="0.5rem"
                   >
-                    <Text display={props.addOns.fontStyle}>
+                    <Text display={design.addOns.fontStyle}>
                       {group.quantity} {getFeatureName(group, group.quantity)}
                     </Text>
 
@@ -779,15 +691,13 @@ export const PlanManager = forwardRef<
         )}
 
         {canCheckout &&
-          props.callToAction.isVisible &&
+          design.callToAction.isVisible &&
           !customPlanBilling?.isAwaitingActivation && (
             <Button
               type="button"
-              onClick={() => {
-                setLayout("checkout");
-              }}
-              $size={props.callToAction.buttonSize}
-              $color={props.callToAction.buttonStyle}
+              onClick={changePlan}
+              $size={design.callToAction.buttonSize}
+              $color={design.callToAction.buttonStyle}
               $fullWidth
             >
               {t("Change plan")}
@@ -798,4 +708,4 @@ export const PlanManager = forwardRef<
   );
 });
 
-PlanManager.displayName = "PlanManager";
+PlanManagerBody.displayName = "PlanManagerBody";

--- a/react/src/components/components/elements/unsubscribe-button/UnsubscribeButton.tsx
+++ b/react/src/components/components/elements/unsubscribe-button/UnsubscribeButton.tsx
@@ -1,7 +1,10 @@
-import { forwardRef, useMemo } from "react";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useEmbed } from "../../../hooks";
+import {
+  UnsubscribeButton as UnsubscribeButtonPrimitive,
+  useUnsubscribeButton,
+} from "../../../composable/unsubscribe-button";
 import { ComponentStyle, DeepPartial, ElementProps } from "../../../types";
 import { Element } from "../../layout";
 import {
@@ -62,19 +65,29 @@ export const UnsubscribeButton = forwardRef<
     React.HTMLAttributes<HTMLDivElement> & {
       portal?: HTMLElement | null;
     }
->(({ children, className, ...rest }, ref) => {
+>(({ className, ...rest }, ref) => {
   const props = resolveDesignProps(rest);
+
+  return (
+    <UnsubscribeButtonPrimitive.Root>
+      <UnsubscribeButtonBody ref={ref} design={props} className={className} />
+    </UnsubscribeButtonPrimitive.Root>
+  );
+});
+
+UnsubscribeButton.displayName = "UnsubscribeButton";
+
+interface UnsubscribeButtonBodyProps {
+  design: DesignProps;
+  className?: string;
+}
+
+const UnsubscribeButtonBody = forwardRef<
+  HTMLDivElement | null,
+  UnsubscribeButtonBodyProps
+>(({ design, className }, ref) => {
   const { t } = useTranslation();
-
-  const { data, setLayout } = useEmbed();
-
-  const hasActiveSubscription = useMemo(() => {
-    return (
-      data?.subscription &&
-      data.subscription.status !== "cancelled" &&
-      !data.subscription.cancelAt
-    );
-  }, [data?.subscription]);
+  const { hasActiveSubscription, unsubscribe } = useUnsubscribeButton();
 
   if (!hasActiveSubscription) {
     return null;
@@ -90,19 +103,17 @@ export const UnsubscribeButton = forwardRef<
     >
       <Button
         type="button"
-        onClick={() => {
-          setLayout("unsubscribe");
-        }}
-        $size={props.button.size}
-        $color={buttonStyles[props.button.style].color}
-        $variant={buttonStyles[props.button.style].variant}
-        $alignment={props.button.alignment}
-        $fullWidth={props.button.fullWidth}
+        onClick={unsubscribe}
+        $size={design.button.size}
+        $color={buttonStyles[design.button.style].color}
+        $variant={buttonStyles[design.button.style].variant}
+        $alignment={design.button.alignment}
+        $fullWidth={design.button.fullWidth}
       >
-        {t(props.button.text) ?? t("Unsubscribe")}
+        {t(design.button.text) ?? t("Unsubscribe")}
       </Button>
     </Element>
   );
 });
 
-UnsubscribeButton.displayName = "UnsubscribeButton";
+UnsubscribeButtonBody.displayName = "UnsubscribeButtonBody";

--- a/react/src/components/components/elements/upcoming-bill/UpcomingBill.tsx
+++ b/react/src/components/components/elements/upcoming-bill/UpcomingBill.tsx
@@ -1,19 +1,14 @@
-import { forwardRef, useCallback, useEffect, useMemo, useState } from "react";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
-  type CurrencyBalance,
-  type InvoiceResponseData,
-} from "../../../api/checkoutexternal";
+  UpcomingBill as UpcomingBillPrimitive,
+  useUpcomingBill,
+} from "../../../composable/upcoming-bill";
 import { type FontStyle } from "../../../embed";
 import { useEmbed, useIsLightBackground } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
-import {
-  ERROR_UNKNOWN,
-  formatCurrency,
-  isError,
-  toPrettyDate,
-} from "../../../utils";
+import { formatCurrency, toPrettyDate } from "../../../utils";
 import { Element } from "../../layout";
 import { Box, Button, Flex, Loader, Text, TransitionBox } from "../../ui";
 
@@ -61,84 +56,41 @@ export const UpcomingBill = forwardRef<
 >(({ className, ...rest }, ref) => {
   const props = resolveDesignProps(rest);
 
+  return (
+    <UpcomingBillPrimitive.Root>
+      <UpcomingBillBody ref={ref} design={props} className={className} />
+    </UpcomingBillPrimitive.Root>
+  );
+});
+
+UpcomingBill.displayName = "UpcomingBill";
+
+interface UpcomingBillBodyProps {
+  design: DesignProps;
+  className?: string;
+}
+
+const UpcomingBillBody = forwardRef<
+  HTMLDivElement | null,
+  UpcomingBillBodyProps
+>(({ design, className }, ref) => {
   const { t } = useTranslation();
 
-  const { data, settings, debug, getUpcomingInvoice, getCustomerBalance } =
-    useEmbed();
+  const { settings } = useEmbed();
 
   const isLightBackground = useIsLightBackground();
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error>();
-  const [upcomingInvoice, setUpcomingInvoice] = useState<
-    InvoiceResponseData | undefined
-  >(data?.upcomingInvoice);
-  const [balances, setBalances] = useState<CurrencyBalance[]>([]);
+  const {
+    isVisible,
+    isLoading,
+    error,
+    upcomingInvoice,
+    balances,
+    discounts,
+    retry: getInvoice,
+  } = useUpcomingBill();
 
-  const discounts = useMemo(() => {
-    return (data?.subscription?.discounts || []).map((discount) => ({
-      couponId: discount.couponId,
-      customerFacingCode: discount.customerFacingCode || undefined,
-      currency: discount.currency || undefined,
-      amountOff: discount.amountOff ?? undefined,
-      percentOff: discount.percentOff ?? undefined,
-      isActive: discount.isActive,
-    }));
-  }, [data?.subscription?.discounts]);
-
-  const getInvoice = useCallback(async () => {
-    if (
-      data?.component?.id &&
-      data?.subscription &&
-      !data.subscription.cancelAt
-    ) {
-      try {
-        setError(undefined);
-        setIsLoading(true);
-
-        const response = await getUpcomingInvoice(data.component.id);
-
-        if (response) {
-          setUpcomingInvoice(response.data);
-        }
-      } catch (err) {
-        setError(isError(err) ? err : ERROR_UNKNOWN);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-  }, [data?.component?.id, data?.subscription, getUpcomingInvoice]);
-
-  const getBalances = useCallback(async () => {
-    try {
-      const response = await getCustomerBalance();
-
-      if (response) {
-        setBalances(response.data.balances);
-      }
-    } catch (err) {
-      debug("Failed to fetch customer balance.", err);
-    }
-  }, [debug, getCustomerBalance]);
-
-  useEffect(() => {
-    getInvoice();
-  }, [getInvoice]);
-
-  useEffect(() => {
-    getBalances();
-  }, [getBalances]);
-
-  // ensure shared data updates are tracked
-  // used to keep in sync with preview data
-  // TODO: move this logic outside of components
-  useEffect(() => {
-    if (data?.upcomingInvoice) {
-      setUpcomingInvoice(data.upcomingInvoice);
-    }
-  }, [data?.upcomingInvoice]);
-
-  if (!data?.subscription || data.subscription.cancelAt) {
+  if (!isVisible) {
     return null;
   }
 
@@ -175,9 +127,9 @@ export const UpcomingBill = forwardRef<
           <TransitionBox>
             {upcomingInvoice ? (
               <Flex $flexDirection="column" $gap="1rem">
-                {props.header.isVisible && upcomingInvoice.dueDate && (
-                  <Text display={props.header.fontStyle}>
-                    {props.header.prefix}{" "}
+                {design.header.isVisible && upcomingInvoice.dueDate && (
+                  <Text display={design.header.fontStyle}>
+                    {design.header.prefix}{" "}
                     {toPrettyDate(upcomingInvoice.dueDate)}
                   </Text>
                 )}
@@ -187,8 +139,8 @@ export const UpcomingBill = forwardRef<
                   $alignItems="start"
                   $gap="1rem"
                 >
-                  {props.price.isVisible && (
-                    <Text display={props.price.fontStyle} $leading="none">
+                  {design.price.isVisible && (
+                    <Text display={design.price.fontStyle} $leading="none">
                       {formatCurrency(
                         upcomingInvoice.amountDue,
                         upcomingInvoice.currency,
@@ -197,7 +149,7 @@ export const UpcomingBill = forwardRef<
                   )}
 
                   <Box $maxWidth="10rem" $textAlign="right">
-                    <Text display={props.contractEndDate.fontStyle}>
+                    <Text display={design.contractEndDate.fontStyle}>
                       {t("Estimated bill")}
                     </Text>
                   </Box>
@@ -308,4 +260,4 @@ export const UpcomingBill = forwardRef<
   );
 });
 
-UpcomingBill.displayName = "UpcomingBill";
+UpcomingBillBody.displayName = "UpcomingBillBody";

--- a/react/src/components/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/react/src/components/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -20,6 +20,10 @@ import {
   type PreviewSubscriptionFinanceResponseData,
 } from "../../../api/checkoutexternal";
 import {
+  CheckoutDialog as CheckoutDialogPrimitive,
+  useCheckoutDialog,
+} from "../../../composable/checkout-dialog";
+import {
   DEFAULT_CURRENCY,
   FETCH_DEBOUNCE_TIMEOUT,
   TEXT_BASE_SIZE,
@@ -140,7 +144,13 @@ interface ConfirmPaymentIntentProps {
   callback: (confirmed: boolean) => void;
 }
 
-export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
+export const CheckoutDialog = (props: CheckoutDialogProps) => (
+  <CheckoutDialogPrimitive.Root>
+    <CheckoutDialogInner {...props} />
+  </CheckoutDialogPrimitive.Root>
+);
+
+const CheckoutDialogInner = ({ top }: CheckoutDialogProps) => {
   const { t } = useTranslation();
 
   const {
@@ -149,13 +159,15 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     settings,
     isPending,
     checkoutState,
-    clearCheckoutState,
     setCheckoutState,
     previewCheckout,
-    setLayout,
     currencyFilter,
     debug,
   } = useEmbed();
+
+  // The dialog open/close lifecycle is exposed via the composable seam
+  // (`useCheckoutDialog`); the rest of the checkout state machine stays here.
+  const { close: handleClose } = useCheckoutDialog();
 
   const isLightBackground = useIsLightBackground();
 
@@ -1447,11 +1459,6 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     },
     [handlePreviewCheckout],
   );
-
-  const handleClose = useCallback(() => {
-    clearCheckoutState();
-    setLayout("portal");
-  }, [setLayout, clearCheckoutState]);
 
   // this is needed to run the `selectPlan` logic on initial load
   // if the user is already on an available plan

--- a/react/src/components/composable/checkout-dialog/CheckoutDialog.composable.test.tsx
+++ b/react/src/components/composable/checkout-dialog/CheckoutDialog.composable.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import {
+  CheckoutDialog,
+  CheckoutDialogContext,
+  type CheckoutDialogContextValue,
+} from ".";
+
+function withContext(
+  ui: React.ReactNode,
+  overrides: Partial<CheckoutDialogContextValue> = {},
+) {
+  const value: CheckoutDialogContextValue = {
+    isOpen: true,
+    close: vi.fn(),
+    ...overrides,
+  };
+  return { value, ...render(
+    <CheckoutDialogContext.Provider value={value}>
+      {ui}
+    </CheckoutDialogContext.Provider>,
+  ) };
+}
+
+describe("CheckoutDialog primitives", () => {
+  test("Close invokes close on click", () => {
+    const close = vi.fn();
+    withContext(<CheckoutDialog.Close>Close</CheckoutDialog.Close>, { close });
+
+    fireEvent.click(screen.getByText("Close"));
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  test("Close supports asChild and emits the part attribute", () => {
+    withContext(
+      <CheckoutDialog.Close asChild>
+        <a href="/x">Close</a>
+      </CheckoutDialog.Close>,
+    );
+    expect(screen.getByRole("link", { name: "Close" })).toHaveAttribute(
+      "data-schematic-part",
+      "checkout-dialog-close",
+    );
+  });
+
+  test("useCheckoutDialog throws outside Root", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      render(<CheckoutDialog.Close>x</CheckoutDialog.Close>),
+    ).toThrow(/must be rendered inside/);
+    spy.mockRestore();
+  });
+});

--- a/react/src/components/composable/checkout-dialog/context.tsx
+++ b/react/src/components/composable/checkout-dialog/context.tsx
@@ -1,0 +1,44 @@
+// Headless controller + context for the CheckoutDialog shell.
+//
+// Intentionally minimal: CheckoutDialog is a large checkout state machine
+// (preview engine, Stripe confirmation, native <dialog> management) that is
+// the product itself, not a display component. This seam models only the
+// dialog open/close lifecycle — both derivable from `useEmbed` alone, so the
+// state machine stays entirely in the styled wrapper. A consumer building a
+// custom checkout shell can drive open/close from here.
+
+import * as React from "react";
+
+import { useEmbed } from "../../hooks";
+import { createPrimitiveContext } from "../internal";
+
+export interface CheckoutDialogContextValue {
+  /** True while the checkout layout is active. */
+  isOpen: boolean;
+  /** Clears checkout state and returns to the portal layout. */
+  close: () => void;
+}
+
+const [CheckoutDialogProvider, useCheckoutDialogContext, CheckoutDialogContext] =
+  createPrimitiveContext<CheckoutDialogContextValue>("CheckoutDialog");
+
+export { CheckoutDialogContext, CheckoutDialogProvider };
+
+/** Consumer-facing hook. Throws outside `CheckoutDialog.Root`. */
+export function useCheckoutDialog(): CheckoutDialogContextValue {
+  return useCheckoutDialogContext("useCheckoutDialog");
+}
+
+export function useCheckoutDialogController(): CheckoutDialogContextValue {
+  const { layout, clearCheckoutState, setLayout } = useEmbed();
+
+  const close = React.useCallback(() => {
+    clearCheckoutState();
+    setLayout("portal");
+  }, [clearCheckoutState, setLayout]);
+
+  return {
+    isOpen: layout === "checkout",
+    close,
+  };
+}

--- a/react/src/components/composable/checkout-dialog/index.tsx
+++ b/react/src/components/composable/checkout-dialog/index.tsx
@@ -1,0 +1,67 @@
+// CheckoutDialog composable namespace (minimal open/close seam).
+//
+//   <CheckoutDialog.Root>
+//     <CheckoutDialog.Close>Close</CheckoutDialog.Close>
+//     // useCheckoutDialog() -> { isOpen, close }
+//   </CheckoutDialog.Root>
+
+import * as React from "react";
+
+import { Slot, partAttrs, type AsChildProps } from "../internal";
+
+import {
+  CheckoutDialogProvider,
+  useCheckoutDialog,
+  useCheckoutDialogController,
+} from "./context";
+
+export interface CheckoutDialogRootProps {
+  children?: React.ReactNode;
+}
+
+/** Pure provider — runs the controller and publishes context. */
+function Root({ children }: CheckoutDialogRootProps) {
+  const value = useCheckoutDialogController();
+  const memoized = React.useMemo(
+    () => value,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value.isOpen, value.close],
+  );
+  return (
+    <CheckoutDialogProvider value={memoized}>{children}</CheckoutDialogProvider>
+  );
+}
+Root.displayName = "CheckoutDialog.Root";
+
+export type CloseProps = AsChildProps<"button">;
+
+/** A button (or `asChild` element) that closes the checkout dialog. */
+const Close = React.forwardRef<HTMLButtonElement, CloseProps>(
+  ({ asChild, onClick, children, ...rest }, ref) => {
+    const { close } = useCheckoutDialog();
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        ref={ref as React.Ref<never>}
+        type={asChild ? undefined : "button"}
+        {...partAttrs("checkout-dialog-close")}
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          (onClick as React.MouseEventHandler<HTMLButtonElement>)?.(event);
+          close();
+        }}
+        {...rest}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+Close.displayName = "CheckoutDialog.Close";
+
+export const CheckoutDialog = Object.assign(Root, { Root, Close });
+
+export {
+  CheckoutDialogContext,
+  useCheckoutDialog,
+  type CheckoutDialogContextValue,
+} from "./context";

--- a/react/src/components/composable/included-features/IncludedFeatures.composable.test.tsx
+++ b/react/src/components/composable/included-features/IncludedFeatures.composable.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { type FeatureUsageResponseData } from "../../api/checkoutexternal";
+
+import {
+  IncludedFeatures,
+  IncludedFeaturesContext,
+  type IncludedFeaturesContextValue,
+} from ".";
+
+const features = [
+  { feature: { id: "f1", name: "Feature 1" } },
+  { feature: { id: "f2", name: "Feature 2" } },
+] as FeatureUsageResponseData[];
+
+function withContext(
+  ui: React.ReactNode,
+  overrides: Partial<IncludedFeaturesContextValue> = {},
+) {
+  const value: IncludedFeaturesContextValue = {
+    featureUsage: features,
+    displayedFeatures: features,
+    shouldShow: true,
+    hasMore: false,
+    expanded: false,
+    toggle: vi.fn(),
+    ...overrides,
+  };
+  return render(
+    <IncludedFeaturesContext.Provider value={value}>
+      {ui}
+    </IncludedFeaturesContext.Provider>,
+  );
+}
+
+describe("IncludedFeatures primitives", () => {
+  test("Content exposes displayed features when shouldShow is true", () => {
+    withContext(
+      <IncludedFeatures.Content>
+        {({ displayedFeatures }) => (
+          <ul>
+            {displayedFeatures.map((f) => (
+              <li key={f.feature?.id}>{f.feature?.name}</li>
+            ))}
+          </ul>
+        )}
+      </IncludedFeatures.Content>,
+    );
+
+    expect(screen.getByText("Feature 1")).toBeInTheDocument();
+    expect(screen.getByText("Feature 2")).toBeInTheDocument();
+  });
+
+  test("Content renders nothing when shouldShow is false", () => {
+    withContext(
+      <IncludedFeatures.Content>{() => <span>x</span>}</IncludedFeatures.Content>,
+      { shouldShow: false },
+    );
+    expect(screen.queryByText("x")).not.toBeInTheDocument();
+  });
+
+  test("ToggleMore gates on hasMore", () => {
+    withContext(
+      <IncludedFeatures.ToggleMore>
+        {() => <span>toggle</span>}
+      </IncludedFeatures.ToggleMore>,
+    );
+    expect(screen.queryByText("toggle")).not.toBeInTheDocument();
+  });
+});

--- a/react/src/components/composable/included-features/context.tsx
+++ b/react/src/components/composable/included-features/context.tsx
@@ -1,0 +1,99 @@
+// Headless controller + context for the IncludedFeatures primitive.
+
+import * as React from "react";
+
+import { type FeatureUsageResponseData } from "../../api/checkoutexternal";
+import { VISIBLE_ENTITLEMENT_COUNT } from "../../const";
+import { useEmbed } from "../../hooks";
+import { createPrimitiveContext } from "../internal";
+
+export interface IncludedFeaturesOptions {
+  /** Optional ordered allow-list of feature ids to show. */
+  visibleFeatures?: string[];
+}
+
+export interface IncludedFeaturesContextValue {
+  /** The full (optionally ordered) feature-usage list. */
+  featureUsage: FeatureUsageResponseData[];
+  /** The collapsed/expanded slice of `featureUsage`. */
+  displayedFeatures: FeatureUsageResponseData[];
+  /** Whether the component should render at all. */
+  shouldShow: boolean;
+  hasMore: boolean;
+  expanded: boolean;
+  toggle: () => void;
+}
+
+const [
+  IncludedFeaturesProvider,
+  useIncludedFeaturesContext,
+  IncludedFeaturesContext,
+] = createPrimitiveContext<IncludedFeaturesContextValue>("IncludedFeatures");
+
+export { IncludedFeaturesContext, IncludedFeaturesProvider };
+
+/** Consumer-facing hook. Throws outside `IncludedFeatures.Root`. */
+export function useIncludedFeatures(): IncludedFeaturesContextValue {
+  return useIncludedFeaturesContext("useIncludedFeatures");
+}
+
+export function useIncludedFeaturesController(
+  options: IncludedFeaturesOptions,
+): IncludedFeaturesContextValue {
+  const { visibleFeatures } = options;
+
+  const { data } = useEmbed();
+
+  const [showCount, setShowCount] = React.useState(VISIBLE_ENTITLEMENT_COUNT);
+
+  const { plan, addOns, featureUsage } = React.useMemo(() => {
+    const orderedFeatureUsage = visibleFeatures?.reduce(
+      (acc: FeatureUsageResponseData[], id) => {
+        const mappedFeatureUsage = data?.featureUsage?.features.find(
+          (usage) => usage.feature?.id === id,
+        );
+
+        if (mappedFeatureUsage) {
+          acc.push(mappedFeatureUsage);
+        }
+
+        return acc;
+      },
+      [],
+    );
+
+    return {
+      plan: data?.company?.plan,
+      addOns: data?.company?.addOns || [],
+      featureUsage: orderedFeatureUsage || data?.featureUsage?.features || [],
+    };
+  }, [
+    visibleFeatures,
+    data?.company?.plan,
+    data?.company?.addOns,
+    data?.featureUsage?.features,
+  ]);
+
+  const featureListSize = featureUsage.length;
+
+  const toggle = () => {
+    setShowCount((prev) =>
+      prev > VISIBLE_ENTITLEMENT_COUNT
+        ? VISIBLE_ENTITLEMENT_COUNT
+        : featureListSize,
+    );
+  };
+
+  // Render when there is any plan, add-on, or feature (features may exist via
+  // company overrides even without a plan/add-on).
+  const shouldShow = !!(featureUsage.length > 0 || plan || addOns.length > 0);
+
+  return {
+    featureUsage,
+    displayedFeatures: featureUsage.slice(0, showCount),
+    shouldShow,
+    hasMore: featureListSize > VISIBLE_ENTITLEMENT_COUNT,
+    expanded: showCount > VISIBLE_ENTITLEMENT_COUNT,
+    toggle,
+  };
+}

--- a/react/src/components/composable/included-features/index.tsx
+++ b/react/src/components/composable/included-features/index.tsx
@@ -1,0 +1,89 @@
+// IncludedFeatures composable namespace.
+//
+//   <IncludedFeatures.Root visibleFeatures={[…]}>
+//     <IncludedFeatures.Content>
+//       {({ displayedFeatures }) => …}
+//     </IncludedFeatures.Content>
+//     <IncludedFeatures.ToggleMore>
+//       {({ expanded, toggle }) => …}
+//     </IncludedFeatures.ToggleMore>
+//   </IncludedFeatures.Root>
+
+import * as React from "react";
+
+import { type FeatureUsageResponseData } from "../../api/checkoutexternal";
+import { type RenderProp } from "../internal";
+
+import {
+  IncludedFeaturesProvider,
+  useIncludedFeatures,
+  useIncludedFeaturesController,
+  type IncludedFeaturesOptions,
+} from "./context";
+
+export interface IncludedFeaturesRootProps extends IncludedFeaturesOptions {
+  children?: React.ReactNode;
+}
+
+/** Pure provider — runs the controller and publishes context. */
+function Root({ children, ...options }: IncludedFeaturesRootProps) {
+  const value = useIncludedFeaturesController(options);
+  const memoized = React.useMemo(
+    () => value,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      value.featureUsage,
+      value.displayedFeatures,
+      value.shouldShow,
+      value.hasMore,
+      value.expanded,
+    ],
+  );
+  return (
+    <IncludedFeaturesProvider value={memoized}>
+      {children}
+    </IncludedFeaturesProvider>
+  );
+}
+Root.displayName = "IncludedFeatures.Root";
+
+/** Renders children only when the component should be shown. */
+function Content({
+  children,
+}: {
+  children: RenderProp<{
+    featureUsage: FeatureUsageResponseData[];
+    displayedFeatures: FeatureUsageResponseData[];
+  }>;
+}) {
+  const { shouldShow, featureUsage, displayedFeatures } = useIncludedFeatures();
+  if (!shouldShow) {
+    return null;
+  }
+  return <>{children({ featureUsage, displayedFeatures })}</>;
+}
+Content.displayName = "IncludedFeatures.Content";
+
+/** Exposes the expand/collapse toggle; renders only when there's more to show. */
+function ToggleMore({
+  children,
+}: {
+  children: RenderProp<{ expanded: boolean; toggle: () => void }>;
+}) {
+  const { hasMore, expanded, toggle } = useIncludedFeatures();
+  return hasMore ? <>{children({ expanded, toggle })}</> : null;
+}
+ToggleMore.displayName = "IncludedFeatures.ToggleMore";
+
+export const IncludedFeatures = Object.assign(Root, {
+  Root,
+  Content,
+  ToggleMore,
+});
+
+export {
+  IncludedFeaturesContext,
+  useIncludedFeatures,
+  type IncludedFeaturesContextValue,
+  type IncludedFeaturesOptions,
+} from "./context";

--- a/react/src/components/composable/index.tsx
+++ b/react/src/components/composable/index.tsx
@@ -69,6 +69,15 @@ export {
   type IncludedFeaturesRootProps,
 } from "./included-features";
 
+// === CheckoutDialog (minimal open/close seam) ===
+export {
+  CheckoutDialog,
+  CheckoutDialogContext,
+  useCheckoutDialog,
+  type CheckoutDialogContextValue,
+  type CheckoutDialogRootProps,
+} from "./checkout-dialog";
+
 // === PlanManager ===
 export {
   PlanManager,

--- a/react/src/components/composable/index.tsx
+++ b/react/src/components/composable/index.tsx
@@ -58,3 +58,45 @@ export {
   type PaymentMethodOptions,
   type PaymentMethodRootProps,
 } from "./payment-method";
+
+// === IncludedFeatures ===
+export {
+  IncludedFeatures,
+  IncludedFeaturesContext,
+  useIncludedFeatures,
+  type IncludedFeaturesContextValue,
+  type IncludedFeaturesOptions,
+  type IncludedFeaturesRootProps,
+} from "./included-features";
+
+// === Invoices ===
+export {
+  Invoices,
+  InvoicesContext,
+  formatInvoices,
+  useInvoices,
+  type FormattedInvoice,
+  type InvoicesContextValue,
+  type InvoicesOptions,
+  type InvoicesRootProps,
+} from "./invoices";
+
+// === UnsubscribeButton ===
+export {
+  UnsubscribeButton,
+  UnsubscribeButtonContext,
+  useUnsubscribeButton,
+  type UnsubscribeButtonContextValue,
+  type UnsubscribeButtonRootProps,
+} from "./unsubscribe-button";
+
+// === UpcomingBill ===
+export {
+  UpcomingBill,
+  UpcomingBillContext,
+  useUpcomingBill,
+  type UpcomingBillContentRenderProps,
+  type UpcomingBillContextValue,
+  type UpcomingBillDiscount,
+  type UpcomingBillRootProps,
+} from "./upcoming-bill";

--- a/react/src/components/composable/index.tsx
+++ b/react/src/components/composable/index.tsx
@@ -69,6 +69,28 @@ export {
   type IncludedFeaturesRootProps,
 } from "./included-features";
 
+// === PlanManager ===
+export {
+  PlanManager,
+  PlanManagerContext,
+  usePlanManager,
+  type ChangePlanTriggerProps,
+  type PlanManagerContextValue,
+  type PlanManagerCreditGroups,
+  type PlanManagerRootProps,
+} from "./plan-manager";
+
+// === MeteredFeatures ===
+export {
+  MeteredFeatures,
+  MeteredFeaturesContext,
+  useMeteredFeatures,
+  type MeteredCreditGroup,
+  type MeteredFeaturesContextValue,
+  type MeteredFeaturesOptions,
+  type MeteredFeaturesRootProps,
+} from "./metered-features";
+
 // === Invoices ===
 export {
   Invoices,

--- a/react/src/components/composable/invoices/Invoices.composable.test.tsx
+++ b/react/src/components/composable/invoices/Invoices.composable.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import {
+  Invoices,
+  InvoicesContext,
+  type FormattedInvoice,
+  type InvoicesContextValue,
+} from ".";
+
+const sampleInvoices: FormattedInvoice[] = [
+  { amount: "$10.00", amountDue: 1000, date: "Jan 1, 2026", url: "/a" },
+  { amount: "$20.00", amountDue: 2000, date: "Feb 1, 2026" },
+  { amount: "$30.00", amountDue: 3000, date: "Mar 1, 2026" },
+];
+
+function withContext(
+  ui: React.ReactNode,
+  overrides: Partial<InvoicesContextValue> = {},
+) {
+  const value: InvoicesContextValue = {
+    invoices: sampleInvoices,
+    visibleInvoices: sampleInvoices.slice(0, 2),
+    isLoading: false,
+    error: undefined,
+    retry: vi.fn(),
+    hasMore: true,
+    expanded: false,
+    toggle: vi.fn(),
+    isEmpty: false,
+    ...overrides,
+  };
+  return render(
+    <InvoicesContext.Provider value={value}>{ui}</InvoicesContext.Provider>,
+  );
+}
+
+describe("Invoices primitives", () => {
+  test("List exposes visible invoices and renders only when ready", () => {
+    withContext(
+      <Invoices.List>
+        {({ visibleInvoices }) => (
+          <ul>
+            {visibleInvoices.map((inv) => (
+              <li key={inv.date}>{inv.amount}</li>
+            ))}
+          </ul>
+        )}
+      </Invoices.List>,
+    );
+
+    expect(screen.getByText("$10.00")).toBeInTheDocument();
+    expect(screen.getByText("$20.00")).toBeInTheDocument();
+    expect(screen.queryByText("$30.00")).not.toBeInTheDocument();
+  });
+
+  test("List renders nothing while loading", () => {
+    withContext(
+      <Invoices.List>{() => <span>list</span>}</Invoices.List>,
+      { isLoading: true },
+    );
+    expect(screen.queryByText("list")).not.toBeInTheDocument();
+  });
+
+  test("ToggleMore exposes toggle and gates on hasMore", () => {
+    const toggle = vi.fn();
+    const { rerender } = withContext(
+      <Invoices.ToggleMore>
+        {({ expanded, toggle }) => (
+          <button onClick={toggle}>{expanded ? "less" : "more"}</button>
+        )}
+      </Invoices.ToggleMore>,
+      { toggle },
+    );
+
+    fireEvent.click(screen.getByText("more"));
+    expect(toggle).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <InvoicesContext.Provider
+        value={{
+          invoices: sampleInvoices,
+          visibleInvoices: sampleInvoices,
+          isLoading: false,
+          error: undefined,
+          retry: vi.fn(),
+          hasMore: false,
+          expanded: true,
+          toggle,
+          isEmpty: false,
+        }}
+      >
+        <Invoices.ToggleMore>{() => <span>toggle</span>}</Invoices.ToggleMore>
+      </InvoicesContext.Provider>,
+    );
+    expect(screen.queryByText("toggle")).not.toBeInTheDocument();
+  });
+
+  test("ErrorState exposes retry", () => {
+    const retry = vi.fn();
+    withContext(
+      <Invoices.ErrorState>
+        {({ retry }) => <button onClick={retry}>retry</button>}
+      </Invoices.ErrorState>,
+      { error: new Error("boom"), retry },
+    );
+
+    fireEvent.click(screen.getByText("retry"));
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/react/src/components/composable/invoices/context.tsx
+++ b/react/src/components/composable/invoices/context.tsx
@@ -1,0 +1,116 @@
+// Headless controller + context for the Invoices primitive.
+//
+// The fetch-on-mount and preview-data-sync effects are ported verbatim from
+// the original `Invoices` component; the React Compiler `set-state-in-effect`
+// rule flags those intentional patterns, so it is disabled here rather than
+// restructured (which would risk behavior changes).
+/* eslint-disable react-hooks/set-state-in-effect */
+
+import * as React from "react";
+
+import { type InvoiceResponseData } from "../../api/checkoutexternal";
+import { MAX_VISIBLE_INVOICE_COUNT } from "../../const";
+import { useEmbed } from "../../hooks";
+import { ERROR_UNKNOWN, isError } from "../../utils";
+import { createPrimitiveContext } from "../internal";
+
+import { formatInvoices, type FormattedInvoice } from "./formatInvoices";
+
+export interface InvoicesOptions {
+  /** Collapsed-list size; the expand toggle flips between this and the max. */
+  limit?: number;
+  /** Externally-supplied invoice data (overrides hydrated data). */
+  data?: InvoiceResponseData[];
+}
+
+export interface InvoicesContextValue {
+  invoices: FormattedInvoice[];
+  /** The collapsed/expanded slice of `invoices`. */
+  visibleInvoices: FormattedInvoice[];
+  isLoading: boolean;
+  error?: Error;
+  retry: () => void;
+  hasMore: boolean;
+  expanded: boolean;
+  toggle: () => void;
+  isEmpty: boolean;
+}
+
+const [InvoicesProvider, useInvoicesContext, InvoicesContext] =
+  createPrimitiveContext<InvoicesContextValue>("Invoices");
+
+export { InvoicesContext, InvoicesProvider };
+
+/** Consumer-facing hook. Throws outside `Invoices.Root`. */
+export function useInvoices(): InvoicesContextValue {
+  return useInvoicesContext("useInvoices");
+}
+
+export function useInvoicesController(
+  options: InvoicesOptions,
+): InvoicesContextValue {
+  const { limit = 2, data: dataProp } = options;
+
+  const { data, listInvoices } = useEmbed();
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+  const [invoices, setInvoices] = React.useState<FormattedInvoice[]>(() =>
+    formatInvoices(
+      data && "invoices" in data
+        ? (data.invoices as InvoiceResponseData[])
+        : dataProp,
+    ),
+  );
+  const [listSize, setListSize] = React.useState(limit);
+
+  const getInvoices = React.useCallback(async () => {
+    try {
+      setError(undefined);
+      setIsLoading(true);
+
+      const response = await listInvoices();
+
+      if (response) {
+        setInvoices(formatInvoices(response.data));
+      }
+    } catch (err) {
+      setError(isError(err) ? err : ERROR_UNKNOWN);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [listInvoices]);
+
+  const toggle = () => {
+    setListSize((prev) => (prev !== limit ? limit : MAX_VISIBLE_INVOICE_COUNT));
+  };
+
+  React.useEffect(() => {
+    getInvoices();
+  }, [getInvoices]);
+
+  React.useEffect(() => {
+    if (dataProp) {
+      setInvoices(formatInvoices(dataProp));
+    }
+  }, [dataProp]);
+
+  // Keep in sync with preview/shared data updates.
+  React.useEffect(() => {
+    if (data && "invoices" in data) {
+      setInvoices(formatInvoices(data.invoices as InvoiceResponseData[]));
+    }
+  }, [data]);
+
+  return {
+    invoices,
+    visibleInvoices: invoices.slice(0, listSize),
+    isLoading,
+    error,
+    retry: getInvoices,
+    hasMore: invoices.length > limit,
+    expanded: listSize !== limit,
+    toggle,
+    isEmpty: invoices.length === 0,
+  };
+}

--- a/react/src/components/composable/invoices/formatInvoices.ts
+++ b/react/src/components/composable/invoices/formatInvoices.ts
@@ -1,0 +1,63 @@
+// Pure invoice formatting/filtering. Lives in the headless layer so both the
+// `Invoices` primitive controller and the styled wrapper share it (and the
+// styled `Invoices.tsx` re-exports it for backward compatibility).
+
+import {
+  InvoiceStatus,
+  type InvoiceResponseData,
+} from "../../api/checkoutexternal";
+import { formatCurrency, toPrettyDate } from "../../utils";
+
+export interface FormattedInvoice {
+  amount: string;
+  amountDue: number;
+  date: string;
+  url?: string;
+}
+
+interface FormatInvoiceOptions {
+  hideUpcoming?: boolean;
+}
+
+export function formatInvoices(
+  invoices?: InvoiceResponseData[],
+  options?: FormatInvoiceOptions,
+): FormattedInvoice[] {
+  const { hideUpcoming = true } = options || {};
+  const now = new Date();
+
+  const excludedStatuses: InvoiceStatus[] = [
+    InvoiceStatus.Void,
+    InvoiceStatus.Draft,
+    InvoiceStatus.Uncollectible,
+  ];
+
+  return (invoices || [])
+    .filter(({ amountDue, dueDate, externalId, status }) => {
+      if (amountDue === 0) return false;
+      if (externalId?.startsWith("upcoming_")) return false;
+      if (status && excludedStatuses.includes(status as InvoiceStatus))
+        return false;
+      if (
+        hideUpcoming &&
+        status !== InvoiceStatus.Paid &&
+        !(dueDate && +dueDate <= +now)
+      )
+        return false;
+      return true;
+    })
+    .sort((a, b) => {
+      const dateA = a.dueDate ?? a.createdAt;
+      const dateB = b.dueDate ?? b.createdAt;
+      return +dateB - +dateA;
+    })
+    .map(({ amountDue, dueDate, createdAt, url, currency }) => {
+      const formatted = formatCurrency(Math.abs(amountDue), currency);
+      return {
+        amount: amountDue < 0 ? `(${formatted})` : formatted,
+        amountDue,
+        date: toPrettyDate(dueDate ?? createdAt),
+        url: url || undefined,
+      };
+    });
+}

--- a/react/src/components/composable/invoices/index.tsx
+++ b/react/src/components/composable/invoices/index.tsx
@@ -1,0 +1,107 @@
+// Invoices composable namespace.
+//
+//   <Invoices.Root limit={2}>
+//     <Invoices.Loading>…</Invoices.Loading>
+//     <Invoices.ErrorState>{({ retry }) => …}</Invoices.ErrorState>
+//     <Invoices.List>{({ visibleInvoices }) => …}</Invoices.List>
+//     <Invoices.ToggleMore>{({ expanded, toggle }) => …}</Invoices.ToggleMore>
+//   </Invoices.Root>
+
+import * as React from "react";
+
+import { type RenderProp } from "../internal";
+
+import {
+  InvoicesProvider,
+  useInvoices,
+  useInvoicesController,
+  type InvoicesOptions,
+} from "./context";
+import { type FormattedInvoice } from "./formatInvoices";
+
+export interface InvoicesRootProps extends InvoicesOptions {
+  children?: React.ReactNode;
+}
+
+/** Pure provider — runs the controller and publishes context. */
+function Root({ children, ...options }: InvoicesRootProps) {
+  const value = useInvoicesController(options);
+  const memoized = React.useMemo(
+    () => value,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      value.invoices,
+      value.visibleInvoices,
+      value.isLoading,
+      value.error,
+      value.retry,
+      value.hasMore,
+      value.expanded,
+    ],
+  );
+  return <InvoicesProvider value={memoized}>{children}</InvoicesProvider>;
+}
+Root.displayName = "Invoices.Root";
+
+/** Renders children only while invoices are loading. */
+function Loading({ children }: { children?: React.ReactNode }) {
+  const { isLoading } = useInvoices();
+  return isLoading ? <>{children}</> : null;
+}
+Loading.displayName = "Invoices.Loading";
+
+/** Renders only when an error occurred; exposes `retry` via render prop. */
+function ErrorState({
+  children,
+}: {
+  children: RenderProp<{ error: Error; retry: () => void }>;
+}) {
+  const { error, retry } = useInvoices();
+  return error ? <>{children({ error, retry })}</> : null;
+}
+ErrorState.displayName = "Invoices.ErrorState";
+
+/** Renders the (collapsed/expanded) invoice list once loaded without error. */
+function List({
+  children,
+}: {
+  children: RenderProp<{
+    invoices: FormattedInvoice[];
+    visibleInvoices: FormattedInvoice[];
+    isEmpty: boolean;
+  }>;
+}) {
+  const { isLoading, error, invoices, visibleInvoices, isEmpty } = useInvoices();
+  if (isLoading || error) {
+    return null;
+  }
+  return <>{children({ invoices, visibleInvoices, isEmpty })}</>;
+}
+List.displayName = "Invoices.List";
+
+/** Exposes the expand/collapse toggle; renders only when there's more to show. */
+function ToggleMore({
+  children,
+}: {
+  children: RenderProp<{ expanded: boolean; toggle: () => void }>;
+}) {
+  const { hasMore, expanded, toggle } = useInvoices();
+  return hasMore ? <>{children({ expanded, toggle })}</> : null;
+}
+ToggleMore.displayName = "Invoices.ToggleMore";
+
+export const Invoices = Object.assign(Root, {
+  Root,
+  Loading,
+  ErrorState,
+  List,
+  ToggleMore,
+});
+
+export {
+  InvoicesContext,
+  useInvoices,
+  type InvoicesContextValue,
+  type InvoicesOptions,
+} from "./context";
+export { formatInvoices, type FormattedInvoice } from "./formatInvoices";

--- a/react/src/components/composable/metered-features/MeteredFeatures.composable.test.tsx
+++ b/react/src/components/composable/metered-features/MeteredFeatures.composable.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { type FeatureUsageResponseData } from "../../api/checkoutexternal";
+
+import {
+  MeteredFeatures,
+  MeteredFeaturesContext,
+  type MeteredCreditGroup,
+  type MeteredFeaturesContextValue,
+} from ".";
+
+const features = [
+  { feature: { id: "f1", name: "Feature 1" } },
+  { feature: { id: "f2", name: "Feature 2" } },
+] as FeatureUsageResponseData[];
+
+const creditGroup = {
+  id: "c1",
+  name: "Credits",
+  total: { used: 1, value: 10 },
+  grants: [],
+} as unknown as MeteredCreditGroup;
+
+function withContext(
+  ui: React.ReactNode,
+  overrides: Partial<MeteredFeaturesContextValue> = {},
+) {
+  const value: MeteredFeaturesContextValue = {
+    meteredFeatures: features,
+    creditGroups: [creditGroup],
+    shouldShow: true,
+    period: "month",
+    canCheckout: true,
+    showCredits: true,
+    isCreditExpanded: () => false,
+    toggleBalanceDetails: vi.fn(),
+    addUsage: vi.fn(),
+    buyCredits: vi.fn(),
+    ...overrides,
+  };
+  return render(
+    <MeteredFeaturesContext.Provider value={value}>
+      {ui}
+    </MeteredFeaturesContext.Provider>,
+  );
+}
+
+describe("MeteredFeatures primitives", () => {
+  test("Features maps over the metered features", () => {
+    withContext(
+      <MeteredFeatures.Features>
+        {(entitlement) => (
+          <div key={entitlement.feature?.id}>{entitlement.feature?.name}</div>
+        )}
+      </MeteredFeatures.Features>,
+    );
+    expect(screen.getByText("Feature 1")).toBeInTheDocument();
+    expect(screen.getByText("Feature 2")).toBeInTheDocument();
+  });
+
+  test("Credits exposes expand state and is gated on showCredits", () => {
+    const toggle = vi.fn();
+    const { rerender } = withContext(
+      <MeteredFeatures.Credits>
+        {(credit, { toggle }) => (
+          <button key={credit.id} onClick={toggle}>
+            {credit.name}
+          </button>
+        )}
+      </MeteredFeatures.Credits>,
+      { toggleBalanceDetails: toggle },
+    );
+
+    fireEvent.click(screen.getByText("Credits"));
+    expect(toggle).toHaveBeenCalledWith("c1");
+
+    rerender(
+      <MeteredFeaturesContext.Provider
+        value={{
+          meteredFeatures: features,
+          creditGroups: [creditGroup],
+          shouldShow: true,
+          period: "month",
+          canCheckout: true,
+          showCredits: false,
+          isCreditExpanded: () => false,
+          toggleBalanceDetails: toggle,
+          addUsage: vi.fn(),
+          buyCredits: vi.fn(),
+        }}
+      >
+        <MeteredFeatures.Credits>
+          {(credit) => <span key={credit.id}>{credit.name}</span>}
+        </MeteredFeatures.Credits>
+      </MeteredFeaturesContext.Provider>,
+    );
+    expect(screen.queryByText("Credits")).not.toBeInTheDocument();
+  });
+
+  test("Empty renders only when there is nothing to show", () => {
+    withContext(<MeteredFeatures.Empty>nothing</MeteredFeatures.Empty>, {
+      shouldShow: false,
+    });
+    expect(screen.getByText("nothing")).toBeInTheDocument();
+  });
+
+  test("useMeteredFeatures throws outside Root", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      render(<MeteredFeatures.Features>{() => null}</MeteredFeatures.Features>),
+    ).toThrow(/must be rendered inside/);
+    spy.mockRestore();
+  });
+});

--- a/react/src/components/composable/metered-features/context.tsx
+++ b/react/src/components/composable/metered-features/context.tsx
@@ -1,0 +1,124 @@
+// Headless controller + context for the MeteredFeatures primitive.
+//
+// Lifts the metered-feature filtering/ordering, credit-grant grouping, the
+// per-credit expand/collapse state, visibility gating, and the checkout
+// actions (add usage / buy credits).
+
+import * as React from "react";
+
+import {
+  FeatureType,
+  type FeatureUsageResponseData,
+} from "../../api/checkoutexternal";
+import { useEmbed } from "../../hooks";
+import { getSubscriptionPeriod, groupCreditGrants } from "../../utils";
+import { createPrimitiveContext } from "../internal";
+
+export type MeteredCreditGroup = ReturnType<typeof groupCreditGrants>[number];
+
+export interface MeteredFeaturesOptions {
+  /** Optional ordered allow-list of feature ids to show. */
+  visibleFeatures?: string[];
+}
+
+export interface MeteredFeaturesContextValue {
+  meteredFeatures: FeatureUsageResponseData[];
+  creditGroups: MeteredCreditGroup[];
+  /** Whether the component should render at all. */
+  shouldShow: boolean;
+  period?: string;
+  canCheckout: boolean;
+  showCredits: boolean;
+  isCreditExpanded: (id: string) => boolean;
+  toggleBalanceDetails: (id: string) => void;
+  /** Opens checkout for purchasing additional usage. */
+  addUsage: () => void;
+  /** Opens checkout for purchasing additional credits. */
+  buyCredits: () => void;
+}
+
+const [
+  MeteredFeaturesProvider,
+  useMeteredFeaturesContext,
+  MeteredFeaturesContext,
+] = createPrimitiveContext<MeteredFeaturesContextValue>("MeteredFeatures");
+
+export { MeteredFeaturesContext, MeteredFeaturesProvider };
+
+/** Consumer-facing hook. Throws outside `MeteredFeatures.Root`. */
+export function useMeteredFeatures(): MeteredFeaturesContextValue {
+  return useMeteredFeaturesContext("useMeteredFeatures");
+}
+
+export function useMeteredFeaturesController(
+  options: MeteredFeaturesOptions,
+): MeteredFeaturesContextValue {
+  const { visibleFeatures } = options;
+
+  const { data, setCheckoutState } = useEmbed();
+
+  const meteredFeatures = React.useMemo(() => {
+    const orderedFeatureUsage = visibleFeatures?.reduce(
+      (acc: FeatureUsageResponseData[], id) => {
+        const mappedFeatureUsage = data?.featureUsage?.features.find(
+          (usage) => usage.feature?.id === id,
+        );
+
+        if (mappedFeatureUsage) {
+          acc.push(mappedFeatureUsage);
+        }
+
+        return acc;
+      },
+      [],
+    );
+
+    return (orderedFeatureUsage || data?.featureUsage?.features || []).filter(
+      ({ feature }) =>
+        feature?.featureType === FeatureType.Event ||
+        feature?.featureType === FeatureType.Trait,
+    );
+  }, [visibleFeatures, data?.featureUsage?.features]);
+
+  const creditGroups = React.useMemo(
+    () => groupCreditGrants(data?.creditGrants || [], { groupBy: "credit" }),
+    [data?.creditGrants],
+  );
+
+  const [creditVisibility, setCreditVisibility] = React.useState(
+    creditGroups.map(({ id }) => ({ id, isExpanded: false })),
+  );
+
+  const toggleBalanceDetails = React.useCallback((id: string) => {
+    setCreditVisibility((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, isExpanded: !item.isExpanded } : item,
+      ),
+    );
+  }, []);
+
+  const isCreditExpanded = React.useCallback(
+    (id: string) =>
+      creditVisibility.find((item) => item.id === id)?.isExpanded ?? false,
+    [creditVisibility],
+  );
+
+  const period =
+    getSubscriptionPeriod(data?.company?.billingSubscription) ??
+    (typeof data?.company?.plan?.planPeriod === "string"
+      ? data.company?.plan?.planPeriod
+      : undefined);
+
+  return {
+    meteredFeatures,
+    creditGroups,
+    shouldShow: meteredFeatures.length > 0 || creditGroups.length > 0,
+    period,
+    canCheckout: data?.capabilities?.checkout ?? false,
+    showCredits: data?.displaySettings?.showCredits ?? true,
+    isCreditExpanded,
+    toggleBalanceDetails,
+    addUsage: () => setCheckoutState({ usage: true }),
+    buyCredits: () => setCheckoutState({ credits: true }),
+  };
+}

--- a/react/src/components/composable/metered-features/index.tsx
+++ b/react/src/components/composable/metered-features/index.tsx
@@ -1,0 +1,121 @@
+// MeteredFeatures composable namespace.
+//
+//   <MeteredFeatures.Root visibleFeatures={[…]}>
+//     <MeteredFeatures.Features>
+//       {(entitlement) => …}
+//     </MeteredFeatures.Features>
+//     <MeteredFeatures.Credits>
+//       {(credit, { expanded, toggle }) => …}
+//     </MeteredFeatures.Credits>
+//   </MeteredFeatures.Root>
+
+import * as React from "react";
+
+import { type FeatureUsageResponseData } from "../../api/checkoutexternal";
+
+import {
+  MeteredFeaturesProvider,
+  useMeteredFeatures,
+  useMeteredFeaturesController,
+  type MeteredCreditGroup,
+  type MeteredFeaturesOptions,
+} from "./context";
+
+export interface MeteredFeaturesRootProps extends MeteredFeaturesOptions {
+  children?: React.ReactNode;
+}
+
+/** Pure provider — runs the controller and publishes context. */
+function Root({ children, ...options }: MeteredFeaturesRootProps) {
+  const value = useMeteredFeaturesController(options);
+  const memoized = React.useMemo(
+    () => value,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      value.meteredFeatures,
+      value.creditGroups,
+      value.shouldShow,
+      value.period,
+      value.canCheckout,
+      value.showCredits,
+      value.isCreditExpanded,
+    ],
+  );
+  return (
+    <MeteredFeaturesProvider value={memoized}>
+      {children}
+    </MeteredFeaturesProvider>
+  );
+}
+Root.displayName = "MeteredFeatures.Root";
+
+/** Renders children only when there are metered features or credits to show. */
+function Empty({ children }: { children?: React.ReactNode }) {
+  const { shouldShow } = useMeteredFeatures();
+  return shouldShow ? null : <>{children}</>;
+}
+Empty.displayName = "MeteredFeatures.Empty";
+
+/** Maps over the metered features, calling the render-prop for each. */
+function Features({
+  children,
+}: {
+  children: (
+    entitlement: FeatureUsageResponseData,
+    index: number,
+  ) => React.ReactNode;
+}) {
+  const { meteredFeatures } = useMeteredFeatures();
+  return <>{meteredFeatures.map((feature, index) => children(feature, index))}</>;
+}
+Features.displayName = "MeteredFeatures.Features";
+
+/**
+ * Maps over the credit groups (only when `showCredits` is enabled), exposing
+ * each group's expand/collapse state.
+ */
+function Credits({
+  children,
+}: {
+  children: (
+    credit: MeteredCreditGroup,
+    state: { expanded: boolean; toggle: () => void },
+    index: number,
+  ) => React.ReactNode;
+}) {
+  const { creditGroups, showCredits, isCreditExpanded, toggleBalanceDetails } =
+    useMeteredFeatures();
+  if (!showCredits) {
+    return null;
+  }
+  return (
+    <>
+      {creditGroups.map((credit, index) =>
+        children(
+          credit,
+          {
+            expanded: isCreditExpanded(credit.id),
+            toggle: () => toggleBalanceDetails(credit.id),
+          },
+          index,
+        ),
+      )}
+    </>
+  );
+}
+Credits.displayName = "MeteredFeatures.Credits";
+
+export const MeteredFeatures = Object.assign(Root, {
+  Root,
+  Empty,
+  Features,
+  Credits,
+});
+
+export {
+  MeteredFeaturesContext,
+  useMeteredFeatures,
+  type MeteredCreditGroup,
+  type MeteredFeaturesContextValue,
+  type MeteredFeaturesOptions,
+} from "./context";

--- a/react/src/components/composable/plan-manager/PlanManager.composable.test.tsx
+++ b/react/src/components/composable/plan-manager/PlanManager.composable.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import {
+  PlanManager,
+  PlanManagerContext,
+  type PlanManagerContextValue,
+} from ".";
+
+function baseValue(
+  overrides: Partial<PlanManagerContextValue> = {},
+): PlanManagerContextValue {
+  return {
+    currentPlan: undefined,
+    currentAddOns: [],
+    creditBundles: [],
+    creditGroups: { plan: [], bundles: [], promotional: [] },
+    billingSubscription: undefined,
+    canCheckout: true,
+    postTrialPlan: undefined,
+    featureUsage: [],
+    usageBasedEntitlements: [],
+    showCredits: true,
+    showZeroPriceAsFree: false,
+    trialPaymentMethodRequired: false,
+    scheduledDowngrade: undefined,
+    subscriptionInterval: undefined,
+    subscriptionCurrency: undefined,
+    willSubscriptionCancel: false,
+    isTrialSubscription: false,
+    currentPlanPeriod: undefined,
+    isFreePlan: false,
+    isUsageBasedPlan: false,
+    hasAutoTopupSelfService: false,
+    customPlanBilling: undefined,
+    trialEnd: {},
+    changePlan: vi.fn(),
+    editAutoTopup: vi.fn(),
+    ...overrides,
+  } as PlanManagerContextValue;
+}
+
+function withContext(
+  ui: React.ReactNode,
+  overrides: Partial<PlanManagerContextValue> = {},
+) {
+  return render(
+    <PlanManagerContext.Provider value={baseValue(overrides)}>
+      {ui}
+    </PlanManagerContext.Provider>,
+  );
+}
+
+describe("PlanManager primitives", () => {
+  test("AddOns maps over current add-ons", () => {
+    withContext(
+      <PlanManager.AddOns>
+        {(addOn) => <div key={addOn.id}>{addOn.name}</div>}
+      </PlanManager.AddOns>,
+      {
+        currentAddOns: [
+          { id: "a1", name: "Add-on 1" },
+        ] as PlanManagerContextValue["currentAddOns"],
+      },
+    );
+    expect(screen.getByText("Add-on 1")).toBeInTheDocument();
+  });
+
+  test("ChangePlanTrigger calls changePlan and gates on canCheckout", () => {
+    const changePlan = vi.fn();
+    const { rerender } = withContext(
+      <PlanManager.ChangePlanTrigger>Change</PlanManager.ChangePlanTrigger>,
+      { changePlan },
+    );
+
+    fireEvent.click(screen.getByText("Change"));
+    expect(changePlan).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <PlanManagerContext.Provider value={baseValue({ canCheckout: false })}>
+        <PlanManager.ChangePlanTrigger>Change</PlanManager.ChangePlanTrigger>
+      </PlanManagerContext.Provider>,
+    );
+    expect(screen.queryByText("Change")).not.toBeInTheDocument();
+  });
+
+  test("Credits exposes the grouped credits and gates on showCredits", () => {
+    withContext(
+      <PlanManager.Credits>
+        {({ plan }) => <span>plan-credits:{plan.length}</span>}
+      </PlanManager.Credits>,
+      {
+        creditGroups: {
+          plan: [
+            {} as PlanManagerContextValue["creditGroups"]["plan"][number],
+          ],
+          bundles: [],
+          promotional: [],
+        },
+      },
+    );
+    expect(screen.getByText("plan-credits:1")).toBeInTheDocument();
+  });
+
+  test("usePlanManager throws outside Root", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      render(<PlanManager.AddOns>{() => null}</PlanManager.AddOns>),
+    ).toThrow(/must be rendered inside/);
+    spy.mockRestore();
+  });
+});

--- a/react/src/components/composable/plan-manager/context.tsx
+++ b/react/src/components/composable/plan-manager/context.tsx
@@ -1,0 +1,208 @@
+// Headless controller + context for the PlanManager primitive.
+//
+// Lifts the (substantial) derived state the container owned: current plan /
+// add-ons / credit groupings, subscription interval & status flags, trial and
+// custom-plan billing notices, and the change-plan / edit-auto-topup actions.
+
+import * as React from "react";
+
+import { BillingCreditGrantReason } from "../../api/checkoutexternal";
+import {
+  useCustomPlanBilling,
+  useEmbed,
+  useTrialEnd,
+} from "../../hooks";
+import type { CreditWithCompanyContext } from "../../types";
+import { getSubscriptionPeriod, groupCreditGrants } from "../../utils";
+import { createPrimitiveContext } from "../internal";
+
+type EmbedData = NonNullable<ReturnType<typeof useEmbed>["data"]>;
+type Company = NonNullable<EmbedData["company"]>;
+type FeatureUsage = NonNullable<EmbedData["featureUsage"]>["features"][number];
+
+export interface PlanManagerCreditGroups {
+  plan: CreditWithCompanyContext[];
+  bundles: CreditWithCompanyContext[];
+  promotional: CreditWithCompanyContext[];
+}
+
+export interface PlanManagerContextValue {
+  currentPlan?: Company["plan"];
+  currentAddOns: Company["addOns"];
+  creditBundles: EmbedData["creditBundles"];
+  creditGroups: PlanManagerCreditGroups;
+  billingSubscription?: Company["billingSubscription"];
+  canCheckout: boolean;
+  postTrialPlan?: EmbedData["postTrialPlan"];
+  featureUsage: FeatureUsage[];
+  usageBasedEntitlements: FeatureUsage[];
+  showCredits: boolean;
+  showZeroPriceAsFree: boolean;
+  trialPaymentMethodRequired: boolean;
+  scheduledDowngrade?: Company["scheduledDowngrade"];
+  subscriptionInterval?: string;
+  subscriptionCurrency?: string;
+  willSubscriptionCancel: boolean;
+  isTrialSubscription: boolean;
+  currentPlanPeriod?: string;
+  isFreePlan: boolean;
+  isUsageBasedPlan: boolean;
+  hasAutoTopupSelfService: boolean;
+  customPlanBilling: ReturnType<typeof useCustomPlanBilling>;
+  trialEnd: ReturnType<typeof useTrialEnd>;
+  /** Opens the checkout layout to change plan. */
+  changePlan: () => void;
+  /** Opens checkout to edit auto top-up settings. */
+  editAutoTopup: () => void;
+}
+
+const [PlanManagerProvider, usePlanManagerContext, PlanManagerContext] =
+  createPrimitiveContext<PlanManagerContextValue>("PlanManager");
+
+export { PlanManagerContext, PlanManagerProvider };
+
+/** Consumer-facing hook. Throws outside `PlanManager.Root`. */
+export function usePlanManager(): PlanManagerContextValue {
+  return usePlanManagerContext("usePlanManager");
+}
+
+export function usePlanManagerController(): PlanManagerContextValue {
+  const { data, setCheckoutState, setLayout } = useEmbed();
+
+  const trialEnd = useTrialEnd();
+  const customPlanBilling = useCustomPlanBilling();
+
+  const {
+    currentPlan,
+    currentAddOns,
+    creditBundles,
+    creditGroups,
+    billingSubscription,
+    canCheckout,
+    postTrialPlan,
+    featureUsage,
+    showCredits,
+    showZeroPriceAsFree,
+    trialPaymentMethodRequired,
+  } = React.useMemo(() => {
+    return {
+      currentPlan: data?.company?.plan,
+      currentAddOns: data?.company?.addOns || [],
+      creditBundles: data?.creditBundles || [],
+      creditGroups: groupCreditGrants(data?.creditGrants || [], {
+        groupBy: "bundle",
+      }).reduce(
+        (acc: PlanManagerCreditGroups, grant) => {
+          switch (grant.grantReason) {
+            case BillingCreditGrantReason.Plan:
+              acc.plan.push(grant);
+              break;
+            case BillingCreditGrantReason.Purchased:
+              acc.bundles.push(grant);
+              break;
+            case BillingCreditGrantReason.Free:
+              acc.promotional.push(grant);
+          }
+
+          return acc;
+        },
+        { plan: [], bundles: [], promotional: [] },
+      ),
+      billingSubscription: data?.company?.billingSubscription,
+      canCheckout: data?.capabilities?.checkout ?? false,
+      postTrialPlan: data?.postTrialPlan,
+      featureUsage: data?.featureUsage?.features || [],
+      trialPaymentMethodRequired: data?.trialPaymentMethodRequired ?? false,
+      showCredits: data?.displaySettings?.showCredits ?? true,
+      showZeroPriceAsFree: data?.displaySettings?.showZeroPriceAsFree ?? false,
+    };
+  }, [
+    data?.capabilities?.checkout,
+    data?.company?.addOns,
+    data?.company?.billingSubscription,
+    data?.company?.plan,
+    data?.creditBundles,
+    data?.creditGrants,
+    data?.featureUsage?.features,
+    data?.postTrialPlan,
+    data?.displaySettings?.showCredits,
+    data?.displaySettings?.showZeroPriceAsFree,
+    data?.trialPaymentMethodRequired,
+  ]);
+
+  const usageBasedEntitlements = React.useMemo(
+    () =>
+      featureUsage.filter((usage) => typeof usage.priceBehavior === "string"),
+    [featureUsage],
+  );
+
+  const {
+    subscriptionInterval,
+    subscriptionCurrency,
+    willSubscriptionCancel,
+    isTrialSubscription,
+  } = React.useMemo(() => {
+    const subscriptionInterval =
+      getSubscriptionPeriod(billingSubscription) ??
+      billingSubscription?.interval;
+    const subscriptionCurrency = billingSubscription?.currency;
+    const isTrialSubscription = billingSubscription?.status === "trialing";
+    const willSubscriptionCancel =
+      typeof billingSubscription?.cancelAt === "number" &&
+      billingSubscription?.cancelAtPeriodEnd === true;
+
+    return {
+      subscriptionInterval,
+      subscriptionCurrency,
+      isTrialSubscription,
+      willSubscriptionCancel,
+    };
+  }, [billingSubscription]);
+
+  const currentPlanPeriod =
+    getSubscriptionPeriod(billingSubscription) ??
+    currentPlan?.planPeriod ??
+    undefined;
+
+  const { isFreePlan, isUsageBasedPlan } = React.useMemo(() => {
+    const isFreePlan = currentPlan?.planPrice === 0;
+    const isUsageBasedPlan = isFreePlan && usageBasedEntitlements.length > 0;
+    return { isFreePlan, isUsageBasedPlan };
+  }, [currentPlan, usageBasedEntitlements]);
+
+  const hasAutoTopupSelfService =
+    currentPlan?.includedCreditGrants.some((grant) => {
+      return grant.billingCreditAutoTopupSelfService;
+    }) ?? false;
+
+  return {
+    currentPlan,
+    currentAddOns,
+    creditBundles,
+    creditGroups,
+    billingSubscription,
+    canCheckout,
+    postTrialPlan,
+    featureUsage,
+    usageBasedEntitlements,
+    showCredits,
+    showZeroPriceAsFree,
+    trialPaymentMethodRequired,
+    scheduledDowngrade: data?.company?.scheduledDowngrade,
+    subscriptionInterval,
+    subscriptionCurrency,
+    willSubscriptionCancel,
+    isTrialSubscription,
+    currentPlanPeriod,
+    isFreePlan,
+    isUsageBasedPlan,
+    hasAutoTopupSelfService,
+    customPlanBilling,
+    trialEnd,
+    changePlan: () => setLayout("checkout"),
+    editAutoTopup: () => {
+      setCheckoutState({ bypassPlanSelection: true });
+      setLayout("checkout");
+    },
+  };
+}

--- a/react/src/components/composable/plan-manager/index.tsx
+++ b/react/src/components/composable/plan-manager/index.tsx
@@ -1,0 +1,140 @@
+// PlanManager composable namespace.
+//
+//   <PlanManager.Root>
+//     <PlanManager.AddOns>{(addOn) => …}</PlanManager.AddOns>
+//     <PlanManager.UsageBasedEntitlements>{(ent) => …}</PlanManager.UsageBasedEntitlements>
+//     <PlanManager.Credits>{({ plan, bundles, promotional }) => …}</PlanManager.Credits>
+//     <PlanManager.ChangePlanTrigger>Change plan</PlanManager.ChangePlanTrigger>
+//   </PlanManager.Root>
+//
+// The header, trial/cancel/custom-billing notices, and other status display
+// are read directly from `usePlanManager()` (they are layout-specific enough
+// that a render-prop-per-section API would add little).
+
+import * as React from "react";
+
+import { Slot, partAttrs, type AsChildProps, type RenderProp } from "../internal";
+
+import {
+  PlanManagerProvider,
+  usePlanManager,
+  usePlanManagerController,
+  type PlanManagerCreditGroups,
+} from "./context";
+
+export interface PlanManagerRootProps {
+  children?: React.ReactNode;
+}
+
+/** Pure provider — runs the controller and publishes context. */
+function Root({ children }: PlanManagerRootProps) {
+  const value = usePlanManagerController();
+  const memoized = React.useMemo(
+    () => value,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      value.currentPlan,
+      value.currentAddOns,
+      value.creditGroups,
+      value.usageBasedEntitlements,
+      value.billingSubscription,
+      value.customPlanBilling,
+      value.trialEnd,
+      value.canCheckout,
+    ],
+  );
+  return <PlanManagerProvider value={memoized}>{children}</PlanManagerProvider>;
+}
+Root.displayName = "PlanManager.Root";
+
+/** Maps over the current add-ons, calling the render-prop for each. */
+function AddOns({
+  children,
+}: {
+  children: (
+    addOn: ReturnType<typeof usePlanManager>["currentAddOns"][number],
+    index: number,
+  ) => React.ReactNode;
+}) {
+  const { currentAddOns } = usePlanManager();
+  return <>{currentAddOns.map((addOn, index) => children(addOn, index))}</>;
+}
+AddOns.displayName = "PlanManager.AddOns";
+
+/** Maps over the usage-based entitlements, calling the render-prop for each. */
+function UsageBasedEntitlements({
+  children,
+}: {
+  children: (
+    entitlement: ReturnType<typeof usePlanManager>["usageBasedEntitlements"][number],
+    index: number,
+  ) => React.ReactNode;
+}) {
+  const { usageBasedEntitlements } = usePlanManager();
+  return (
+    <>
+      {usageBasedEntitlements.map((entitlement, index) =>
+        children(entitlement, index),
+      )}
+    </>
+  );
+}
+UsageBasedEntitlements.displayName = "PlanManager.UsageBasedEntitlements";
+
+/** Exposes the grouped plan/bundle/promotional credits via render prop. */
+function Credits({ children }: { children: RenderProp<PlanManagerCreditGroups> }) {
+  const { creditGroups, showCredits } = usePlanManager();
+  if (!showCredits) {
+    return null;
+  }
+  return <>{children(creditGroups)}</>;
+}
+Credits.displayName = "PlanManager.Credits";
+
+export type ChangePlanTriggerProps = AsChildProps<"button">;
+
+/**
+ * A button (or `asChild` element) that opens checkout to change plan. Renders
+ * nothing when checkout is unavailable.
+ */
+const ChangePlanTrigger = React.forwardRef<
+  HTMLButtonElement,
+  ChangePlanTriggerProps
+>(({ asChild, onClick, children, ...rest }, ref) => {
+  const { canCheckout, changePlan } = usePlanManager();
+  if (!canCheckout) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      ref={ref as React.Ref<never>}
+      type={asChild ? undefined : "button"}
+      {...partAttrs("change-plan-trigger")}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        (onClick as React.MouseEventHandler<HTMLButtonElement>)?.(event);
+        changePlan();
+      }}
+      {...rest}
+    >
+      {children}
+    </Comp>
+  );
+});
+ChangePlanTrigger.displayName = "PlanManager.ChangePlanTrigger";
+
+export const PlanManager = Object.assign(Root, {
+  Root,
+  AddOns,
+  UsageBasedEntitlements,
+  Credits,
+  ChangePlanTrigger,
+});
+
+export {
+  PlanManagerContext,
+  usePlanManager,
+  type PlanManagerContextValue,
+  type PlanManagerCreditGroups,
+} from "./context";

--- a/react/src/components/composable/unsubscribe-button/UnsubscribeButton.composable.test.tsx
+++ b/react/src/components/composable/unsubscribe-button/UnsubscribeButton.composable.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import {
+  UnsubscribeButton,
+  UnsubscribeButtonContext,
+  type UnsubscribeButtonContextValue,
+} from ".";
+
+function withContext(
+  ui: React.ReactNode,
+  overrides: Partial<UnsubscribeButtonContextValue> = {},
+) {
+  const value: UnsubscribeButtonContextValue = {
+    hasActiveSubscription: true,
+    unsubscribe: vi.fn(),
+    ...overrides,
+  };
+  return {
+    value,
+    ...render(
+      <UnsubscribeButtonContext.Provider value={value}>
+        {ui}
+      </UnsubscribeButtonContext.Provider>,
+    ),
+  };
+}
+
+describe("UnsubscribeButton primitives", () => {
+  test("Trigger invokes unsubscribe on click", () => {
+    const unsubscribe = vi.fn();
+    withContext(
+      <UnsubscribeButton.Trigger>Cancel</UnsubscribeButton.Trigger>,
+      { unsubscribe },
+    );
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test("Trigger supports asChild and emits the part attribute", () => {
+    withContext(
+      <UnsubscribeButton.Trigger asChild>
+        <a href="/x">Cancel</a>
+      </UnsubscribeButton.Trigger>,
+    );
+
+    const link = screen.getByRole("link", { name: "Cancel" });
+    expect(link).toHaveAttribute(
+      "data-schematic-part",
+      "unsubscribe-trigger",
+    );
+  });
+
+  test("useUnsubscribeButton throws outside Root", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      render(<UnsubscribeButton.Trigger>x</UnsubscribeButton.Trigger>),
+    ).toThrow(/must be rendered inside/);
+    spy.mockRestore();
+  });
+});

--- a/react/src/components/composable/unsubscribe-button/context.tsx
+++ b/react/src/components/composable/unsubscribe-button/context.tsx
@@ -1,0 +1,43 @@
+// Headless controller + context for the UnsubscribeButton primitive.
+
+import * as React from "react";
+
+import { useEmbed } from "../../hooks";
+import { createPrimitiveContext } from "../internal";
+
+export interface UnsubscribeButtonContextValue {
+  /** True when there is an active, non-cancelling subscription. */
+  hasActiveSubscription: boolean;
+  /** Opens the unsubscribe layout. */
+  unsubscribe: () => void;
+}
+
+const [
+  UnsubscribeButtonProvider,
+  useUnsubscribeButtonContext,
+  UnsubscribeButtonContext,
+] = createPrimitiveContext<UnsubscribeButtonContextValue>("UnsubscribeButton");
+
+export { UnsubscribeButtonContext, UnsubscribeButtonProvider };
+
+/** Consumer-facing hook. Throws outside `UnsubscribeButton.Root`. */
+export function useUnsubscribeButton(): UnsubscribeButtonContextValue {
+  return useUnsubscribeButtonContext("useUnsubscribeButton");
+}
+
+export function useUnsubscribeButtonController(): UnsubscribeButtonContextValue {
+  const { data, setLayout } = useEmbed();
+
+  const hasActiveSubscription = React.useMemo(
+    () =>
+      !!data?.subscription &&
+      data.subscription.status !== "cancelled" &&
+      !data.subscription.cancelAt,
+    [data?.subscription],
+  );
+
+  return {
+    hasActiveSubscription,
+    unsubscribe: () => setLayout("unsubscribe"),
+  };
+}

--- a/react/src/components/composable/unsubscribe-button/index.tsx
+++ b/react/src/components/composable/unsubscribe-button/index.tsx
@@ -1,0 +1,68 @@
+// UnsubscribeButton composable namespace.
+//
+//   <UnsubscribeButton.Root>
+//     <UnsubscribeButton.Trigger>Unsubscribe</UnsubscribeButton.Trigger>
+//   </UnsubscribeButton.Root>
+
+import * as React from "react";
+
+import { Slot, partAttrs, type AsChildProps } from "../internal";
+
+import {
+  UnsubscribeButtonProvider,
+  useUnsubscribeButton,
+  useUnsubscribeButtonController,
+} from "./context";
+
+export interface UnsubscribeButtonRootProps {
+  children?: React.ReactNode;
+}
+
+/** Pure provider — runs the controller and publishes context. */
+function Root({ children }: UnsubscribeButtonRootProps) {
+  const value = useUnsubscribeButtonController();
+  const memoized = React.useMemo(
+    () => value,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value.hasActiveSubscription],
+  );
+  return (
+    <UnsubscribeButtonProvider value={memoized}>
+      {children}
+    </UnsubscribeButtonProvider>
+  );
+}
+Root.displayName = "UnsubscribeButton.Root";
+
+export type TriggerProps = AsChildProps<"button">;
+
+/** A button (or `asChild` element) that opens the unsubscribe flow. */
+const Trigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
+  ({ asChild, onClick, children, ...rest }, ref) => {
+    const { unsubscribe } = useUnsubscribeButton();
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        ref={ref as React.Ref<never>}
+        type={asChild ? undefined : "button"}
+        {...partAttrs("unsubscribe-trigger")}
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          (onClick as React.MouseEventHandler<HTMLButtonElement>)?.(event);
+          unsubscribe();
+        }}
+        {...rest}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+Trigger.displayName = "UnsubscribeButton.Trigger";
+
+export const UnsubscribeButton = Object.assign(Root, { Root, Trigger });
+
+export {
+  UnsubscribeButtonContext,
+  useUnsubscribeButton,
+  type UnsubscribeButtonContextValue,
+} from "./context";

--- a/react/src/components/composable/upcoming-bill/UpcomingBill.composable.test.tsx
+++ b/react/src/components/composable/upcoming-bill/UpcomingBill.composable.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { type InvoiceResponseData } from "../../api/checkoutexternal";
+
+import {
+  UpcomingBill,
+  UpcomingBillContext,
+  type UpcomingBillContextValue,
+} from ".";
+
+const invoice = {
+  amountDue: 4200,
+  currency: "usd",
+} as InvoiceResponseData;
+
+function withContext(
+  ui: React.ReactNode,
+  overrides: Partial<UpcomingBillContextValue> = {},
+) {
+  const value: UpcomingBillContextValue = {
+    isVisible: true,
+    isLoading: false,
+    error: undefined,
+    upcomingInvoice: invoice,
+    balances: [],
+    discounts: [],
+    retry: vi.fn(),
+    ...overrides,
+  };
+  return render(
+    <UpcomingBillContext.Provider value={value}>
+      {ui}
+    </UpcomingBillContext.Provider>,
+  );
+}
+
+describe("UpcomingBill primitives", () => {
+  test("Content exposes the invoice once loaded", () => {
+    withContext(
+      <UpcomingBill.Content>
+        {({ upcomingInvoice }) => (
+          <span>{upcomingInvoice?.amountDue ?? "none"}</span>
+        )}
+      </UpcomingBill.Content>,
+    );
+    expect(screen.getByText("4200")).toBeInTheDocument();
+  });
+
+  test("Loading gates on isLoading; Content hidden while loading", () => {
+    withContext(
+      <>
+        <UpcomingBill.Loading>loading…</UpcomingBill.Loading>
+        <UpcomingBill.Content>{() => <span>ready</span>}</UpcomingBill.Content>
+      </>,
+      { isLoading: true },
+    );
+    expect(screen.getByText("loading…")).toBeInTheDocument();
+    expect(screen.queryByText("ready")).not.toBeInTheDocument();
+  });
+
+  test("ErrorState exposes retry and hides Content on error", () => {
+    const retry = vi.fn();
+    withContext(
+      <>
+        <UpcomingBill.ErrorState>
+          {({ retry }) => <button onClick={retry}>retry</button>}
+        </UpcomingBill.ErrorState>
+        <UpcomingBill.Content>{() => <span>ready</span>}</UpcomingBill.Content>
+      </>,
+      { error: new Error("boom"), retry },
+    );
+
+    expect(screen.queryByText("ready")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("retry"));
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/react/src/components/composable/upcoming-bill/context.tsx
+++ b/react/src/components/composable/upcoming-bill/context.tsx
@@ -1,0 +1,135 @@
+// Headless controller + context for the UpcomingBill primitive.
+//
+// Lifts the container's data fetching (upcoming invoice + customer balances),
+// loading/error state, discount derivation, and visibility gating.
+//
+// The fetch-on-mount and preview-data-sync effects (and the discounts memo)
+// are ported verbatim from the original `UpcomingBill` component; the React
+// Compiler health rules below flag those intentional patterns, so they are
+// disabled here rather than restructured (which would risk behavior changes).
+/* eslint-disable react-hooks/set-state-in-effect, react-hooks/preserve-manual-memoization */
+
+import * as React from "react";
+
+import {
+  type CurrencyBalance,
+  type InvoiceResponseData,
+} from "../../api/checkoutexternal";
+import { useEmbed } from "../../hooks";
+import { ERROR_UNKNOWN, isError } from "../../utils";
+import { createPrimitiveContext } from "../internal";
+
+export interface UpcomingBillDiscount {
+  couponId: string;
+  customerFacingCode?: string;
+  currency?: string;
+  amountOff?: number;
+  percentOff?: number;
+  isActive: boolean;
+}
+
+export interface UpcomingBillContextValue {
+  /** False when there is no subscription, or it is scheduled to cancel. */
+  isVisible: boolean;
+  isLoading: boolean;
+  error?: Error;
+  upcomingInvoice?: InvoiceResponseData;
+  balances: CurrencyBalance[];
+  discounts: UpcomingBillDiscount[];
+  /** Re-fetches the upcoming invoice. */
+  retry: () => void;
+}
+
+const [UpcomingBillProvider, useUpcomingBillContext, UpcomingBillContext] =
+  createPrimitiveContext<UpcomingBillContextValue>("UpcomingBill");
+
+export { UpcomingBillContext, UpcomingBillProvider };
+
+/** Consumer-facing hook. Throws outside `UpcomingBill.Root`. */
+export function useUpcomingBill(): UpcomingBillContextValue {
+  return useUpcomingBillContext("useUpcomingBill");
+}
+
+export function useUpcomingBillController(): UpcomingBillContextValue {
+  const { data, debug, getUpcomingInvoice, getCustomerBalance } = useEmbed();
+
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+  const [upcomingInvoice, setUpcomingInvoice] = React.useState<
+    InvoiceResponseData | undefined
+  >(data?.upcomingInvoice);
+  const [balances, setBalances] = React.useState<CurrencyBalance[]>([]);
+
+  const discounts = React.useMemo<UpcomingBillDiscount[]>(
+    () =>
+      (data?.subscription?.discounts || []).map((discount) => ({
+        couponId: discount.couponId,
+        customerFacingCode: discount.customerFacingCode || undefined,
+        currency: discount.currency || undefined,
+        amountOff: discount.amountOff ?? undefined,
+        percentOff: discount.percentOff ?? undefined,
+        isActive: discount.isActive,
+      })),
+    [data?.subscription?.discounts],
+  );
+
+  const getInvoice = React.useCallback(async () => {
+    if (
+      data?.component?.id &&
+      data?.subscription &&
+      !data.subscription.cancelAt
+    ) {
+      try {
+        setError(undefined);
+        setIsLoading(true);
+
+        const response = await getUpcomingInvoice(data.component.id);
+
+        if (response) {
+          setUpcomingInvoice(response.data);
+        }
+      } catch (err) {
+        setError(isError(err) ? err : ERROR_UNKNOWN);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  }, [data?.component?.id, data?.subscription, getUpcomingInvoice]);
+
+  const getBalances = React.useCallback(async () => {
+    try {
+      const response = await getCustomerBalance();
+
+      if (response) {
+        setBalances(response.data.balances);
+      }
+    } catch (err) {
+      debug("Failed to fetch customer balance.", err);
+    }
+  }, [debug, getCustomerBalance]);
+
+  React.useEffect(() => {
+    getInvoice();
+  }, [getInvoice]);
+
+  React.useEffect(() => {
+    getBalances();
+  }, [getBalances]);
+
+  // Keep in sync with preview/shared data updates.
+  React.useEffect(() => {
+    if (data?.upcomingInvoice) {
+      setUpcomingInvoice(data.upcomingInvoice);
+    }
+  }, [data?.upcomingInvoice]);
+
+  return {
+    isVisible: !!data?.subscription && !data.subscription.cancelAt,
+    isLoading,
+    error,
+    upcomingInvoice,
+    balances,
+    discounts,
+    retry: getInvoice,
+  };
+}

--- a/react/src/components/composable/upcoming-bill/index.tsx
+++ b/react/src/components/composable/upcoming-bill/index.tsx
@@ -1,0 +1,101 @@
+// UpcomingBill composable namespace.
+//
+//   <UpcomingBill.Root>
+//     <UpcomingBill.Loading>…</UpcomingBill.Loading>
+//     <UpcomingBill.ErrorState>{({ retry }) => …}</UpcomingBill.ErrorState>
+//     <UpcomingBill.Content>
+//       {({ upcomingInvoice, balances, discounts }) => …}
+//     </UpcomingBill.Content>
+//   </UpcomingBill.Root>
+
+import * as React from "react";
+
+import {
+  type CurrencyBalance,
+  type InvoiceResponseData,
+} from "../../api/checkoutexternal";
+import { type RenderProp } from "../internal";
+
+import {
+  UpcomingBillProvider,
+  useUpcomingBill,
+  useUpcomingBillController,
+  type UpcomingBillDiscount,
+} from "./context";
+
+export interface UpcomingBillRootProps {
+  children?: React.ReactNode;
+}
+
+/** Pure provider — runs the controller and publishes context. */
+function Root({ children }: UpcomingBillRootProps) {
+  const value = useUpcomingBillController();
+  const memoized = React.useMemo(
+    () => value,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      value.isVisible,
+      value.isLoading,
+      value.error,
+      value.upcomingInvoice,
+      value.balances,
+      value.discounts,
+      value.retry,
+    ],
+  );
+  return <UpcomingBillProvider value={memoized}>{children}</UpcomingBillProvider>;
+}
+Root.displayName = "UpcomingBill.Root";
+
+/** Renders children only while the upcoming invoice is loading. */
+function Loading({ children }: { children?: React.ReactNode }) {
+  const { isLoading } = useUpcomingBill();
+  return isLoading ? <>{children}</> : null;
+}
+Loading.displayName = "UpcomingBill.Loading";
+
+/** Renders only when an error occurred; exposes `retry` via render prop. */
+function ErrorState({
+  children,
+}: {
+  children: RenderProp<{ error: Error; retry: () => void }>;
+}) {
+  const { error, retry } = useUpcomingBill();
+  return error ? <>{children({ error, retry })}</> : null;
+}
+ErrorState.displayName = "UpcomingBill.ErrorState";
+
+export interface UpcomingBillContentRenderProps {
+  upcomingInvoice?: InvoiceResponseData;
+  balances: CurrencyBalance[];
+  discounts: UpcomingBillDiscount[];
+}
+
+/** Renders the invoice details once loaded without error. */
+function Content({
+  children,
+}: {
+  children: RenderProp<UpcomingBillContentRenderProps>;
+}) {
+  const { isLoading, error, upcomingInvoice, balances, discounts } =
+    useUpcomingBill();
+  if (isLoading || error) {
+    return null;
+  }
+  return <>{children({ upcomingInvoice, balances, discounts })}</>;
+}
+Content.displayName = "UpcomingBill.Content";
+
+export const UpcomingBill = Object.assign(Root, {
+  Root,
+  Loading,
+  ErrorState,
+  Content,
+});
+
+export {
+  UpcomingBillContext,
+  useUpcomingBill,
+  type UpcomingBillContextValue,
+  type UpcomingBillDiscount,
+} from "./context";


### PR DESCRIPTION
## Context

Follows the headless composable pilot (#1361). That PR established the pattern — a `usX()` controller hook + context, a pure-provider `Root`, headless parts, and a dot-notation namespace, with the styled `/components` exports becoming thin wrappers — on `PricingTable` and `PaymentMethod`. This PR rolls that pattern out to the remaining page components.

Every styled `/components` export stays a thin wrapper with **unchanged props, `sch-*` classNames, and `data-testid`s**.

## What's here (3 commits)

**1. Four more display components** (`ab2c3887`)
- `IncludedFeatures`, `Invoices`, `UpcomingBill`, `UnsubscribeButton`.
- `formatInvoices` relocated to the headless layer (pure) and re-exported from the styled file for backward compatibility.

**2. The two heaviest display components** (`cb9c7589`)
- `MeteredFeatures` — controller (feature filtering/ordering, credit-grant grouping, per-credit expand state, add-usage/buy-credits actions) + `Features`/`Credits`/`Empty` parts.
- `PlanManager` — controller lifts the container's substantial derived state (plan/add-ons/credit groupings, subscription status flags, trial/custom-billing notices, change-plan/edit-auto-topup actions) + `AddOns`/`UsageBasedEntitlements`/`Credits`/`ChangePlanTrigger` parts.

**3. CheckoutDialog open/close seam** (`27cdbcff`)
- Minimal by design: CheckoutDialog is a ~1875-line checkout state machine (preview engine, Stripe confirmation, native `<dialog>`) that is the product itself. Only the dialog lifecycle is exposed — `useCheckoutDialog()` → `{ isOpen, close }` + `CheckoutDialog.Close` — both derivable from `useEmbed` alone, so the state machine stays entirely in the styled wrapper.
- `SchematicEmbed` is intentionally left as-is (AST renderer + styled `ThemeContext` guard make a headless split low-value). Documented in `react/CLAUDE.md`.

## Coverage

Fully decomposed: `PricingTable`, `PaymentMethod`, `IncludedFeatures`, `Invoices`, `UpcomingBill`, `UnsubscribeButton`, `MeteredFeatures`, `PlanManager`. Seam-only: `CheckoutDialog`. Not decomposed: `SchematicEmbed`.

## Notes

- The two data-fetching controllers (`UpcomingBill`, `Invoices`) carry scoped `eslint-disable` comments for the React Compiler `set-state-in-effect` / `preserve-manual-memoization` rules — their fetch/sync effects are ported verbatim from the originals; restructuring would risk behavior changes.
- All new namespaces flow through the single `/composable` esbuild bundle (no build wiring changes beyond exports).

## Verification

- `yarn tsc` — clean
- `yarn lint` — clean
- `yarn test` — 405 passed / 3 skipped (40 files); existing `Invoices.test.ts` (`formatInvoices`) passes unchanged
- `yarn build:bundles && yarn check:tree-shake` — root and `/composable` bundles clean of styled-components/Stripe/i18next/icons
- api-extractor `/composable` rollup succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)