### PR TITLE
chore(deps): bump @angular packages to 21.2.17

### DIFF
--- a/angular/yarn.lock
+++ b/angular/yarn.lock
@@ -11,9 +11,9 @@
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@angular/compiler-cli@^21.2.0":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-21.2.9.tgz#844aae9c7a349f1d1e7faeefacca1c2b079e5132"
-  integrity sha512-hTTW/OiqTXrwTneS18CMp47OX0XSbLYl2rIomLS3nXVJniSETH6S/k+LqQtGWWgLbzsd3PzUOOckHnvzpTBTsA==
+  version "21.2.17"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-21.2.17.tgz#1667d9d3ac39d63ff216dd3a85fc5b37d83146eb"
+  integrity sha512-KithZ3b0HBFH0NbUcswBcjpN9y09vLbarMD7qmGWTnGUBk4W8cn4sbT8zJyv9CRKg9ZcuUBeJYKUfUPn/u/5OQ==
   dependencies:
     "@babel/core" "7.29.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -25,16 +25,16 @@
     yargs "^18.0.0"
 
 "@angular/compiler@^21.2.0":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-21.2.9.tgz#3341cc894dda43cfa948f3d946fadabc9a0fb147"
-  integrity sha512-clsK1EsSPtAuqlRl4CciA/gsvsW7xe0eWcvHxtrMW6DYaUJ6X4AAuDxEEJ5cf/3Mpw4s8KssjIUPPtbrUIGLSQ==
+  version "21.2.17"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-21.2.17.tgz#581c32d5b2788fced368b32793702043295a562a"
+  integrity sha512-p+NdjYiwAz9Zmu2yul0LlMXaFjMISVVa24+/MVMoKFeQeI82QE8jDywPlnOSHQHvdCcQVpS7saeEriZzX3JuBQ==
   dependencies:
     tslib "^2.3.0"
 
 "@angular/core@^21.2.0":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-21.2.9.tgz#a5e6b48f5c2df741c7890bf35b67209c540bb4c5"
-  integrity sha512-uZLq2aedJ+0uEZxyf6a1Nc7y1aZ7akAW7K1Kon8JUDZOvI2IDbk0i00MzkELt8q9uSmSSqg9zNKuhjspFf0Pyw==
+  version "21.2.17"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-21.2.17.tgz#cbed1509afd41422ef09539be0fb5cf5755e2b18"
+  integrity sha512-wYHpwIdnUnjQFOJJNqRcGx7LS3u64jT+R9L0TnMR/ViBM9dQgGYImlSikkftg2yrFCNo5aKRxhG2LLskQurVdg==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
Bumps `@angular/core`, `@angular/compiler`, `@angular/compiler-cli` → 21.2.17 (hydration DOM clobbering + sanitization-bypass XSS).