### PR TITLE
SCHY-442 Display Apple Pay and Google Pay saved payment methods

### DIFF
--- a/components/src/components/elements/payment-method/PaymentMethodElement.tsx
+++ b/components/src/components/elements/payment-method/PaymentMethodElement.tsx
@@ -15,6 +15,8 @@ type PaymentMethodType =
   | "card"
   | "us_bank_account"
   | "amazon_pay"
+  | "apple_pay"
+  | "google_pay"
   | "cashapp"
   | "paypal"
   | "link"
@@ -123,6 +125,18 @@ const getPaymentMethodData = ({
       iconName: "amazonpay",
       iconTitle: billingName || billingEmail || "Amazon Pay account",
       label: billingName || billingEmail || "Amazon Pay account",
+    },
+    apple_pay: {
+      iconName: "applepay",
+      iconTitle: "Apple Pay",
+      label: cardLast4 ? "Apple Pay ending in" : "Apple Pay",
+      paymentLast4: cardLast4,
+    },
+    google_pay: {
+      iconName: "google",
+      iconTitle: "Google Pay",
+      label: cardLast4 ? "Google Pay ending in" : "Google Pay",
+      paymentLast4: cardLast4,
     },
     cashapp: {
       iconName: "cashapp",


### PR DESCRIPTION
## Summary

- **`PaymentMethodElement.tsx`** — add display cases for `apple_pay`/`google_pay` saved methods, rendering the wallet brand icon + the underlying card's last4 instead of the generic fallback. (Only relevant if the backend maps wallets to those `paymentMethodType` values; if it reports `"card"`, existing card rendering already covers it.)

Linear: [SCHY-442](https://linear.app/schematic/issue/SCHY-442/support-other-payment-methods)