### PR TITLE
Add useSchematicCreditBalance hook to schematic-react

### DIFF
--- a/react/CLAUDE.md
+++ b/react/CLAUDE.md
@@ -63,6 +63,7 @@ The library is built on a React context pattern:
 2. Core Hooks:
    - `useSchematicFlag`: Check feature flag values
    - `useSchematicEntitlement`: Check entitlements with usage data
+   - `useSchematicCreditBalance`: Read a company's live, lease-aware credit balance by credit ID
    - `useSchematicEvents`: Track events and identify users/companies
    - `useSchematicIsPending`: Check if data is still loading
    - `useSchematicContext`: Access and modify context

--- a/react/README.md
+++ b/react/README.md
@@ -175,6 +175,46 @@ The hook returns an object with the following properties:
 | `trialEndDate` | `Date \| undefined` | The trial end date, if the company has or had a trial |
 | `trialStatus` | `"active" \| "expired" \| "converted" \| undefined` | The company's trial status: `active` if the trial is ongoing, `expired` if the trial ended without conversion, `converted` if the company converted to a paid plan, or `undefined` if the company has never trialed |
 
+### Credit balances
+
+To render a company's live, lease-aware credit balance, use the `useSchematicCreditBalance` hook. It is keyed by credit ID and updates reactively as balances change over the DataStream — including while a credit lease is open, when the raw `remaining` value would otherwise read stale or falsely "exhausted".
+
+By default the hook returns the **spendable** balance (`settled`), which is the only number end users should see:
+
+```tsx
+import { useSchematicCreditBalance } from "@schematichq/schematic-react";
+
+const CreditMeter = () => {
+    const { balance, isLoading } = useSchematicCreditBalance("credit-id");
+
+    if (isLoading) {
+        return <div>Loading…</div>;
+    }
+
+    return <div>{balance} credits remaining</div>;
+};
+```
+
+The hook returns an object with the following properties:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `balance` | `number` | The selected balance (`settled` by default — the spendable balance, `remaining + reserved`). `0` while loading or when the company holds no balance in this credit. |
+| `isLoading` | `boolean` | `true` while the balance is still loading and no value has arrived yet |
+
+`settled` is the right number to display: during an open lease, `remaining` can drop to `0` even though the company still has spendable credit, whereas `settled` reflects the true balance net of actual consumption.
+
+For advanced lease-aware accounting you can request a different balance via the `type` option:
+
+```tsx
+// "remaining" excludes the open lease hold; "reserved" is the held amount
+const { balance: remaining } = useSchematicCreditBalance("credit-id", {
+    type: "remaining",
+});
+```
+
+> The credit ID is available on a feature's entitlement — `useSchematicEntitlement(key)` returns `creditId` (along with `creditRemaining`, `creditReserved`, and `creditSettled`) for credit-based features.
+
 ## Fallback Behavior
 
 The SDK includes built-in fallback behavior you can use to ensure your application continues to function even when unable to reach Schematic (e.g., during service disruptions or network issues).

--- a/react/README.md
+++ b/react/README.md
@@ -177,9 +177,7 @@ The hook returns an object with the following properties:
 
 ### Credit balances
 
-To render a company's live, lease-aware credit balance, use the `useSchematicCreditBalance` hook. It is keyed by credit ID and updates reactively as balances change over the DataStream — including while a credit lease is open, when the raw `remaining` value would otherwise read stale or falsely "exhausted".
-
-By default the hook returns the **spendable** balance (`settled`), which is the only number end users should see:
+To display a company's credit balance, use the `useSchematicCreditBalance` hook. It is keyed by credit ID and updates reactively as the balance changes over the DataStream:
 
 ```tsx
 import { useSchematicCreditBalance } from "@schematichq/schematic-react";
@@ -199,21 +197,10 @@ The hook returns an object with the following properties:
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `balance` | `number` | The selected balance (`settled` by default — the spendable balance, `remaining + reserved`). `0` while loading or when the company holds no balance in this credit. |
+| `balance` | `number` | The spendable balance, or `0` while loading or when the company holds no balance in this credit |
 | `isLoading` | `boolean` | `true` while the balance is still loading and no value has arrived yet |
 
-`settled` is the right number to display: during an open lease, `remaining` can drop to `0` even though the company still has spendable credit, whereas `settled` reflects the true balance net of actual consumption.
-
-For advanced lease-aware accounting you can request a different balance via the `type` option:
-
-```tsx
-// "remaining" excludes the open lease hold; "reserved" is the held amount
-const { balance: remaining } = useSchematicCreditBalance("credit-id", {
-    type: "remaining",
-});
-```
-
-> The credit ID is available on a feature's entitlement — `useSchematicEntitlement(key)` returns `creditId` (along with `creditRemaining`, `creditReserved`, and `creditSettled`) for credit-based features.
+The credit ID is available on a feature's entitlement: `useSchematicEntitlement(key)` returns `creditId` for credit-based features.
 
 ## Fallback Behavior
 

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-react",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "main": "dist/schematic-react.cjs.js",
   "module": "dist/schematic-react.esm.js",
   "types": "dist/schematic-react.d.ts",

--- a/react/package.json
+++ b/react/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@microsoft/api-extractor": "^7.58.9",
-    "@schematichq/schematic-js": "^1.4.0",
+    "@schematichq/schematic-js": "^1.5.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/react/src/hooks/schematic.ts
+++ b/react/src/hooks/schematic.ts
@@ -18,21 +18,9 @@ export type UseSchematicPlanOpts = SchematicHookOpts & {
   fallback?: SchematicJS.CheckPlanReturn;
 };
 
-/**
- * Which balance `useSchematicCreditBalance` surfaces. Defaults to "settled" —
- * the spendable balance (remaining + reserved) and the only number end users
- * should see. "remaining" / "reserved" are for advanced lease-aware accounting.
- */
-export type CreditBalanceType = "settled" | "remaining" | "reserved";
-
-export type UseSchematicCreditBalanceOpts = SchematicHookOpts & {
-  /** Which balance to surface. Defaults to "settled". */
-  type?: CreditBalanceType;
-};
-
 /** A company's credit balance for a single credit type, plus a loading flag */
 export type SchematicCreditBalance = {
-  /** The selected balance (settled by default; choose another via `opts.type`); 0 while loading or when the company holds no balance in this credit */
+  /** The spendable balance; 0 while loading or when the company holds no balance in this credit */
   balance: number;
   /** True while the balance is still loading and no value has arrived yet */
   isLoading: boolean;
@@ -157,20 +145,16 @@ export const useSchematicPlan = (
 /**
  * Returns a company's live, lease-aware credit balance for a single credit type.
  *
- * By default it surfaces `settled` — the spendable balance (remaining +
- * reserved), and the only number end users should see. The value is sourced
- * from the streamed `credit_balances` map (keyed by credit ID) and re-renders
- * as `credit_reserved` / `credit_balances` partials arrive over the DataStream,
- * so it stays accurate during an open lease — when the raw `remaining` would
- * otherwise read stale / falsely "exhausted". Pass `opts.type` to surface
- * `remaining` or `reserved` instead for advanced lease-aware accounting.
+ * Surfaces the spendable `settled` balance, sourced from the streamed
+ * `credit_balances` map (keyed by credit ID). It re-renders as partials arrive
+ * over the DataStream, so it stays accurate during an open lease — when the raw
+ * `remaining` would otherwise read stale / falsely "exhausted".
  */
 export const useSchematicCreditBalance = (
   creditId: string,
-  opts?: UseSchematicCreditBalanceOpts,
+  opts?: SchematicHookOpts,
 ): SchematicCreditBalance => {
   const client = useSchematicClient(opts);
-  const type = opts?.type ?? "settled";
 
   const subscribe = useCallback(
     (callback: () => void) => client.addCreditBalanceListener(callback),
@@ -197,10 +181,10 @@ export const useSchematicCreditBalance = (
 
   return useMemo(
     () => ({
-      balance: balance?.[type] ?? 0,
+      balance: balance?.settled ?? 0,
       isLoading: balance === undefined && isPending,
     }),
-    [balance, type, isPending],
+    [balance, isPending],
   );
 };
 

--- a/react/src/hooks/schematic.ts
+++ b/react/src/hooks/schematic.ts
@@ -18,6 +18,26 @@ export type UseSchematicPlanOpts = SchematicHookOpts & {
   fallback?: SchematicJS.CheckPlanReturn;
 };
 
+/**
+ * Which balance `useSchematicCreditBalance` surfaces. Defaults to "settled" —
+ * the spendable balance (remaining + reserved) and the only number end users
+ * should see. "remaining" / "reserved" are for advanced lease-aware accounting.
+ */
+export type CreditBalanceType = "settled" | "remaining" | "reserved";
+
+export type UseSchematicCreditBalanceOpts = SchematicHookOpts & {
+  /** Which balance to surface. Defaults to "settled". */
+  type?: CreditBalanceType;
+};
+
+/** A company's credit balance for a single credit type, plus a loading flag */
+export type SchematicCreditBalance = {
+  /** The selected balance (settled by default; choose another via `opts.type`); 0 while loading or when the company holds no balance in this credit */
+  balance: number;
+  /** True while the balance is still loading and no value has arrived yet */
+  isLoading: boolean;
+};
+
 export const useSchematicClient = (opts?: SchematicHookOpts) => {
   const schematic = useSchematic();
   const { client } = opts ?? {};
@@ -132,6 +152,56 @@ export const useSchematicPlan = (
   }, [client, fallbackPlan]);
 
   return useSyncExternalStore(subscribe, getSnapshot, () => fallbackPlan);
+};
+
+/**
+ * Returns a company's live, lease-aware credit balance for a single credit type.
+ *
+ * By default it surfaces `settled` — the spendable balance (remaining +
+ * reserved), and the only number end users should see. The value is sourced
+ * from the streamed `credit_balances` map (keyed by credit ID) and re-renders
+ * as `credit_reserved` / `credit_balances` partials arrive over the DataStream,
+ * so it stays accurate during an open lease — when the raw `remaining` would
+ * otherwise read stale / falsely "exhausted". Pass `opts.type` to surface
+ * `remaining` or `reserved` instead for advanced lease-aware accounting.
+ */
+export const useSchematicCreditBalance = (
+  creditId: string,
+  opts?: UseSchematicCreditBalanceOpts,
+): SchematicCreditBalance => {
+  const client = useSchematicClient(opts);
+  const type = opts?.type ?? "settled";
+
+  const subscribe = useCallback(
+    (callback: () => void) => client.addCreditBalanceListener(callback),
+    [client],
+  );
+
+  const getSnapshot = useCallback(
+    () => client.getCreditBalance(creditId),
+    [client, creditId],
+  );
+
+  const balance = useSyncExternalStore(subscribe, getSnapshot, () => undefined);
+
+  const isPendingSubscribe = useCallback(
+    (callback: () => void) => client.addIsPendingListener(callback),
+    [client],
+  );
+
+  const isPending = useSyncExternalStore(
+    isPendingSubscribe,
+    () => client.getIsPending(),
+    () => true,
+  );
+
+  return useMemo(
+    () => ({
+      balance: balance?.[type] ?? 0,
+      isLoading: balance === undefined && isPending,
+    }),
+    [balance, type, isPending],
+  );
 };
 
 export const useSchematicIsPending = (opts?: SchematicHookOpts) => {

--- a/react/src/index.spec.tsx
+++ b/react/src/index.spec.tsx
@@ -105,9 +105,8 @@ const createFakeClient = () => {
     const renderBalance = (
       creditId: string,
       client: ReturnType<typeof createFakeClient>,
-      opts?: { type?: "settled" | "remaining" | "reserved" },
     ) =>
-      renderHook(() => useSchematicCreditBalance(creditId, opts), {
+      renderHook(() => useSchematicCreditBalance(creditId), {
         wrapper: ({ children }: { children: React.ReactNode }) => (
           <SchematicProvider client={client as unknown as Schematic}>
             {children}
@@ -122,10 +121,10 @@ const createFakeClient = () => {
       expect(result.current).toEqual({ balance: 0, isLoading: true });
     });
 
-    it("surfaces settled as the default headline balance", () => {
+    it("surfaces the settled (spendable) balance", () => {
       // Repro from SCH-6526: 6000 grant, lease tracked to 2558. The streamed
       // `remaining` froze at 0 mid-lease; `settled` (spendable) is 3442 — and
-      // that's the default the hook returns.
+      // that's what the hook returns.
       const client = createFakeClient();
       const { result } = renderBalance("credit-abc", client);
 
@@ -137,26 +136,6 @@ const createFakeClient = () => {
       });
 
       expect(result.current).toEqual({ balance: 3442, isLoading: false });
-    });
-
-    it("surfaces remaining/reserved when requested via opts.type", () => {
-      const client = createFakeClient();
-      const remainingHook = renderBalance("credit-abc", client, {
-        type: "remaining",
-      });
-      const reservedHook = renderBalance("credit-abc", client, {
-        type: "reserved",
-      });
-
-      act(() => {
-        client.__setPending(false);
-        client.__emitBalances({
-          "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
-        });
-      });
-
-      expect(remainingHook.result.current.balance).toBe(0);
-      expect(reservedHook.result.current.balance).toBe(3442);
     });
 
     it("re-renders as credit balance partials arrive", () => {

--- a/react/src/index.spec.tsx
+++ b/react/src/index.spec.tsx
@@ -1,7 +1,12 @@
 import { vi } from "vitest";
-import { render } from "@testing-library/react";
-import { Schematic } from "@schematichq/schematic-js";
-import { SchematicProvider, useSchematicFlag } from "./index";
+import React from "react";
+import { act, render, renderHook } from "@testing-library/react";
+import { Schematic, type CreditBalances } from "@schematichq/schematic-js";
+import {
+  SchematicProvider,
+  useSchematicCreditBalance,
+  useSchematicFlag,
+} from "./index";
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch as typeof fetch;
@@ -56,4 +61,138 @@ describe("schematic-react", () => {
     expect(typeof client.track).toBe("function");
     expect(typeof client.identify).toBe("function");
   });
+
+  it("should export useSchematicCreditBalance hook", () => {
+    expect(useSchematicCreditBalance).toBeDefined();
+  });
 });
+
+// A minimal controllable client that satisfies the methods the credit balance
+// hook reads, so we can drive DataStream-style updates without websockets.
+const createFakeClient = () => {
+  let balances: CreditBalances = {};
+  let isPending = true;
+  const balanceListeners = new Set<() => void>();
+  const pendingListeners = new Set<() => void>();
+
+  return {
+    getCreditBalance: (creditId: string) => balances[creditId],
+    getCreditBalances: () => balances,
+    addCreditBalanceListener: (cb: () => void) => {
+      balanceListeners.add(cb);
+      return () => balanceListeners.delete(cb);
+    },
+    getIsPending: () => isPending,
+    addIsPendingListener: (cb: () => void) => {
+      pendingListeners.add(cb);
+      return () => pendingListeners.delete(cb);
+    },
+    // test-only helpers
+    __emitBalances: (next: CreditBalances) => {
+      balances = next;
+      balanceListeners.forEach((cb) => cb());
+    },
+    __setPending: (next: boolean) => {
+      isPending = next;
+      pendingListeners.forEach((cb) => cb());
+    },
+  };
+};
+
+(isDOMEnvironment ? describe : describe.skip)(
+  "useSchematicCreditBalance",
+  () => {
+    const renderBalance = (
+      creditId: string,
+      client: ReturnType<typeof createFakeClient>,
+      opts?: { type?: "settled" | "remaining" | "reserved" },
+    ) =>
+      renderHook(() => useSchematicCreditBalance(creditId, opts), {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <SchematicProvider client={client as unknown as Schematic}>
+            {children}
+          </SchematicProvider>
+        ),
+      });
+
+    it("reports isLoading until a balance is available", () => {
+      const client = createFakeClient();
+      const { result } = renderBalance("credit-abc", client);
+
+      expect(result.current).toEqual({ balance: 0, isLoading: true });
+    });
+
+    it("surfaces settled as the default headline balance", () => {
+      // Repro from SCH-6526: 6000 grant, lease tracked to 2558. The streamed
+      // `remaining` froze at 0 mid-lease; `settled` (spendable) is 3442 — and
+      // that's the default the hook returns.
+      const client = createFakeClient();
+      const { result } = renderBalance("credit-abc", client);
+
+      act(() => {
+        client.__setPending(false);
+        client.__emitBalances({
+          "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+        });
+      });
+
+      expect(result.current).toEqual({ balance: 3442, isLoading: false });
+    });
+
+    it("surfaces remaining/reserved when requested via opts.type", () => {
+      const client = createFakeClient();
+      const remainingHook = renderBalance("credit-abc", client, {
+        type: "remaining",
+      });
+      const reservedHook = renderBalance("credit-abc", client, {
+        type: "reserved",
+      });
+
+      act(() => {
+        client.__setPending(false);
+        client.__emitBalances({
+          "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+        });
+      });
+
+      expect(remainingHook.result.current.balance).toBe(0);
+      expect(reservedHook.result.current.balance).toBe(3442);
+    });
+
+    it("re-renders as credit balance partials arrive", () => {
+      const client = createFakeClient();
+      const { result } = renderBalance("credit-abc", client);
+
+      act(() => {
+        client.__setPending(false);
+        client.__emitBalances({
+          "credit-abc": { remaining: 3442, reserved: 0, settled: 3442 },
+        });
+      });
+      expect(result.current.balance).toBe(3442);
+
+      // A credit_reserved partial arrives: a lease opens holding 3442. settled
+      // stays 3442, so the headline number does not falsely drop.
+      act(() => {
+        client.__emitBalances({
+          "credit-abc": { remaining: 0, reserved: 3442, settled: 3442 },
+        });
+      });
+      expect(result.current.balance).toBe(3442);
+    });
+
+    it("returns 0 (not loading) for an unknown credit once loaded", () => {
+      const client = createFakeClient();
+      const { result } = renderBalance("credit-missing", client);
+
+      act(() => {
+        client.__setPending(false);
+        client.__emitBalances({
+          "credit-abc": { remaining: 1, reserved: 0, settled: 1 },
+        });
+      });
+
+      expect(result.current).toEqual({ balance: 0, isLoading: false });
+    });
+  },
+);

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -5,12 +5,16 @@ import {
 } from "./context";
 import {
   useSchematicContext,
+  useSchematicCreditBalance,
   useSchematicEntitlement,
   useSchematicEvents,
   useSchematicFlag,
   useSchematicIsPending,
   useSchematicPlan,
+  type CreditBalanceType,
+  type SchematicCreditBalance,
   type SchematicHookOpts,
+  type UseSchematicCreditBalanceOpts,
   type UseSchematicPlanOpts,
   type UseSchematicFlagOpts,
 } from "./hooks";
@@ -18,6 +22,7 @@ import {
 export {
   useSchematic,
   useSchematicContext,
+  useSchematicCreditBalance,
   useSchematicEntitlement,
   useSchematicEvents,
   useSchematicFlag,
@@ -27,8 +32,11 @@ export {
 };
 
 export type {
+  CreditBalanceType,
+  SchematicCreditBalance,
   SchematicHookOpts,
   SchematicProviderProps,
+  UseSchematicCreditBalanceOpts,
   UseSchematicFlagOpts,
   UseSchematicPlanOpts,
 };
@@ -43,6 +51,9 @@ export {
 export type {
   CheckFlagReturn,
   CheckPlanReturn,
+  CompanyCreditBalance,
+  CreditBalance,
+  CreditBalances,
   Event,
   EventBody,
   EventBodyIdentify,

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -11,10 +11,8 @@ import {
   useSchematicFlag,
   useSchematicIsPending,
   useSchematicPlan,
-  type CreditBalanceType,
   type SchematicCreditBalance,
   type SchematicHookOpts,
-  type UseSchematicCreditBalanceOpts,
   type UseSchematicPlanOpts,
   type UseSchematicFlagOpts,
 } from "./hooks";
@@ -32,11 +30,9 @@ export {
 };
 
 export type {
-  CreditBalanceType,
   SchematicCreditBalance,
   SchematicHookOpts,
   SchematicProviderProps,
-  UseSchematicCreditBalanceOpts,
   UseSchematicFlagOpts,
   UseSchematicPlanOpts,
 };

--- a/react/src/version.ts
+++ b/react/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.4.1";
+export const version = "1.5.0";

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -849,13 +849,13 @@
     argparse "~1.0.9"
     string-argv "~0.3.1"
 
-"@schematichq/schematic-js@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@schematichq/schematic-js/-/schematic-js-1.4.0.tgz#1cdb53f0c2053f97934d65c83a95af78754dcc89"
-  integrity sha512-/fb8BXbBXFS09y6xul8JqloQWijvbE3xIOrOed1wzuaftuFWLJ8wUEGvuBRE7/3op0GhcvyT8nLdJ1y+yipaAg==
+"@schematichq/schematic-js@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@schematichq/schematic-js/-/schematic-js-1.5.0.tgz#d1b3cf3d1e6f8a84c4d2aeeae159aa685309a60f"
+  integrity sha512-d+pMyDLwBKpZfpSsrna/+miGGj44qQei13vTqQ1TBVEMDKGC2S0/ad8DaZy+MslDTV6WBfUj/KEsORs6T+4PBA==
   dependencies:
     cross-fetch "^4.1.0"
-    uuid "^13.0.0"
+    uuid "^14.0.1"
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
@@ -3490,10 +3490,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^13.0.0:
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.2.tgz#41bc9c07b12f665089c205f6507976adbdf84ff8"
-  integrity sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==
+uuid@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
+  integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
 
 "vite@^6.0.0 || ^7.0.0 || ^8.0.0":
   version "8.0.16"


### PR DESCRIPTION
Adds `useSchematicCreditBalance(creditId)`, which shows a live-streaming credit balance for a given credit type (settled/lease-aware balance).

Here's an example view from schematic-next-example where I used this hook and pinged the API to grant credits while the websocket was live (increasing the balance): 
<img width="1277" height="952" alt="useSchematicCreditBalance-live" src="https://github.com/user-attachments/assets/361c0a04-2c93-4d8d-bb92-feede499bc8b" />

I also retooled my Metronome demo app to use this and it seems to work well.