### PR TITLE
Stream credit balances to schematic-js

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -88,14 +88,11 @@ schematic.cleanup();
 
 ### Credit balances
 
-In websocket mode, the client also tracks the company's lease-aware credit balances, keyed by credit ID. These update in real time as balances change — including while a credit lease is open, when the raw `remaining` value would otherwise read stale.
+In websocket mode, the client also tracks the company's credit balances, keyed by credit ID, updating in real time as balances change:
 
 ```typescript
-// Read the balance for a single credit type
+// Read the balance for a single credit, or all balances for the current context
 const balance = schematic.getCreditBalance("credit-id");
-// => { settled, remaining, reserved } | undefined
-
-// Or read all credit balances for the current context, keyed by credit ID
 const balances = schematic.getCreditBalances();
 
 // Subscribe to balance changes
@@ -104,7 +101,7 @@ const unsubscribe = schematic.addCreditBalanceListener((balances) => {
 });
 ```
 
-Each balance has three fields: `settled` (the spendable balance including any open lease hold, i.e. `remaining + reserved` — the number to display to end users), `remaining` (available to fund new consumption, excluding any open lease hold), and `reserved` (the amount held by an open lease, `0` when none is open).
+`settled` is the spendable balance and the number to display to end users.
 
 ## Fallback Behavior
 

--- a/js/README.md
+++ b/js/README.md
@@ -86,6 +86,26 @@ await schematic.checkFlag("some-flag-key");
 schematic.cleanup();
 ```
 
+### Credit balances
+
+In websocket mode, the client also tracks the company's lease-aware credit balances, keyed by credit ID. These update in real time as balances change — including while a credit lease is open, when the raw `remaining` value would otherwise read stale.
+
+```typescript
+// Read the balance for a single credit type
+const balance = schematic.getCreditBalance("credit-id");
+// => { settled, remaining, reserved } | undefined
+
+// Or read all credit balances for the current context, keyed by credit ID
+const balances = schematic.getCreditBalances();
+
+// Subscribe to balance changes
+const unsubscribe = schematic.addCreditBalanceListener((balances) => {
+    console.log(balances["credit-id"]?.settled);
+});
+```
+
+Each balance has three fields: `settled` (the spendable balance including any open lease hold, i.e. `remaining + reserved` — the number to display to end users), `remaining` (available to fund new consumption, excluding any open lease hold), and `reserved` (the amount held by an open lease, `0` when none is open).
+
 ## Fallback Behavior
 
 The SDK includes built-in fallback behavior you can use to ensure your application continues to function even when unable to reach Schematic (e.g., during service disruptions or network issues).

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-js",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "main": "dist/schematic.cjs.js",
   "module": "dist/schematic.esm.js",
   "types": "dist/schematic.d.ts",

--- a/js/src/cacheVersion.ts
+++ b/js/src/cacheVersion.ts
@@ -2,4 +2,4 @@
 // Hash of the structural shape of cached types; bumps automatically when any
 // of CachedFlagState, CachedContextEntry, CheckFlagReturn, or CheckPlanReturn
 // changes shape. See scripts/generate-cache-version.mjs for details.
-export const cacheVersion = "6edb2005";
+export const cacheVersion = "bb56e75d";

--- a/js/src/index.spec.ts
+++ b/js/src/index.spec.ts
@@ -5,6 +5,7 @@ import {
   CheckFlagReturnFromJSON,
   CheckPlanReturn,
   CheckPlanReturnFromJSON,
+  CreditBalancesFromJSON,
   RuleType,
   StoragePersister,
 } from "./types";
@@ -3158,6 +3159,237 @@ describe("CheckFlagReturnFromJSON", () => {
     expect(result.creditRemaining).toBeUndefined();
     expect(result.softLimit).toBeUndefined();
   });
+
+  it("should surface creditId, creditReserved, and creditSettled from entitlement", () => {
+    const result = CheckFlagReturnFromJSON({
+      flag: "test-flag",
+      value: true,
+      reason: "match",
+      entitlement: {
+        feature_id: "feat-1",
+        feature_key: "test-flag",
+        value_type: "credit",
+        credit_id: "credit-abc",
+        credit_remaining: 3442,
+        credit_reserved: 0,
+        credit_settled: 3442,
+      },
+    });
+
+    expect(result.creditId).toBe("credit-abc");
+    expect(result.creditRemaining).toBe(3442);
+    expect(result.creditReserved).toBe(0);
+    expect(result.creditSettled).toBe(3442);
+  });
+
+  it("should return undefined for credit fields when entitlement has null values", () => {
+    const result = CheckFlagReturnFromJSON({
+      flag: "test-flag",
+      value: true,
+      reason: "match",
+      entitlement: {
+        feature_id: "feat-1",
+        feature_key: "test-flag",
+        value_type: "boolean",
+        credit_id: null,
+        credit_reserved: null,
+        credit_settled: null,
+      },
+    });
+
+    expect(result.creditId).toBeUndefined();
+    expect(result.creditReserved).toBeUndefined();
+    expect(result.creditSettled).toBeUndefined();
+  });
+});
+
+describe("CreditBalancesFromJSON", () => {
+  it("should map a credit_balances payload keyed by credit ID", () => {
+    const result = CreditBalancesFromJSON({
+      "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+      "credit-xyz": { remaining: 100, reserved: 0, settled: 100 },
+    });
+
+    expect(result).toEqual({
+      "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+      "credit-xyz": { remaining: 100, reserved: 0, settled: 100 },
+    });
+  });
+
+  it("should coerce missing numeric fields to 0", () => {
+    const result = CreditBalancesFromJSON({
+      "credit-abc": { settled: 3442 },
+    });
+
+    expect(result["credit-abc"]).toEqual({
+      remaining: 0,
+      reserved: 0,
+      settled: 3442,
+    });
+  });
+
+  it("should return an empty map for null/undefined input", () => {
+    expect(CreditBalancesFromJSON(null)).toEqual({});
+    expect(CreditBalancesFromJSON(undefined)).toEqual({});
+  });
+});
+
+describe("Credit balances over WebSocket", () => {
+  const TEST_WS_URL = "ws://localhost:1234";
+  const FULL_WS_URL = `${TEST_WS_URL}/flags/bootstrap?apiKey=API_KEY`;
+  let mockServer: WebSocketServer;
+
+  const context = {
+    company: { companyId: "456" },
+    user: { userId: "123" },
+  };
+
+  beforeEach(() => {
+    mockServer?.stop();
+    mockServer = new WebSocketServer(FULL_WS_URL);
+  });
+
+  afterEach(async () => {
+    mockServer.stop();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+
+  it("should expose lease-aware credit balances from the DataStream", async () => {
+    // Repro from SCH-6526: 6000 grant, lease tracked to 2558. The streamed
+    // `remaining` froze at 0 mid-lease, but `settled` (spendable) is 3442.
+    mockServer.on("connection", (socket) => {
+      socket.on("message", () => {
+        socket.send(
+          JSON.stringify({
+            flags: [{ flag: "credits-feature", value: true }],
+            credit_balances: {
+              "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+            },
+          }),
+        );
+      });
+    });
+
+    const schematic = new Schematic("API_KEY", {
+      useWebSocket: true,
+      webSocketUrl: TEST_WS_URL,
+    });
+
+    await schematic.checkFlag({ key: "credits-feature", context });
+
+    const balance = schematic.getCreditBalance("credit-abc");
+    expect(balance).toEqual({ remaining: 0, reserved: 3442, settled: 3442 });
+    expect(balance?.settled).toBe(3442);
+
+    expect(schematic.getCreditBalances()).toEqual({
+      "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+    });
+
+    await schematic.cleanup();
+  });
+
+  it("should notify credit balance listeners on DataStream updates", async () => {
+    let sendUpdate: (() => void) | undefined;
+
+    mockServer.on("connection", (socket) => {
+      socket.on("message", () => {
+        socket.send(
+          JSON.stringify({
+            flags: [{ flag: "credits-feature", value: true }],
+            credit_balances: {
+              "credit-abc": { remaining: 3442, reserved: 0, settled: 3442 },
+            },
+          }),
+        );
+      });
+      sendUpdate = () =>
+        socket.send(
+          JSON.stringify({
+            credit_balances: {
+              "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+            },
+          }),
+        );
+    });
+
+    const schematic = new Schematic("API_KEY", {
+      useWebSocket: true,
+      webSocketUrl: TEST_WS_URL,
+    });
+
+    // Arity-1 listener so the dispatcher passes the balances value (an arity-0
+    // listener — like React's useSyncExternalStore subscriber — is notified
+    // with no args and reads state via the getter instead).
+    const listener = vi.fn((balances: unknown) => balances);
+    schematic.addCreditBalanceListener(listener);
+
+    await schematic.checkFlag({ key: "credits-feature", context });
+    expect(listener).toHaveBeenCalledWith({
+      "credit-abc": { remaining: 3442, reserved: 0, settled: 3442 },
+    });
+
+    // Simulate a credit_reserved partial arriving mid-lease
+    sendUpdate?.();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(schematic.getCreditBalance("credit-abc")?.settled).toBe(3442);
+    expect(schematic.getCreditBalance("credit-abc")?.reserved).toBe(3442);
+    expect(listener).toHaveBeenLastCalledWith({
+      "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+    });
+
+    await schematic.cleanup();
+  });
+
+  it("should merge partial credit_balances updates per credit ID", async () => {
+    let sendUpdate: (() => void) | undefined;
+
+    mockServer.on("connection", (socket) => {
+      socket.on("message", () => {
+        socket.send(
+          JSON.stringify({
+            flags: [{ flag: "credits-feature", value: true }],
+            credit_balances: {
+              "credit-abc": { remaining: 100, reserved: 0, settled: 100 },
+              "credit-xyz": { remaining: 50, reserved: 0, settled: 50 },
+            },
+          }),
+        );
+      });
+      sendUpdate = () =>
+        socket.send(
+          JSON.stringify({
+            credit_balances: {
+              "credit-abc": { remaining: 0, reserved: 100, settled: 100 },
+            },
+          }),
+        );
+    });
+
+    const schematic = new Schematic("API_KEY", {
+      useWebSocket: true,
+      webSocketUrl: TEST_WS_URL,
+    });
+
+    await schematic.checkFlag({ key: "credits-feature", context });
+
+    sendUpdate?.();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // The partial only touched credit-abc; credit-xyz must be retained.
+    expect(schematic.getCreditBalances()).toEqual({
+      "credit-abc": { remaining: 0, reserved: 100, settled: 100 },
+      "credit-xyz": { remaining: 50, reserved: 0, settled: 50 },
+    });
+
+    await schematic.cleanup();
+  });
+
+  it("should return undefined for an unknown credit ID and an empty map with no balances", () => {
+    const schematic = new Schematic("API_KEY", { offline: true });
+    expect(schematic.getCreditBalance("nope")).toBeUndefined();
+    expect(schematic.getCreditBalances()).toEqual({});
+  });
 });
 
 describe("Persistent flag state cache", () => {
@@ -3196,6 +3428,34 @@ describe("Persistent flag state cache", () => {
       const check = client.getFlagCheck("FEATURE_X");
       expect(check?.value).toBe(true);
       expect(check?.reason).toBe("cached");
+    });
+
+    it("hydrates credit balances for a matching context and exposes them on setContext", async () => {
+      const storage = createTestStorage({
+        [cacheKey]: JSON.stringify({
+          version: cacheVersion,
+          contexts: {
+            [contextString(ctxA)]: {
+              checks: {
+                FEATURE_X: { flag: "FEATURE_X", value: true, reason: "cached" },
+              },
+              creditBalances: {
+                "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+              },
+              updatedAt: Date.now(),
+            },
+          },
+        }),
+      });
+
+      const client = new Schematic("API_KEY", { storage });
+      await client.setContext(ctxA);
+
+      expect(client.getCreditBalance("credit-abc")).toEqual({
+        remaining: 0,
+        reserved: 3442,
+        settled: 3442,
+      });
     });
 
     it("does not expose cached values for a non-matching context", async () => {

--- a/js/src/index.spec.ts
+++ b/js/src/index.spec.ts
@@ -3216,15 +3216,22 @@ describe("CreditBalancesFromJSON", () => {
     });
   });
 
-  it("should coerce missing numeric fields to 0", () => {
+  it("should skip credits with missing/non-numeric fields rather than zero-fill", () => {
     const result = CreditBalancesFromJSON({
-      "credit-abc": { settled: 3442 },
+      // missing remaining/reserved
+      "credit-partial": { settled: 3442 },
+      // non-numeric field
+      "credit-bad": { remaining: "0", reserved: 0, settled: 0 },
+      // complete entry is retained
+      "credit-ok": { remaining: 100, reserved: 0, settled: 100 },
     });
 
-    expect(result["credit-abc"]).toEqual({
-      remaining: 0,
+    expect(result["credit-partial"]).toBeUndefined();
+    expect(result["credit-bad"]).toBeUndefined();
+    expect(result["credit-ok"]).toEqual({
+      remaining: 100,
       reserved: 0,
-      settled: 3442,
+      settled: 100,
     });
   });
 

--- a/js/src/index.spec.ts
+++ b/js/src/index.spec.ts
@@ -3385,6 +3385,105 @@ describe("Credit balances over WebSocket", () => {
     await schematic.cleanup();
   });
 
+  it("should not notify or churn references when a partial re-carries an unchanged balance", async () => {
+    let sendSame: (() => void) | undefined;
+
+    mockServer.on("connection", (socket) => {
+      socket.on("message", () => {
+        socket.send(
+          JSON.stringify({
+            flags: [{ flag: "credits-feature", value: true }],
+            credit_balances: {
+              "credit-abc": { remaining: 100, reserved: 0, settled: 100 },
+            },
+          }),
+        );
+      });
+      // A debounced credit_reserved partial that re-carries the identical value.
+      sendSame = () =>
+        socket.send(
+          JSON.stringify({
+            credit_balances: {
+              "credit-abc": { remaining: 100, reserved: 0, settled: 100 },
+            },
+          }),
+        );
+    });
+
+    const schematic = new Schematic("API_KEY", {
+      useWebSocket: true,
+      webSocketUrl: TEST_WS_URL,
+    });
+
+    const listener = vi.fn((balances: unknown) => balances);
+    schematic.addCreditBalanceListener(listener);
+
+    await schematic.checkFlag({ key: "credits-feature", context });
+    expect(listener).toHaveBeenCalledTimes(1);
+    const balanceRef = schematic.getCreditBalance("credit-abc");
+    const mapRef = schematic.getCreditBalances();
+
+    // An identical balance re-arrives: no notify, and the stored references are
+    // unchanged so useSyncExternalStore consumers don't re-render.
+    sendSame?.();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(schematic.getCreditBalance("credit-abc")).toBe(balanceRef);
+    expect(schematic.getCreditBalances()).toBe(mapRef);
+
+    await schematic.cleanup();
+  });
+
+  it("should retain unchanged credit references when a different credit changes", async () => {
+    let changeXyz: (() => void) | undefined;
+
+    mockServer.on("connection", (socket) => {
+      socket.on("message", () => {
+        socket.send(
+          JSON.stringify({
+            flags: [{ flag: "credits-feature", value: true }],
+            credit_balances: {
+              "credit-abc": { remaining: 100, reserved: 0, settled: 100 },
+              "credit-xyz": { remaining: 50, reserved: 0, settled: 50 },
+            },
+          }),
+        );
+      });
+      changeXyz = () =>
+        socket.send(
+          JSON.stringify({
+            credit_balances: {
+              "credit-xyz": { remaining: 25, reserved: 25, settled: 50 },
+            },
+          }),
+        );
+    });
+
+    const schematic = new Schematic("API_KEY", {
+      useWebSocket: true,
+      webSocketUrl: TEST_WS_URL,
+    });
+
+    await schematic.checkFlag({ key: "credits-feature", context });
+    const abcRef = schematic.getCreditBalance("credit-abc");
+
+    // A partial that only moves credit-xyz must not churn credit-abc's
+    // reference — a useSchematicCreditBalance("credit-abc") consumer should not
+    // re-render.
+    changeXyz?.();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(schematic.getCreditBalance("credit-abc")).toBe(abcRef);
+    expect(schematic.getCreditBalance("credit-xyz")).toEqual({
+      remaining: 25,
+      reserved: 25,
+      settled: 50,
+    });
+
+    await schematic.cleanup();
+  });
+
   it("should return undefined for an unknown credit ID and an empty map with no balances", () => {
     const schematic = new Schematic("API_KEY", { offline: true });
     expect(schematic.getCreditBalance("nope")).toBeUndefined();

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -602,18 +602,38 @@ export class Schematic {
       ) {
         const contextStr = contextString(context);
         const updates = CreditBalancesFromJSON(message.credit_balances);
-        const merged: CreditBalances = {
-          ...(this.creditBalances[contextStr] ?? {}),
-          ...updates,
-        };
-        this.creditBalances[contextStr] = merged;
+        const previous = this.creditBalances[contextStr] ?? {};
 
-        this.debug(
-          `WebSocket credit balance update received. Notifying listeners`,
-          { creditBalances: merged },
-        );
+        // Merge per-credit, but only swap in the new object when the value
+        // actually changed. Debounced credit_reserved partials can re-carry an
+        // identical balance; keeping the existing reference for unchanged
+        // credits preserves referential stability for useSyncExternalStore
+        // consumers and lets us skip the notify entirely when nothing moved.
+        let changed = false;
+        const merged: CreditBalances = { ...previous };
+        for (const [creditId, next] of Object.entries(updates)) {
+          const current = previous[creditId];
+          if (
+            current === undefined ||
+            current.remaining !== next.remaining ||
+            current.reserved !== next.reserved ||
+            current.settled !== next.settled
+          ) {
+            merged[creditId] = next;
+            changed = true;
+          }
+        }
 
-        this.notifyCreditBalanceListeners(merged);
+        if (changed) {
+          this.creditBalances[contextStr] = merged;
+
+          this.debug(
+            `WebSocket credit balance update received. Notifying listeners`,
+            { creditBalances: merged },
+          );
+
+          this.notifyCreditBalanceListeners(merged);
+        }
       }
 
       // Persist updated flag state for this context so the next page load

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -12,6 +12,11 @@ import {
   CheckPlanReturn,
   CheckPlanReturnFromJSON,
   CheckOptions,
+  CreditBalance,
+  CreditBalanceListenerFn,
+  CreditBalances,
+  CreditBalancesFromJSON,
+  CreditBalancesListenerFn,
   EmptyListenerFn,
   Event,
   EventBody,
@@ -41,6 +46,7 @@ const flagStateCacheDefaultMaxAgeMs = 7 * 24 * 60 * 60 * 1000;
 type CachedContextEntry = {
   checks: Record<string, CheckFlagReturn>;
   plan?: CheckPlanReturn;
+  creditBalances?: CreditBalances;
   updatedAt: number;
 };
 
@@ -48,6 +54,11 @@ type CachedFlagState = {
   version: string;
   contexts: Record<string, CachedContextEntry>;
 };
+
+// Shared stable empty reference returned by getCreditBalances() when a context
+// has no balances, so callers using it in React's useSyncExternalStore don't
+// see a new object on every render.
+const emptyCreditBalances: CreditBalances = Object.freeze({});
 
 /* @preserve */
 export class Schematic {
@@ -66,6 +77,7 @@ export class Schematic {
   private isPending: boolean = true;
   private isPendingListeners: Set<PendingListenerFn> = new Set();
   private planListeners: Set<PlanListenerFn> = new Set();
+  private creditBalanceListeners: Set<CreditBalanceListenerFn> = new Set();
   private storage: StoragePersister | undefined;
   private persistFlagState: boolean = true;
   private flagStateCacheKey: string;
@@ -81,6 +93,7 @@ export class Schematic {
     Record<string, CheckFlagReturn | undefined> | undefined
   > = {};
   private planChecks: Record<string, CheckPlanReturn | undefined> = {};
+  private creditBalances: Record<string, CreditBalances | undefined> = {};
   private webSocketUrl = "wss://api.schematichq.com";
   private webSocketConnectionTimeout = 10000;
   private webSocketReconnect = true;
@@ -580,6 +593,29 @@ export class Schematic {
         this.notifyPlanListeners(plan);
       }
 
+      // Lease-aware credit balances arrive keyed by credit ID. A message may
+      // carry only a subset of credit types (e.g. a debounced credit_reserved
+      // partial), so merge per-credit rather than replacing the whole map.
+      if (
+        message.credit_balances !== undefined &&
+        message.credit_balances !== null
+      ) {
+        const contextStr = contextString(context);
+        const updates = CreditBalancesFromJSON(message.credit_balances);
+        const merged: CreditBalances = {
+          ...(this.creditBalances[contextStr] ?? {}),
+          ...updates,
+        };
+        this.creditBalances[contextStr] = merged;
+
+        this.debug(
+          `WebSocket credit balance update received. Notifying listeners`,
+          { creditBalances: merged },
+        );
+
+        this.notifyCreditBalanceListeners(merged);
+      }
+
       // Persist updated flag state for this context so the next page load
       // can boot with these values rather than fallbacks
       this.persistContextToCache(contextString(context));
@@ -757,6 +793,10 @@ export class Schematic {
         const cachedPlan = this.planChecks[newContextStr];
         if (cachedPlan !== undefined) {
           this.notifyPlanListeners(cachedPlan);
+        }
+        const cachedCreditBalances = this.creditBalances[newContextStr];
+        if (cachedCreditBalances !== undefined) {
+          this.notifyCreditBalanceListeners(cachedCreditBalances);
         }
       } else {
         this.setIsPending(true);
@@ -1100,7 +1140,14 @@ export class Schematic {
     if (cachedChecks !== undefined && Object.keys(cachedChecks).length > 0) {
       return true;
     }
-    return this.planChecks[contextStr] !== undefined;
+    if (this.planChecks[contextStr] !== undefined) {
+      return true;
+    }
+    const cachedCreditBalances = this.creditBalances[contextStr];
+    return (
+      cachedCreditBalances !== undefined &&
+      Object.keys(cachedCreditBalances).length > 0
+    );
   };
 
   private readFlagStateCache = (): CachedFlagState | null => {
@@ -1180,6 +1227,32 @@ export class Schematic {
     return revived;
   };
 
+  private reviveCachedCreditBalances = (
+    raw: unknown,
+  ): CreditBalances | null => {
+    if (raw === null || typeof raw !== "object") return null;
+    const revived: CreditBalances = {};
+    for (const [creditId, value] of Object.entries(
+      raw as Record<string, unknown>,
+    )) {
+      if (value === null || typeof value !== "object") continue;
+      const obj = value as Record<string, unknown>;
+      if (
+        typeof obj.remaining !== "number" ||
+        typeof obj.reserved !== "number" ||
+        typeof obj.settled !== "number"
+      ) {
+        continue;
+      }
+      revived[creditId] = {
+        remaining: obj.remaining,
+        reserved: obj.reserved,
+        settled: obj.settled,
+      };
+    }
+    return Object.keys(revived).length > 0 ? revived : null;
+  };
+
   private hydrateFlagStateFromCache = (): void => {
     const parsed = this.readFlagStateCache();
     if (parsed === null) return;
@@ -1226,9 +1299,19 @@ export class Schematic {
         }
       }
 
+      let revivedCreditBalances: CreditBalances | undefined;
+      if (entry.creditBalances !== undefined && entry.creditBalances !== null) {
+        const balances = this.reviveCachedCreditBalances(entry.creditBalances);
+        if (balances !== null) {
+          revivedCreditBalances = balances;
+          this.creditBalances[contextStr] = balances;
+        }
+      }
+
       fresh[contextStr] = {
         checks: revivedChecks,
         plan: revivedPlan,
+        creditBalances: revivedCreditBalances,
         updatedAt: entry.updatedAt,
       };
       contextsLoaded += 1;
@@ -1243,7 +1326,12 @@ export class Schematic {
   private persistContextToCache = (contextStr: string): void => {
     const checksForContext = this.checks[contextStr];
     const planForContext = this.planChecks[contextStr];
-    if (checksForContext === undefined && planForContext === undefined) {
+    const creditBalancesForContext = this.creditBalances[contextStr];
+    if (
+      checksForContext === undefined &&
+      planForContext === undefined &&
+      creditBalancesForContext === undefined
+    ) {
       return;
     }
 
@@ -1268,6 +1356,7 @@ export class Schematic {
     this.cachedFlagState.contexts[contextStr] = {
       checks: cleanChecks,
       plan: planForContext,
+      creditBalances: creditBalancesForContext,
       updatedAt: Date.now(),
     };
 
@@ -1285,6 +1374,9 @@ export class Schematic {
       }
       for (const key of Object.keys(this.planChecks)) {
         if (!survivorKeys.has(key)) delete this.planChecks[key];
+      }
+      for (const key of Object.keys(this.creditBalances)) {
+        if (!survivorKeys.has(key)) delete this.creditBalances[key];
       }
 
       this.cachedFlagState = {
@@ -2101,6 +2193,20 @@ export class Schematic {
     return plan;
   };
 
+  /** Get the company's lease-aware credit balances for the current context, keyed by credit ID */
+  getCreditBalances = (): CreditBalances => {
+    const contextStr = contextString(this.context);
+    // Return a stable empty reference when absent so callers using this in
+    // React's useSyncExternalStore don't see a new object every render.
+    return this.creditBalances[contextStr] ?? emptyCreditBalances;
+  };
+
+  /** Get the company's lease-aware balance for a single credit type in the current context */
+  getCreditBalance = (creditId: string): CreditBalance | undefined => {
+    const contextStr = contextString(this.context);
+    return this.creditBalances[contextStr]?.[creditId];
+  };
+
   // flag checks state
   getFlagCheck = (flagKey: string): CheckFlagReturn | undefined => {
     const contextStr = contextString(this.context);
@@ -2187,6 +2293,15 @@ export class Schematic {
     };
   };
 
+  /** Register an event listener that will be notified with the company's credit balances (keyed by credit ID) whenever they change */
+  addCreditBalanceListener = (listener: CreditBalanceListenerFn) => {
+    this.creditBalanceListeners.add(listener);
+
+    return () => {
+      this.creditBalanceListeners.delete(listener);
+    };
+  };
+
   private notifyFlagCheckListeners = (
     flagKey: string,
     check: CheckFlagReturn,
@@ -2269,6 +2384,20 @@ export class Schematic {
       });
     });
   };
+
+  private notifyCreditBalanceListeners = (value: CreditBalances) => {
+    const listeners = this.creditBalanceListeners ?? [];
+
+    if (listeners.size > 0) {
+      this.debug(`Notifying ${listeners.size} credit balance listeners`, {
+        value,
+      });
+    }
+
+    listeners.forEach((listener) =>
+      notifyCreditBalanceListener(listener, value),
+    );
+  };
 }
 
 const notifyPendingListener = (listener: PendingListenerFn, value: boolean) => {
@@ -2307,6 +2436,17 @@ const notifyPlanListener = (
 ) => {
   if (listener.length > 0) {
     (listener as CheckPlanReturnListenerFn)(value);
+  } else {
+    (listener as EmptyListenerFn)();
+  }
+};
+
+const notifyCreditBalanceListener = (
+  listener: CreditBalanceListenerFn,
+  value: CreditBalances,
+) => {
+  if (listener.length > 0) {
+    (listener as CreditBalancesListenerFn)(value);
   } else {
     (listener as EmptyListenerFn)();
   }

--- a/js/src/types/index.ts
+++ b/js/src/types/index.ts
@@ -1,5 +1,6 @@
 import {
   CheckFlagResponseDataFromJSON,
+  CompanyCreditBalanceFromJSON,
   DatastreamCompanyPlanFromJSON,
 } from "./api/models";
 import { EventBodyFlagCheck } from "./api/models/EventBodyFlagCheck";
@@ -82,8 +83,14 @@ export type CheckFlagReturn = {
   featureUsageExceeded?: boolean;
   /** If company keys were provided and matched a company, its ID */
   companyId?: string;
-  /** If the company has a credit-based entitlement for this feature, the remaining credit amount */
+  /** If the company has a credit-based entitlement for this feature, the ID of the credit */
+  creditId?: string;
+  /** If the company has a credit-based entitlement for this feature, the credit available to fund new consumption excluding any open lease hold (the value lease-holding SDKs gate on) */
   creditRemaining?: number;
+  /** If the company has a credit-based entitlement for this feature, the unspent amount held by an open credit lease, 0 when none is open */
+  creditReserved?: number;
+  /** If the company has a credit-based entitlement for this feature, the spendable balance including any open lease hold (creditRemaining + creditReserved); the number to display to end users */
+  creditSettled?: number;
   /** If an error occurred while checking the flag, the error message */
   error?: string;
   /** If a numeric feature entitlement rule was matched, its allocation */
@@ -120,6 +127,19 @@ export type CheckPlanReturn = {
   trialEndDate?: Date;
   trialStatus?: TrialStatus;
 };
+
+/** A company's lease-aware balance for a single credit type */
+export type CreditBalance = {
+  /** Spendable balance including any open lease hold (remaining + reserved); the number to display to end users */
+  settled: number;
+  /** Remaining credit excluding any open lease hold (the value lease-holding SDKs gate on) */
+  remaining: number;
+  /** Amount held by the company's open credit lease, 0 when none is open */
+  reserved: number;
+};
+
+/** A company's lease-aware credit balances keyed by credit ID */
+export type CreditBalances = Record<string, CreditBalance>;
 
 /** Optional type for implementing custom client-side storage */
 export type StoragePersister = {
@@ -214,6 +234,10 @@ export type PendingListenerFn = BooleanListenerFn | EmptyListenerFn;
 export type CheckFlagReturnListenerFn = (value: CheckFlagReturn) => void;
 export type CheckPlanReturnListenerFn = (value: CheckPlanReturn) => void;
 export type PlanListenerFn = CheckPlanReturnListenerFn | EmptyListenerFn;
+export type CreditBalancesListenerFn = (value: CreditBalances) => void;
+export type CreditBalanceListenerFn =
+  | CreditBalancesListenerFn
+  | EmptyListenerFn;
 
 export const CheckFlagReturnFromJSON = (
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -253,10 +277,19 @@ export const CheckFlagReturnFromJSON = (
   return {
     featureUsageExceeded,
     companyId: companyId == null ? undefined : companyId,
+    creditId: entitlement?.creditId == null ? undefined : entitlement.creditId,
     creditRemaining:
       entitlement?.creditRemaining == null
         ? undefined
         : entitlement.creditRemaining,
+    creditReserved:
+      entitlement?.creditReserved == null
+        ? undefined
+        : entitlement.creditReserved,
+    creditSettled:
+      entitlement?.creditSettled == null
+        ? undefined
+        : entitlement.creditSettled,
     error: error == null ? undefined : error,
     featureAllocation:
       resolvedAllocation == null ? undefined : resolvedAllocation,
@@ -294,10 +327,35 @@ export const CheckPlanReturnFromJSON = (
   };
 };
 
+export const CreditBalancesFromJSON = (
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  json: any,
+): CreditBalances => {
+  if (json == null || typeof json !== "object") {
+    return {};
+  }
+
+  const balances: CreditBalances = {};
+  for (const [creditId, raw] of Object.entries(json)) {
+    if (raw == null || typeof raw !== "object") continue;
+    const { remaining, reserved, settled } = CompanyCreditBalanceFromJSON(raw);
+    // Tolerant reader: the stream always sends all three, but coerce any
+    // missing/non-numeric field to 0 so consumers only deal with numbers.
+    balances[creditId] = {
+      remaining: typeof remaining === "number" ? remaining : 0,
+      reserved: typeof reserved === "number" ? reserved : 0,
+      settled: typeof settled === "number" ? settled : 0,
+    };
+  }
+
+  return balances;
+};
+
 export type { EventBodyFlagCheck } from "./api/models/EventBodyFlagCheck";
 export { EventBodyFlagCheckToJSON } from "./api/models/EventBodyFlagCheck";
 export type { CheckFlagResponseData } from "./api/models/CheckFlagResponseData";
 export { CheckFlagResponseFromJSON } from "./api/models/CheckFlagResponse";
+export type { CompanyCreditBalance } from "./api/models/CompanyCreditBalance";
 export { CheckFlagsResponseFromJSON } from "./api/models/CheckFlagsResponse";
 export { DatastreamCompanyPlanFromJSON } from "./api/models/DatastreamCompanyPlan";
 export { TrialStatus } from "./api/models/TrialStatus";

--- a/js/src/types/index.ts
+++ b/js/src/types/index.ts
@@ -339,13 +339,21 @@ export const CreditBalancesFromJSON = (
   for (const [creditId, raw] of Object.entries(json)) {
     if (raw == null || typeof raw !== "object") continue;
     const { remaining, reserved, settled } = CompanyCreditBalanceFromJSON(raw);
-    // Tolerant reader: the stream always sends all three, but coerce any
-    // missing/non-numeric field to 0 so consumers only deal with numbers.
-    balances[creditId] = {
-      remaining: typeof remaining === "number" ? remaining : 0,
-      reserved: typeof reserved === "number" ? reserved : 0,
-      settled: typeof settled === "number" ? settled : 0,
-    };
+    // Tolerant reader: the stream is expected to send all three for a credit,
+    // but skip any entry that's missing/non-numeric rather than zero-filling. A
+    // fabricated 0 would read as a real (and wrong) balance — a false
+    // "exhausted" — and could violate settled = remaining + reserved. A true
+    // field-subset partial is skipped whole, not merged; either way the merge in
+    // index.ts preserves the credit's last good value. Matches the strict shape
+    // check in reviveCachedCreditBalances.
+    if (
+      typeof remaining !== "number" ||
+      typeof reserved !== "number" ||
+      typeof settled !== "number"
+    ) {
+      continue;
+    }
+    balances[creditId] = { remaining, reserved, settled };
   }
 
   return balances;

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.4.1';
+export const version = '1.5.0';


### PR DESCRIPTION
Prerequisite for SCH-6590 (`useSchematicCreditBalance` in schematic-react)