### PR TITLE
Hide credit top-up surfaces when plan grant availability is off

### DIFF
--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -20,11 +20,11 @@ import {
   entitlementHasHardLimit,
   formatCurrency,
   formatNumber,
+  getBundleOffCreditIds,
   getFeatureName,
   getSubscriptionPeriod,
   getUsageDetails,
   groupCreditGrants,
-  isBundlePurchaseOff,
   modifyDate,
   toPrettyDate,
   type UsageDetails,
@@ -237,17 +237,12 @@ export const MeteredFeatures = forwardRef<
     [data?.creditGrants],
   );
 
-  const bundleOffCreditIds = useMemo(() => {
-    const ids = new Set<string>();
-    (data?.company?.plan?.includedCreditGrants ?? []).forEach((grant) => {
-      if (isBundlePurchaseOff(grant)) {
-        ids.add(grant.creditId);
-      }
-    });
-    return ids;
-  }, [data?.company?.plan?.includedCreditGrants]);
+  const bundleOffCreditIds = useMemo(
+    () => getBundleOffCreditIds(data?.company?.plan?.includedCreditGrants),
+    [data?.company?.plan?.includedCreditGrants],
+  );
 
-  const [creditVisibility, setCreditVisibility] = useState(
+  const [creditVisibility, setCreditVisibility] = useState(() =>
     creditGroups.map(({ id }) => ({ id, isExpanded: false })),
   );
 

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -232,9 +232,10 @@ export const MeteredFeatures = forwardRef<
     );
   }, [props.visibleFeatures, data?.featureUsage?.features]);
 
-  const creditGroups = groupCreditGrants(data?.creditGrants || [], {
-    groupBy: "credit",
-  });
+  const creditGroups = useMemo(
+    () => groupCreditGrants(data?.creditGrants || [], { groupBy: "credit" }),
+    [data?.creditGrants],
+  );
 
   const bundleOffCreditIds = useMemo(() => {
     const ids = new Set<string>();

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -24,7 +24,7 @@ import {
   getSubscriptionPeriod,
   getUsageDetails,
   groupCreditGrants,
-  isTopupOff,
+  isBundlePurchaseOff,
   modifyDate,
   toPrettyDate,
   type UsageDetails,
@@ -236,17 +236,16 @@ export const MeteredFeatures = forwardRef<
     groupBy: "credit",
   });
 
-  // Credits whose plan grant has top-up availability "off" cannot be purchased,
-  // so the "Buy More" button is hidden for them.
-  const topupOffCreditIds = useMemo(() => {
+  const bundleOffCreditIds = useMemo(() => {
     const ids = new Set<string>();
     (data?.company?.plan?.includedCreditGrants ?? []).forEach((grant) => {
-      if (isTopupOff(grant)) {
+      if (isBundlePurchaseOff(grant)) {
         ids.add(grant.creditId);
       }
     });
     return ids;
   }, [data?.company?.plan?.includedCreditGrants]);
+
   const [creditVisibility, setCreditVisibility] = useState(
     creditGroups.map(({ id }) => ({ id, isExpanded: false })),
   );
@@ -457,7 +456,7 @@ export const MeteredFeatures = forwardRef<
                       }
                     />
 
-                    {canCheckout && !topupOffCreditIds.has(credit.id) && (
+                    {canCheckout && !bundleOffCreditIds.has(credit.id) && (
                       <Button
                         type="button"
                         onClick={() => {

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -24,6 +24,7 @@ import {
   getSubscriptionPeriod,
   getUsageDetails,
   groupCreditGrants,
+  isTopupOff,
   modifyDate,
   toPrettyDate,
   type UsageDetails,
@@ -234,6 +235,18 @@ export const MeteredFeatures = forwardRef<
   const creditGroups = groupCreditGrants(data?.creditGrants || [], {
     groupBy: "credit",
   });
+
+  // Credits whose plan grant has top-up availability "off" cannot be purchased,
+  // so the "Buy More" button is hidden for them.
+  const topupOffCreditIds = useMemo(() => {
+    const ids = new Set<string>();
+    (data?.company?.plan?.includedCreditGrants ?? []).forEach((grant) => {
+      if (isTopupOff(grant)) {
+        ids.add(grant.creditId);
+      }
+    });
+    return ids;
+  }, [data?.company?.plan?.includedCreditGrants]);
   const [creditVisibility, setCreditVisibility] = useState(
     creditGroups.map(({ id }) => ({ id, isExpanded: false })),
   );
@@ -444,7 +457,7 @@ export const MeteredFeatures = forwardRef<
                       }
                     />
 
-                    {canCheckout && (
+                    {canCheckout && !topupOffCreditIds.has(credit.id) && (
                       <Button
                         type="button"
                         onClick={() => {

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -92,7 +92,7 @@ const Limit = ({ entitlement, usageDetails, fontStyle }: LimitProps) => {
           : priceBehavior === EntitlementPriceBehavior.PayAsYouGo &&
               typeof cost === "number"
             ? formatCurrency(cost, billingPrice?.currency)
-            : data?.displaySettings.showCredits &&
+            : data?.displaySettings?.showCredits &&
                 priceBehavior === EntitlementPriceBehavior.CreditBurndown &&
                 typeof planEntitlement?.valueCredit !== "undefined" &&
                 typeof planEntitlement?.consumptionRate === "number"

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -242,16 +242,23 @@ export const MeteredFeatures = forwardRef<
     [data?.company?.plan?.includedCreditGrants],
   );
 
-  const [creditVisibility, setCreditVisibility] = useState(() =>
-    creditGroups.map(({ id }) => ({ id, isExpanded: false })),
+  // Track expanded credits by id rather than seeding an array from creditGroups:
+  // the component can mount before credit data loads, and a seeded array would
+  // never resync, leaving the expand chevron a no-op for late-arriving credits.
+  const [expandedCreditIds, setExpandedCreditIds] = useState<Set<string>>(
+    () => new Set(),
   );
 
   const toggleBalanceDetails = useCallback((id: string) => {
-    setCreditVisibility((prev) =>
-      prev.map((item) =>
-        item.id === id ? { ...item, isExpanded: !item.isExpanded } : item,
-      ),
-    );
+    setExpandedCreditIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
   }, []);
 
   const shouldShowFeatures =
@@ -397,9 +404,7 @@ export const MeteredFeatures = forwardRef<
 
       {showCredits &&
         creditGroups.map((credit, index) => {
-          const isExpanded =
-            creditVisibility.find(({ id }) => credit.id === id)?.isExpanded ??
-            false;
+          const isExpanded = expandedCreditIds.has(credit.id);
 
           return (
             <Element key={index} as={Flex} $flexDirection="column" $gap="1rem">

--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -611,7 +611,8 @@ export const PlanManager = forwardRef<
                       (acc: React.ReactNode[], grant) => {
                         if (
                           !grant.credit ||
-                          !grant.billingCreditAutoTopupSelfService
+                          !grant.billingCreditAutoTopupSelfService ||
+                          isAutoTopupOff(grant)
                         ) {
                           return acc;
                         }

--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -24,6 +24,7 @@ import {
   groupCreditGrants,
   isAutoTopupEnabled,
   isAutoTopupOff,
+  isSelfServiceAutoTopupAvailable,
   lighten,
   shortenPeriod,
   toPrettyDate,
@@ -225,9 +226,9 @@ export const PlanManager = forwardRef<
   }, [currentPlan, usageBasedEntitlements]);
 
   const hasAutoTopupSelfService =
-    currentPlan?.includedCreditGrants.some((grant) => {
-      return grant.billingCreditAutoTopupSelfService && !isAutoTopupOff(grant);
-    }) ?? false;
+    currentPlan?.includedCreditGrants.some((grant) =>
+      isSelfServiceAutoTopupAvailable(grant),
+    ) ?? false;
 
   return (
     <>
@@ -611,8 +612,7 @@ export const PlanManager = forwardRef<
                       (acc: React.ReactNode[], grant) => {
                         if (
                           !grant.credit ||
-                          !grant.billingCreditAutoTopupSelfService ||
-                          isAutoTopupOff(grant)
+                          !isSelfServiceAutoTopupAvailable(grant)
                         ) {
                           return acc;
                         }

--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -23,6 +23,7 @@ import {
   getSubscriptionPeriod,
   groupCreditGrants,
   isAutoTopupEnabled,
+  isAutoTopupOff,
   lighten,
   shortenPeriod,
   toPrettyDate,
@@ -225,7 +226,7 @@ export const PlanManager = forwardRef<
 
   const hasAutoTopupSelfService =
     currentPlan?.includedCreditGrants.some((grant) => {
-      return grant.billingCreditAutoTopupSelfService;
+      return grant.billingCreditAutoTopupSelfService && !isAutoTopupOff(grant);
     }) ?? false;
 
   return (
@@ -572,12 +573,14 @@ export const PlanManager = forwardRef<
                               $color={settings.theme.typography.text.color}
                             >
                               {group.total.used} {t("used")}
-                              {hasAutoTopup && planCreditGrant && (
-                                <AutoTopupNotice
-                                  thresholdCredits={thresholdCredits}
-                                  topupAmount={topupAmount}
-                                />
-                              )}
+                              {hasAutoTopup &&
+                                planCreditGrant &&
+                                !isAutoTopupOff(planCreditGrant) && (
+                                  <AutoTopupNotice
+                                    thresholdCredits={thresholdCredits}
+                                    topupAmount={topupAmount}
+                                  />
+                                )}
                             </Text>
                           </Flex>
                         )}

--- a/components/src/components/shared/checkout-dialog/AutoTopup.tsx
+++ b/components/src/components/shared/checkout-dialog/AutoTopup.tsx
@@ -5,7 +5,10 @@ import { PlanCreditGrantView } from "../../../api/checkoutexternal";
 import { TEXT_BASE_SIZE } from "../../../const";
 import { useEmbed } from "../../../hooks";
 import { AutoTopupConfig } from "../../../types";
-import { getFeatureName, isAutoTopupOff } from "../../../utils";
+import {
+  getFeatureName,
+  isSelfServiceAutoTopupAvailable,
+} from "../../../utils";
 import { cardBoxShadow } from "../../layout";
 import { Box, Flex, Input, Text, Toggle } from "../../ui";
 
@@ -31,7 +34,7 @@ export const AutoTopup = ({
   const configurableCreditGrants = useMemo(() => {
     return planCreditGrants.reduce(
       (acc: (PlanCreditGrantView & { cost?: number })[], grant) => {
-        if (grant.billingCreditAutoTopupSelfService && !isAutoTopupOff(grant)) {
+        if (isSelfServiceAutoTopupAvailable(grant)) {
           const {
             companyAutoTopupEnabled,
             companyAutoTopupThresholdCredits,

--- a/components/src/components/shared/checkout-dialog/AutoTopup.tsx
+++ b/components/src/components/shared/checkout-dialog/AutoTopup.tsx
@@ -5,7 +5,7 @@ import { PlanCreditGrantView } from "../../../api/checkoutexternal";
 import { TEXT_BASE_SIZE } from "../../../const";
 import { useEmbed } from "../../../hooks";
 import { AutoTopupConfig } from "../../../types";
-import { getFeatureName } from "../../../utils";
+import { getFeatureName, isAutoTopupOff } from "../../../utils";
 import { cardBoxShadow } from "../../layout";
 import { Box, Flex, Input, Text, Toggle } from "../../ui";
 
@@ -31,7 +31,7 @@ export const AutoTopup = ({
   const configurableCreditGrants = useMemo(() => {
     return planCreditGrants.reduce(
       (acc: (PlanCreditGrantView & { cost?: number })[], grant) => {
-        if (grant.billingCreditAutoTopupSelfService) {
+        if (grant.billingCreditAutoTopupSelfService && !isAutoTopupOff(grant)) {
           const {
             companyAutoTopupEnabled,
             companyAutoTopupThresholdCredits,

--- a/components/src/components/shared/checkout-dialog/AutoTopup.tsx
+++ b/components/src/components/shared/checkout-dialog/AutoTopup.tsx
@@ -71,11 +71,11 @@ export const AutoTopup = ({
 
   return (
     <Flex $flexDirection="column" $gap="1rem">
-      {configurableCreditGrants.map((grant, index) => {
+      {configurableCreditGrants.map((grant) => {
         return (
           <Box
             as="section"
-            key={index}
+            key={grant.id}
             $padding={`${cardPadding}rem`}
             $backgroundColor={settings.theme.card.background}
             $borderRadius={`${settings.theme.card.borderRadius / TEXT_BASE_SIZE}rem`}

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -47,6 +47,8 @@ import {
   getAddOnPrice,
   getPlanPrice,
   getSubscriptionPeriod,
+  isAutoTopupOff,
+  isBundlePurchaseOff,
   isError,
   isScheduledCheckoutConflictMessage,
   mergeCompanyGrants,
@@ -445,10 +447,18 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
   ]);
 
   const [creditBundles, setCreditBundles] = useState<CreditBundle[]>(() => {
-    return (data?.creditBundles || []).map((bundle) => ({
-      ...bundle,
-      count: 0,
-    }));
+    const bundleOffCreditIds = new Set(
+      (data?.company?.plan?.includedCreditGrants ?? [])
+        .filter((grant) => isBundlePurchaseOff(grant))
+        .map((grant) => grant.creditId),
+    );
+
+    return (data?.creditBundles || [])
+      .filter((bundle) => !bundleOffCreditIds.has(bundle.creditId))
+      .map((bundle) => ({
+        ...bundle,
+        count: 0,
+      }));
   });
 
   const selectedPlanPriceId = useMemo(() => {
@@ -687,9 +697,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     const hasSelfServiceAutoTopup = selectedPlan?.includedCreditGrants.some(
       (grant) => {
         const isSelfService = grant.billingCreditAutoTopupSelfService ?? false;
-        return isSelfService;
+
+        return isSelfService && !isAutoTopupOff(grant);
       },
     );
+
     if (hasSelfServiceAutoTopup) {
       stages.push({
         id: "autoTopup",

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -977,10 +977,6 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         updates.payInAdvanceEntitlements || payInAdvanceEntitlements;
       const resolvedAddOnPayInAdvanceEntitlements =
         updates.addOnPayInAdvanceEntitlements || addOnPayInAdvanceEntitlements;
-      // Drop add-ons incompatible with the plan being previewed. The closure's
-      // `addOns` is filtered against the currently selected plan, which lags a
-      // plan switch (the preview fires before the memo recomputes), so filter
-      // against the resolved `plan` here.
       const resolvedAddOns = (updates.addOns || addOns).filter((addOn) =>
         isAddOnCompatibleWithPlan(
           addOn.id,

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -44,12 +44,12 @@ import {
   buildAutoTopupRequestBody,
   buildCreditBundlesRequestBody,
   buildPayInAdvanceRequestBody,
+  deriveCreditBundles,
   getAddOnPrice,
   getPlanPrice,
   getSubscriptionPeriod,
   isAddOnCompatibleWithPlan,
   isAutoTopupOff,
-  isBundlePurchaseOff,
   isError,
   isScheduledCheckoutConflictMessage,
   mergeCompanyGrants,
@@ -446,18 +446,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
   const [bundleCounts, setBundleCounts] = useState<Record<string, number>>({});
 
   const creditBundles = useMemo<CreditBundle[]>(() => {
-    const bundleOffCreditIds = new Set(
-      (selectedPlan?.includedCreditGrants ?? [])
-        .filter((grant) => isBundlePurchaseOff(grant))
-        .map((grant) => grant.creditId),
+    return deriveCreditBundles(
+      selectedPlan?.includedCreditGrants,
+      data?.creditBundles,
+      bundleCounts,
     );
-
-    return (data?.creditBundles || [])
-      .filter((bundle) => !bundleOffCreditIds.has(bundle.creditId))
-      .map((bundle) => ({
-        ...bundle,
-        count: bundleCounts[bundle.id] ?? 0,
-      }));
   }, [selectedPlan?.includedCreditGrants, data?.creditBundles, bundleCounts]);
 
   const selectedPlanPriceId = useMemo(() => {
@@ -945,14 +938,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       // Filter bundles against the plan being previewed: a stale debounced
       // update may carry a bundle for a credit whose grant on the resolved
       // plan has bundle purchase off, and that must not reach the request.
-      const bundleOffCreditIds = new Set(
-        (plan?.includedCreditGrants ?? [])
-          .filter((grant) => isBundlePurchaseOff(grant))
-          .map((grant) => grant.creditId),
+      // No counts map — preserve the counts already on the passed bundles.
+      const resolvedCreditBundles = deriveCreditBundles(
+        plan?.includedCreditGrants,
+        updates.creditBundles || creditBundles,
       );
-      const resolvedCreditBundles = (
-        updates.creditBundles || creditBundles
-      ).filter((bundle) => !bundleOffCreditIds.has(bundle.creditId));
 
       // A credit-bundle-only purchase on a non-billing subscription has no plan
       // or price to send; the backend charges for the credits standalone.
@@ -1256,17 +1246,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       }
 
       // rederive credit bundles since they may depend on plan grant setting
-      const bundleOffCreditIds = new Set(
-        (plan?.includedCreditGrants ?? [])
-          .filter((grant) => isBundlePurchaseOff(grant))
-          .map((grant) => grant.creditId),
+      const resolvedCreditBundles = deriveCreditBundles(
+        plan?.includedCreditGrants,
+        data?.creditBundles,
+        bundleCounts,
       );
-      const resolvedCreditBundles = (data?.creditBundles || [])
-        .filter((bundle) => !bundleOffCreditIds.has(bundle.creditId))
-        .map((bundle) => ({
-          ...bundle,
-          count: bundleCounts[bundle.id] ?? 0,
-        }));
 
       handlePreviewCheckout({
         period,

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -40,18 +40,20 @@ import type {
 } from "../../../types";
 import {
   ERROR_UNKNOWN,
+  buildAddOnCompatibilityLookup,
   buildAddOnRequestBody,
   buildAutoTopupRequestBody,
   buildCreditBundlesRequestBody,
   buildPayInAdvanceRequestBody,
   deriveCreditBundles,
+  filterCreditBundles,
   getAddOnPrice,
   getPlanPrice,
   getSubscriptionPeriod,
-  isAddOnCompatibleWithPlan,
-  isAutoTopupOff,
+  isAddOnCompatibleWithLookup,
   isError,
   isScheduledCheckoutConflictMessage,
+  isSelfServiceAutoTopupAvailable,
   mergeCompanyGrants,
   planOffersCurrencyForPeriod,
   planSupportsCurrency,
@@ -404,6 +406,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     return ids;
   });
 
+  const addOnCompatibilityLookup = useMemo(
+    () => buildAddOnCompatibilityLookup(data?.addOnCompatibilities),
+    [data?.addOnCompatibilities],
+  );
+
   const addOns = useMemo(() => {
     return availableAddOns
       .filter((availAddOn) => {
@@ -424,10 +431,10 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           return true;
         }
 
-        return isAddOnCompatibleWithPlan(
+        return isAddOnCompatibleWithLookup(
+          addOnCompatibilityLookup,
           availAddOn.id,
           selectedPlan.id,
-          data?.addOnCompatibilities,
         );
       })
       .map((addOn) => ({
@@ -435,7 +442,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         isSelected: selectedAddOnIds.has(addOn.id),
       }));
   }, [
-    data?.addOnCompatibilities,
+    addOnCompatibilityLookup,
     availableAddOns,
     selectedPlan,
     hasCurrency,
@@ -445,13 +452,20 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
   const [bundleCounts, setBundleCounts] = useState<Record<string, number>>({});
 
+  // Fall back to the company's current-plan grants when no plan is selected
+  // (e.g. a credit-only purchase, or a preview that reset selectedPlanId), so a
+  // bundle-off credit is still gated rather than slipping through unfiltered.
+  const bundleGatingGrants =
+    selectedPlan?.includedCreditGrants ??
+    data?.company?.plan?.includedCreditGrants;
+
   const creditBundles = useMemo<CreditBundle[]>(() => {
     return deriveCreditBundles(
-      selectedPlan?.includedCreditGrants,
+      bundleGatingGrants,
       data?.creditBundles,
       bundleCounts,
     );
-  }, [selectedPlan?.includedCreditGrants, data?.creditBundles, bundleCounts]);
+  }, [bundleGatingGrants, data?.creditBundles, bundleCounts]);
 
   const selectedPlanPriceId = useMemo(() => {
     if (!selectedPlan) {
@@ -687,11 +701,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     }
 
     const hasSelfServiceAutoTopup = selectedPlan?.includedCreditGrants.some(
-      (grant) => {
-        const isSelfService = grant.billingCreditAutoTopupSelfService ?? false;
-
-        return isSelfService && !isAutoTopupOff(grant);
-      },
+      (grant) => isSelfServiceAutoTopupAvailable(grant),
     );
 
     if (hasSelfServiceAutoTopup) {
@@ -938,9 +948,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       // Filter bundles against the plan being previewed: a stale debounced
       // update may carry a bundle for a credit whose grant on the resolved
       // plan has bundle purchase off, and that must not reach the request.
-      // No counts map — preserve the counts already on the passed bundles.
-      const resolvedCreditBundles = deriveCreditBundles(
-        plan?.includedCreditGrants,
+      // filterCreditBundles preserves the counts already on the passed bundles;
+      // fall back to the current-plan grants when previewing a credit-only
+      // purchase so the gating still applies.
+      const resolvedCreditBundles = filterCreditBundles(
+        plan?.includedCreditGrants ?? data?.company?.plan?.includedCreditGrants,
         updates.creditBundles || creditBundles,
       );
 
@@ -978,10 +990,10 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       const resolvedAddOnPayInAdvanceEntitlements =
         updates.addOnPayInAdvanceEntitlements || addOnPayInAdvanceEntitlements;
       const resolvedAddOns = (updates.addOns || addOns).filter((addOn) =>
-        isAddOnCompatibleWithPlan(
+        isAddOnCompatibleWithLookup(
+          addOnCompatibilityLookup,
           addOn.id,
           plan?.id,
-          data?.addOnCompatibilities,
         ),
       );
       const resolvedPlanCreditGrants = mergeCompanyGrants(
@@ -1119,7 +1131,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     },
     [
       t,
-      data?.addOnCompatibilities,
+      addOnCompatibilityLookup,
       data?.company?.plan?.includedCreditGrants,
       data?.company?.billingSubscription,
       previewCheckout,
@@ -1245,11 +1257,14 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         setSelectedAddOnIds(new Set());
       }
 
-      // rederive credit bundles since they may depend on plan grant setting
-      const resolvedCreditBundles = deriveCreditBundles(
-        plan?.includedCreditGrants,
-        data?.creditBundles,
-        bundleCounts,
+      // Apply the latest counts to the raw bundles and let handlePreviewCheckout
+      // perform the single bundle-off filter against the resolved plan (avoids
+      // filtering here and again there for the same plan).
+      const resolvedCreditBundles = (data?.creditBundles ?? []).map(
+        (bundle) => ({
+          ...bundle,
+          count: bundleCounts[bundle.id] ?? 0,
+        }),
       );
 
       handlePreviewCheckout({
@@ -1468,20 +1483,23 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
   const updateCreditBundleCount = useCallback(
     (id: string, updatedCount: number) => {
-      setBundleCounts((prev) => ({ ...prev, [id]: updatedCount }));
+      setBundleCounts((prev) => {
+        const nextCounts = { ...prev, [id]: updatedCount };
 
-      const updated = creditBundles.map((bundle) =>
-        bundle.id === id
-          ? {
-              ...bundle,
-              count: updatedCount,
-            }
-          : bundle,
-      );
+        // Derive the preview payload from the latest counts inside the updater
+        // so rapid successive edits don't preview a stale snapshot.
+        debouncedPreviewCheckout({
+          creditBundles: deriveCreditBundles(
+            bundleGatingGrants,
+            data?.creditBundles,
+            nextCounts,
+          ),
+        });
 
-      debouncedPreviewCheckout({ creditBundles: updated });
+        return nextCounts;
+      });
     },
-    [creditBundles, debouncedPreviewCheckout],
+    [bundleGatingGrants, data?.creditBundles, debouncedPreviewCheckout],
   );
 
   const updateAddOnEntitlementQuantity = useCallback(

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -451,6 +451,10 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
   ]);
 
   const [bundleCounts, setBundleCounts] = useState<Record<string, number>>({});
+  // Mirror of bundleCounts updated synchronously in updateCreditBundleCount so
+  // it can merge rapid successive edits without a stale closure, while keeping
+  // the setBundleCounts updater pure.
+  const bundleCountsRef = useRef(bundleCounts);
 
   // Fall back to the company's current-plan grants when no plan is selected
   // (e.g. a credit-only purchase, or a preview that reset selectedPlanId), so a
@@ -1483,20 +1487,19 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
   const updateCreditBundleCount = useCallback(
     (id: string, updatedCount: number) => {
-      setBundleCounts((prev) => {
-        const nextCounts = { ...prev, [id]: updatedCount };
+      // Merge against the ref (updated synchronously) so rapid successive edits
+      // don't preview a stale snapshot, without putting a side effect in the
+      // setBundleCounts updater (which must stay pure).
+      const nextCounts = { ...bundleCountsRef.current, [id]: updatedCount };
+      bundleCountsRef.current = nextCounts;
+      setBundleCounts(nextCounts);
 
-        // Derive the preview payload from the latest counts inside the updater
-        // so rapid successive edits don't preview a stale snapshot.
-        debouncedPreviewCheckout({
-          creditBundles: deriveCreditBundles(
-            bundleGatingGrants,
-            data?.creditBundles,
-            nextCounts,
-          ),
-        });
-
-        return nextCounts;
+      debouncedPreviewCheckout({
+        creditBundles: deriveCreditBundles(
+          bundleGatingGrants,
+          data?.creditBundles,
+          nextCounts,
+        ),
       });
     },
     [bundleGatingGrants, data?.creditBundles, debouncedPreviewCheckout],

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -942,14 +942,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           : promoCode;
       const skipTrial = !(updates.shouldTrial ?? shouldTrial);
 
-      const bundleOffCreditIds = new Set(
-        (plan?.includedCreditGrants ?? [])
-          .filter((grant) => isBundlePurchaseOff(grant))
-          .map((grant) => grant.creditId),
-      );
-      const resolvedCreditBundles = (
-        updates.creditBundles || creditBundles
-      ).filter((bundle) => !bundleOffCreditIds.has(bundle.creditId));
+      const resolvedCreditBundles = updates.creditBundles || creditBundles;
 
       // A credit-bundle-only purchase on a non-billing subscription has no plan
       // or price to send; the backend charges for the credits standalone.
@@ -1130,6 +1123,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     },
     [
       t,
+      data?.addOnCompatibilities,
       data?.company?.plan?.includedCreditGrants,
       data?.company?.billingSubscription,
       previewCheckout,
@@ -1255,6 +1249,19 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         setSelectedAddOnIds(new Set());
       }
 
+      // rederive credit bundles since they may depend on plan grant setting
+      const bundleOffCreditIds = new Set(
+        (plan?.includedCreditGrants ?? [])
+          .filter((grant) => isBundlePurchaseOff(grant))
+          .map((grant) => grant.creditId),
+      );
+      const resolvedCreditBundles = (data?.creditBundles || [])
+        .filter((bundle) => !bundleOffCreditIds.has(bundle.creditId))
+        .map((bundle) => ({
+          ...bundle,
+          count: bundleCounts[bundle.id] ?? 0,
+        }));
+
       handlePreviewCheckout({
         period,
         plan,
@@ -1270,13 +1277,16 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
                   priceBehavior === EntitlementPriceBehavior.PayInAdvance,
               ),
             }),
+        creditBundles: resolvedCreditBundles,
       });
     },
     [
+      data?.creditBundles,
       selectedPlan?.id,
       planPeriod,
       showPeriodToggle,
       featureUsage,
+      bundleCounts,
       shouldTrial,
       willTrialWithoutPaymentMethod,
       handlePreviewCheckout,

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -47,6 +47,7 @@ import {
   getAddOnPrice,
   getPlanPrice,
   getSubscriptionPeriod,
+  isAddOnCompatibleWithPlan,
   isAutoTopupOff,
   isBundlePurchaseOff,
   isError,
@@ -423,15 +424,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           return true;
         }
 
-        const ourCompats = data?.addOnCompatibilities.find(
-          (compat) => compat.sourcePlanId === availAddOn.id,
+        return isAddOnCompatibleWithPlan(
+          availAddOn.id,
+          selectedPlan.id,
+          data?.addOnCompatibilities,
         );
-
-        if (!ourCompats || !ourCompats.compatiblePlanIds?.length) {
-          return true;
-        }
-
-        return ourCompats?.compatiblePlanIds.includes(selectedPlan?.id);
       })
       .map((addOn) => ({
         ...addOn,
@@ -446,9 +443,11 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     selectedAddOnIds,
   ]);
 
-  const [creditBundles, setCreditBundles] = useState<CreditBundle[]>(() => {
+  const [bundleCounts, setBundleCounts] = useState<Record<string, number>>({});
+
+  const creditBundles = useMemo<CreditBundle[]>(() => {
     const bundleOffCreditIds = new Set(
-      (data?.company?.plan?.includedCreditGrants ?? [])
+      (selectedPlan?.includedCreditGrants ?? [])
         .filter((grant) => isBundlePurchaseOff(grant))
         .map((grant) => grant.creditId),
     );
@@ -457,9 +456,9 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       .filter((bundle) => !bundleOffCreditIds.has(bundle.creditId))
       .map((bundle) => ({
         ...bundle,
-        count: 0,
+        count: bundleCounts[bundle.id] ?? 0,
       }));
-  });
+  }, [selectedPlan?.includedCreditGrants, data?.creditBundles, bundleCounts]);
 
   const selectedPlanPriceId = useMemo(() => {
     if (!selectedPlan) {
@@ -943,14 +942,21 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           : promoCode;
       const skipTrial = !(updates.shouldTrial ?? shouldTrial);
 
+      const bundleOffCreditIds = new Set(
+        (plan?.includedCreditGrants ?? [])
+          .filter((grant) => isBundlePurchaseOff(grant))
+          .map((grant) => grant.creditId),
+      );
+      const resolvedCreditBundles = (
+        updates.creditBundles || creditBundles
+      ).filter((bundle) => !bundleOffCreditIds.has(bundle.creditId));
+
       // A credit-bundle-only purchase on a non-billing subscription has no plan
       // or price to send; the backend charges for the credits standalone.
       const isCreditOnly =
         !data?.company?.billingSubscription &&
         !planPriceId &&
-        (updates.creditBundles || creditBundles).some(
-          (bundle) => bundle.count > 0,
-        ) &&
+        resolvedCreditBundles.some((bundle) => bundle.count > 0) &&
         !(updates.addOns || addOns).some(
           (addOn) =>
             addOn.isSelected &&
@@ -978,8 +984,17 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         updates.payInAdvanceEntitlements || payInAdvanceEntitlements;
       const resolvedAddOnPayInAdvanceEntitlements =
         updates.addOnPayInAdvanceEntitlements || addOnPayInAdvanceEntitlements;
-      const resolvedAddOns = updates.addOns || addOns;
-      const resolvedCreditBundles = updates.creditBundles || creditBundles;
+      // Drop add-ons incompatible with the plan being previewed. The closure's
+      // `addOns` is filtered against the currently selected plan, which lags a
+      // plan switch (the preview fires before the memo recomputes), so filter
+      // against the resolved `plan` here.
+      const resolvedAddOns = (updates.addOns || addOns).filter((addOn) =>
+        isAddOnCompatibleWithPlan(
+          addOn.id,
+          plan?.id,
+          data?.addOnCompatibilities,
+        ),
+      );
       const resolvedPlanCreditGrants = mergeCompanyGrants(
         plan?.includedCreditGrants,
         data?.company?.plan?.includedCreditGrants,
@@ -1453,22 +1468,20 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
 
   const updateCreditBundleCount = useCallback(
     (id: string, updatedCount: number) => {
-      setCreditBundles((prev) => {
-        const updated = prev.map((bundle) =>
-          bundle.id === id
-            ? {
-                ...bundle,
-                count: updatedCount,
-              }
-            : bundle,
-        );
+      setBundleCounts((prev) => ({ ...prev, [id]: updatedCount }));
 
-        debouncedPreviewCheckout({ creditBundles: updated });
+      const updated = creditBundles.map((bundle) =>
+        bundle.id === id
+          ? {
+              ...bundle,
+              count: updatedCount,
+            }
+          : bundle,
+      );
 
-        return updated;
-      });
+      debouncedPreviewCheckout({ creditBundles: updated });
     },
-    [debouncedPreviewCheckout],
+    [creditBundles, debouncedPreviewCheckout],
   );
 
   const updateAddOnEntitlementQuantity = useCallback(

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -942,7 +942,17 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
           : promoCode;
       const skipTrial = !(updates.shouldTrial ?? shouldTrial);
 
-      const resolvedCreditBundles = updates.creditBundles || creditBundles;
+      // Filter bundles against the plan being previewed: a stale debounced
+      // update may carry a bundle for a credit whose grant on the resolved
+      // plan has bundle purchase off, and that must not reach the request.
+      const bundleOffCreditIds = new Set(
+        (plan?.includedCreditGrants ?? [])
+          .filter((grant) => isBundlePurchaseOff(grant))
+          .map((grant) => grant.creditId),
+      );
+      const resolvedCreditBundles = (
+        updates.creditBundles || creditBundles
+      ).filter((bundle) => !bundleOffCreditIds.has(bundle.creditId));
 
       // A credit-bundle-only purchase on a non-billing subscription has no plan
       // or price to send; the backend charges for the credits standalone.

--- a/components/src/components/shared/checkout-dialog/Plan/Entitlement.tsx
+++ b/components/src/components/shared/checkout-dialog/Plan/Entitlement.tsx
@@ -51,7 +51,7 @@ export const Entitlement = ({
 
   const showCredits = data?.displaySettings?.showCredits ?? true;
   const showFeatureDescription =
-    data?.displaySettings.showFeatureDescription ?? false;
+    data?.displaySettings?.showFeatureDescription ?? false;
 
   const secondaryTextSize = 0.875 * settings.theme.typography.text.fontSize;
   const secondaryTextColor = `color-mix(in oklch, ${settings.theme.typography.text.color} 62.5%, ${settings.theme.card.background})`;

--- a/components/src/components/shared/checkout-dialog/Quantity.test.tsx
+++ b/components/src/components/shared/checkout-dialog/Quantity.test.tsx
@@ -1,0 +1,88 @@
+import { screen } from "@testing-library/react";
+
+import { render } from "../../../test/setup";
+import type { UsageBasedEntitlement } from "../../../types";
+
+import { Quantity } from "./Quantity";
+
+type EntitlementOverrides = Partial<Omit<UsageBasedEntitlement, "feature">> & {
+  feature?: { id: string; name: string };
+};
+
+function makeEntitlement(
+  overrides: EntitlementOverrides = {},
+): UsageBasedEntitlement {
+  return {
+    id: "ent-1",
+    featureId: "feat-1",
+    feature: {
+      id: "feat-1",
+      name: "Feature",
+    },
+    allocation: 0,
+    usage: 0,
+    quantity: 0,
+    ...overrides,
+  } as UsageBasedEntitlement;
+}
+
+describe("`Quantity` component", () => {
+  it("renders the entitlement quantity in the uncontrolled input", () => {
+    render(
+      <Quantity
+        isLoading={false}
+        period="month"
+        entitlements={[makeEntitlement({ quantity: 5 })]}
+        updateQuantity={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("spinbutton")).toHaveValue(5);
+  });
+
+  // Regression guard for the uncontrolled-input + key bug: switching plans
+  // replaces the entitlement at a given position with a different one (new id).
+  // With an index-based key React reused the same uncontrolled <input> DOM node
+  // and `defaultValue` (a mount-only prop) was never re-applied, leaving the
+  // previous entitlement's typed value showing for a different feature. Keying
+  // by entitlement identity remounts the input so it reflects the new value.
+  it("re-syncs the uncontrolled input when the entitlement at a position changes identity", () => {
+    const { rerender } = render(
+      <Quantity
+        isLoading={false}
+        period="month"
+        entitlements={[
+          makeEntitlement({
+            id: "ent-a",
+            featureId: "feat-a",
+            feature: { id: "feat-a", name: "Feature A" },
+            quantity: 5,
+          }),
+        ]}
+        updateQuantity={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Feature A")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton")).toHaveValue(5);
+
+    rerender(
+      <Quantity
+        isLoading={false}
+        period="month"
+        entitlements={[
+          makeEntitlement({
+            id: "ent-b",
+            featureId: "feat-b",
+            feature: { id: "feat-b", name: "Feature B" },
+            quantity: 2,
+          }),
+        ]}
+        updateQuantity={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Feature B")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton")).toHaveValue(2);
+  });
+});

--- a/components/src/components/shared/checkout-dialog/Quantity.test.tsx
+++ b/components/src/components/shared/checkout-dialog/Quantity.test.tsx
@@ -40,12 +40,6 @@ describe("`Quantity` component", () => {
     expect(screen.getByRole("spinbutton")).toHaveValue(5);
   });
 
-  // Regression guard for the uncontrolled-input + key bug: switching plans
-  // replaces the entitlement at a given position with a different one (new id).
-  // With an index-based key React reused the same uncontrolled <input> DOM node
-  // and `defaultValue` (a mount-only prop) was never re-applied, leaving the
-  // previous entitlement's typed value showing for a different feature. Keying
-  // by entitlement identity remounts the input so it reflects the new value.
   it("re-syncs the uncontrolled input when the entitlement at a position changes identity", () => {
     const { rerender } = render(
       <Quantity

--- a/components/src/components/shared/checkout-dialog/Quantity.tsx
+++ b/components/src/components/shared/checkout-dialog/Quantity.tsx
@@ -42,7 +42,7 @@ export const Quantity = ({
 
   return (
     <Flex $flexDirection="column" $gap="1rem">
-      {entitlements.reduce((acc: React.ReactElement[], entitlement, index) => {
+      {entitlements.reduce((acc: React.ReactElement[], entitlement) => {
         if (entitlement.feature) {
           const entitlementBillingPrice = getEntitlementPrice(
             entitlement,
@@ -60,8 +60,14 @@ export const Quantity = ({
           const tiered = isTieredPrice(entitlementBillingPrice);
 
           acc.push(
+            // Key by entitlement identity, not list index: the inputs are
+            // uncontrolled (defaultValue), so an index key would let React
+            // reuse one input's DOM node for a different entitlement on a
+            // plan switch, leaving a stale typed value. An identity key remounts
+            // a genuinely different entitlement (re-applying defaultValue) while
+            // leaving a surviving row's node — and its preserved value — intact.
             <Flex
-              key={index}
+              key={entitlement.id}
               $justifyContent="space-between"
               $alignItems="center"
               $gap="1rem"

--- a/components/src/components/shared/checkout-dialog/Quantity.tsx
+++ b/components/src/components/shared/checkout-dialog/Quantity.tsx
@@ -60,12 +60,6 @@ export const Quantity = ({
           const tiered = isTieredPrice(entitlementBillingPrice);
 
           acc.push(
-            // Key by entitlement identity, not list index: the inputs are
-            // uncontrolled (defaultValue), so an index key would let React
-            // reuse one input's DOM node for a different entitlement on a
-            // plan switch, leaving a stale typed value. An identity key remounts
-            // a genuinely different entitlement (re-applying defaultValue) while
-            // leaving a surviving row's node — and its preserved value — intact.
             <Flex
               key={entitlement.id}
               $justifyContent="space-between"

--- a/components/src/components/shared/hard-limit-tooltip/HardLimitTooltip.test.tsx
+++ b/components/src/components/shared/hard-limit-tooltip/HardLimitTooltip.test.tsx
@@ -140,17 +140,19 @@ describe("`HardLimitTooltip` component", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  test("throws when data exists but displaySettings is undefined", () => {
+  test("does not render when data exists but displaySettings is undefined", () => {
     mockUseEmbed.mockReturnValue({
       data: { displaySettings: undefined },
     });
     mockUseIsLightBackground.mockReturnValue(true);
 
-    // The component accesses data?.displaySettings.showHardLimit
-    // which throws if data exists but displaySettings is undefined
-    expect(() =>
-      render(<HardLimitTooltip feature={createMockFeature()} limit={500} />),
-    ).toThrow();
+    // The component reads data?.displaySettings?.showHardLimit, so a missing
+    // displaySettings resolves to `false` rather than throwing.
+    const { container } = render(
+      <HardLimitTooltip feature={createMockFeature()} limit={500} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 
   test("uses feature name fallback when singularName and pluralName are not set", () => {

--- a/components/src/components/shared/hard-limit-tooltip/HardLimitTooltip.tsx
+++ b/components/src/components/shared/hard-limit-tooltip/HardLimitTooltip.tsx
@@ -22,7 +22,7 @@ export const HardLimitTooltip = ({
 
   const isLightBackground = useIsLightBackground();
 
-  const showHardLimit = data?.displaySettings.showHardLimit ?? false;
+  const showHardLimit = data?.displaySettings?.showHardLimit ?? false;
 
   if (!showHardLimit || !feature || typeof limit !== "number") {
     return null;

--- a/components/src/utils/api/checkout.test.ts
+++ b/components/src/utils/api/checkout.test.ts
@@ -638,7 +638,10 @@ describe("buildAddOnRequestBody", () => {
 
 describe("isAddOnCompatibleWithPlan", () => {
   const compatibilities = [
-    { sourcePlanId: "addon-restricted", compatiblePlanIds: ["plan-a", "plan-b"] },
+    {
+      sourcePlanId: "addon-restricted",
+      compatiblePlanIds: ["plan-a", "plan-b"],
+    },
     { sourcePlanId: "addon-empty", compatiblePlanIds: [] },
   ];
 

--- a/components/src/utils/api/checkout.test.ts
+++ b/components/src/utils/api/checkout.test.ts
@@ -13,10 +13,12 @@ import type {
   UsageBasedEntitlement,
 } from "../../types";
 import {
+  buildAddOnCompatibilityLookup,
   buildAddOnRequestBody,
   buildAutoTopupRequestBody,
   buildCreditBundlesRequestBody,
   buildPayInAdvanceRequestBody,
+  isAddOnCompatibleWithLookup,
   isAddOnCompatibleWithPlan,
   isScheduledCheckoutConflictMessage,
 } from "./checkout";
@@ -677,6 +679,46 @@ describe("isAddOnCompatibleWithPlan", () => {
 
   it("should treat any add-on as compatible when no compatibilities are provided", () => {
     expect(isAddOnCompatibleWithPlan("addon-restricted", "plan-a")).toBe(true);
+  });
+});
+
+describe("buildAddOnCompatibilityLookup / isAddOnCompatibleWithLookup", () => {
+  const compatibilities = [
+    {
+      sourcePlanId: "addon-restricted",
+      compatiblePlanIds: ["plan-a", "plan-b"],
+    },
+    { sourcePlanId: "addon-empty", compatiblePlanIds: [] },
+  ];
+
+  it("matches isAddOnCompatibleWithPlan across the same cases", () => {
+    const lookup = buildAddOnCompatibilityLookup(compatibilities);
+
+    for (const [addOnId, planId] of [
+      ["addon-unknown", "plan-a"],
+      ["addon-empty", "plan-a"],
+      ["addon-restricted", "plan-b"],
+      ["addon-restricted", "plan-c"],
+      ["addon-restricted", undefined],
+    ] as [string, string | undefined][]) {
+      expect(isAddOnCompatibleWithLookup(lookup, addOnId, planId)).toBe(
+        isAddOnCompatibleWithPlan(addOnId, planId, compatibilities),
+      );
+    }
+  });
+
+  it("keeps the first entry when a source plan id is duplicated", () => {
+    const lookup = buildAddOnCompatibilityLookup([
+      { sourcePlanId: "addon-dup", compatiblePlanIds: ["plan-a"] },
+      { sourcePlanId: "addon-dup", compatiblePlanIds: ["plan-b"] },
+    ]);
+
+    expect(isAddOnCompatibleWithLookup(lookup, "addon-dup", "plan-a")).toBe(
+      true,
+    );
+    expect(isAddOnCompatibleWithLookup(lookup, "addon-dup", "plan-b")).toBe(
+      false,
+    );
   });
 });
 

--- a/components/src/utils/api/checkout.test.ts
+++ b/components/src/utils/api/checkout.test.ts
@@ -660,15 +660,15 @@ describe("buildAddOnCompatibilityLookup / isAddOnCompatibleWithLookup", () => {
   });
 
   it("returns true when the plan is in compatiblePlanIds", () => {
-    expect(isAddOnCompatibleWithLookup(lookup, "addon-restricted", "plan-b")).toBe(
-      true,
-    );
+    expect(
+      isAddOnCompatibleWithLookup(lookup, "addon-restricted", "plan-b"),
+    ).toBe(true);
   });
 
   it("returns false when the plan is not in compatiblePlanIds", () => {
-    expect(isAddOnCompatibleWithLookup(lookup, "addon-restricted", "plan-c")).toBe(
-      false,
-    );
+    expect(
+      isAddOnCompatibleWithLookup(lookup, "addon-restricted", "plan-c"),
+    ).toBe(false);
   });
 
   it("returns false for a restricted add-on when no plan is provided", () => {

--- a/components/src/utils/api/checkout.test.ts
+++ b/components/src/utils/api/checkout.test.ts
@@ -19,7 +19,6 @@ import {
   buildCreditBundlesRequestBody,
   buildPayInAdvanceRequestBody,
   isAddOnCompatibleWithLookup,
-  isAddOnCompatibleWithPlan,
   isScheduledCheckoutConflictMessage,
 } from "./checkout";
 
@@ -638,50 +637,6 @@ describe("buildAddOnRequestBody", () => {
   });
 });
 
-describe("isAddOnCompatibleWithPlan", () => {
-  const compatibilities = [
-    {
-      sourcePlanId: "addon-restricted",
-      compatiblePlanIds: ["plan-a", "plan-b"],
-    },
-    { sourcePlanId: "addon-empty", compatiblePlanIds: [] },
-  ];
-
-  it("should treat an add-on with no compatibility entry as compatible", () => {
-    expect(
-      isAddOnCompatibleWithPlan("addon-unknown", "plan-a", compatibilities),
-    ).toBe(true);
-  });
-
-  it("should treat an add-on with an empty compatiblePlanIds as compatible", () => {
-    expect(
-      isAddOnCompatibleWithPlan("addon-empty", "plan-a", compatibilities),
-    ).toBe(true);
-  });
-
-  it("should return true when the plan is in compatiblePlanIds", () => {
-    expect(
-      isAddOnCompatibleWithPlan("addon-restricted", "plan-b", compatibilities),
-    ).toBe(true);
-  });
-
-  it("should return false when the plan is not in compatiblePlanIds", () => {
-    expect(
-      isAddOnCompatibleWithPlan("addon-restricted", "plan-c", compatibilities),
-    ).toBe(false);
-  });
-
-  it("should return false for a restricted add-on when no plan is provided", () => {
-    expect(
-      isAddOnCompatibleWithPlan("addon-restricted", undefined, compatibilities),
-    ).toBe(false);
-  });
-
-  it("should treat any add-on as compatible when no compatibilities are provided", () => {
-    expect(isAddOnCompatibleWithPlan("addon-restricted", "plan-a")).toBe(true);
-  });
-});
-
 describe("buildAddOnCompatibilityLookup / isAddOnCompatibleWithLookup", () => {
   const compatibilities = [
     {
@@ -690,33 +645,55 @@ describe("buildAddOnCompatibilityLookup / isAddOnCompatibleWithLookup", () => {
     },
     { sourcePlanId: "addon-empty", compatiblePlanIds: [] },
   ];
+  const lookup = buildAddOnCompatibilityLookup(compatibilities);
 
-  it("matches isAddOnCompatibleWithPlan across the same cases", () => {
-    const lookup = buildAddOnCompatibilityLookup(compatibilities);
+  it("treats an add-on with no compatibility entry as compatible", () => {
+    expect(isAddOnCompatibleWithLookup(lookup, "addon-unknown", "plan-a")).toBe(
+      true,
+    );
+  });
 
-    for (const [addOnId, planId] of [
-      ["addon-unknown", "plan-a"],
-      ["addon-empty", "plan-a"],
-      ["addon-restricted", "plan-b"],
-      ["addon-restricted", "plan-c"],
-      ["addon-restricted", undefined],
-    ] as [string, string | undefined][]) {
-      expect(isAddOnCompatibleWithLookup(lookup, addOnId, planId)).toBe(
-        isAddOnCompatibleWithPlan(addOnId, planId, compatibilities),
-      );
-    }
+  it("treats an add-on with an empty compatiblePlanIds as compatible", () => {
+    expect(isAddOnCompatibleWithLookup(lookup, "addon-empty", "plan-a")).toBe(
+      true,
+    );
+  });
+
+  it("returns true when the plan is in compatiblePlanIds", () => {
+    expect(isAddOnCompatibleWithLookup(lookup, "addon-restricted", "plan-b")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the plan is not in compatiblePlanIds", () => {
+    expect(isAddOnCompatibleWithLookup(lookup, "addon-restricted", "plan-c")).toBe(
+      false,
+    );
+  });
+
+  it("returns false for a restricted add-on when no plan is provided", () => {
+    expect(
+      isAddOnCompatibleWithLookup(lookup, "addon-restricted", undefined),
+    ).toBe(false);
+  });
+
+  it("treats any add-on as compatible for an empty lookup", () => {
+    const emptyLookup = buildAddOnCompatibilityLookup();
+    expect(
+      isAddOnCompatibleWithLookup(emptyLookup, "addon-restricted", "plan-a"),
+    ).toBe(true);
   });
 
   it("keeps the first entry when a source plan id is duplicated", () => {
-    const lookup = buildAddOnCompatibilityLookup([
+    const dupLookup = buildAddOnCompatibilityLookup([
       { sourcePlanId: "addon-dup", compatiblePlanIds: ["plan-a"] },
       { sourcePlanId: "addon-dup", compatiblePlanIds: ["plan-b"] },
     ]);
 
-    expect(isAddOnCompatibleWithLookup(lookup, "addon-dup", "plan-a")).toBe(
+    expect(isAddOnCompatibleWithLookup(dupLookup, "addon-dup", "plan-a")).toBe(
       true,
     );
-    expect(isAddOnCompatibleWithLookup(lookup, "addon-dup", "plan-b")).toBe(
+    expect(isAddOnCompatibleWithLookup(dupLookup, "addon-dup", "plan-b")).toBe(
       false,
     );
   });

--- a/components/src/utils/api/checkout.test.ts
+++ b/components/src/utils/api/checkout.test.ts
@@ -1,14 +1,23 @@
-import type { BillingPriceView } from "../../api/checkoutexternal";
-import { PlanIcon } from "../../api/checkoutexternal";
 import type {
+  BillingPriceView,
+  PlanCreditGrantView,
+} from "../../api/checkoutexternal";
+import {
+  BillingCreditAutoTopupAvailability,
+  PlanIcon,
+} from "../../api/checkoutexternal";
+import type {
+  AutoTopupConfig,
   CreditBundle,
   SelectedPlan,
   UsageBasedEntitlement,
 } from "../../types";
 import {
   buildAddOnRequestBody,
+  buildAutoTopupRequestBody,
   buildCreditBundlesRequestBody,
   buildPayInAdvanceRequestBody,
+  isAddOnCompatibleWithPlan,
   isScheduledCheckoutConflictMessage,
 } from "./checkout";
 
@@ -111,6 +120,132 @@ function makeCreditBundle(overrides: Partial<CreditBundle> = {}): CreditBundle {
     ...overrides,
   };
 }
+
+function makePlanCreditGrant(
+  overrides: Partial<PlanCreditGrantView> = {},
+): PlanCreditGrantView {
+  return {
+    id: "grant-1",
+    billingCreditAutoTopupAvailability: null,
+    ...overrides,
+  } as PlanCreditGrantView;
+}
+
+function makeAutoTopupConfig(
+  overrides: Partial<AutoTopupConfig> = {},
+): AutoTopupConfig {
+  return {
+    companyAutoTopupEnabled: true,
+    companyAutoTopupThresholdCredits: 10,
+    companyAutoTopupAmount: 100,
+    ...overrides,
+  };
+}
+
+describe("buildAutoTopupRequestBody", () => {
+  it("should return an empty array for empty credit grants", () => {
+    const result = buildAutoTopupRequestBody({
+      creditGrants: [],
+      autoTopupConfigs: new Map(),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("should emit an override for a grant with a config and availability not off", () => {
+    const creditGrants = [
+      makePlanCreditGrant({
+        id: "grant-1",
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Automatic,
+      }),
+    ];
+    const autoTopupConfigs = new Map([["grant-1", makeAutoTopupConfig()]]);
+
+    const result = buildAutoTopupRequestBody({
+      creditGrants,
+      autoTopupConfigs,
+    });
+
+    expect(result).toEqual([
+      {
+        planCreditGrantId: "grant-1",
+        autoTopupEnabled: true,
+        autoTopupAmount: 100,
+        autoTopupThresholdCredits: 10,
+      },
+    ]);
+  });
+
+  it("should skip a grant whose availability is off even when a config exists", () => {
+    const creditGrants = [
+      makePlanCreditGrant({
+        id: "grant-1",
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Off,
+      }),
+    ];
+    const autoTopupConfigs = new Map([
+      ["grant-1", makeAutoTopupConfig({ companyAutoTopupEnabled: false })],
+    ]);
+
+    const result = buildAutoTopupRequestBody({
+      creditGrants,
+      autoTopupConfigs,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("should skip a grant without a matching config", () => {
+    const creditGrants = [
+      makePlanCreditGrant({
+        id: "grant-1",
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Automatic,
+      }),
+    ];
+
+    const result = buildAutoTopupRequestBody({
+      creditGrants,
+      autoTopupConfigs: new Map(),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("should emit overrides only for non-off grants in a mixed set", () => {
+    const creditGrants = [
+      makePlanCreditGrant({
+        id: "grant-on",
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Automatic,
+      }),
+      makePlanCreditGrant({
+        id: "grant-off",
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Off,
+      }),
+    ];
+    const autoTopupConfigs = new Map([
+      ["grant-on", makeAutoTopupConfig({ companyAutoTopupAmount: 50 })],
+      ["grant-off", makeAutoTopupConfig()],
+    ]);
+
+    const result = buildAutoTopupRequestBody({
+      creditGrants,
+      autoTopupConfigs,
+    });
+
+    expect(result).toEqual([
+      {
+        planCreditGrantId: "grant-on",
+        autoTopupEnabled: true,
+        autoTopupAmount: 50,
+        autoTopupThresholdCredits: 10,
+      },
+    ]);
+  });
+});
 
 describe("buildPayInAdvanceRequestBody", () => {
   it("should return an empty array for empty entitlements", () => {
@@ -498,6 +633,47 @@ describe("buildAddOnRequestBody", () => {
       { addOnId: "addon-1", priceId: "mp-1" },
       { addOnId: "addon-3", priceId: "mp-3" },
     ]);
+  });
+});
+
+describe("isAddOnCompatibleWithPlan", () => {
+  const compatibilities = [
+    { sourcePlanId: "addon-restricted", compatiblePlanIds: ["plan-a", "plan-b"] },
+    { sourcePlanId: "addon-empty", compatiblePlanIds: [] },
+  ];
+
+  it("should treat an add-on with no compatibility entry as compatible", () => {
+    expect(
+      isAddOnCompatibleWithPlan("addon-unknown", "plan-a", compatibilities),
+    ).toBe(true);
+  });
+
+  it("should treat an add-on with an empty compatiblePlanIds as compatible", () => {
+    expect(
+      isAddOnCompatibleWithPlan("addon-empty", "plan-a", compatibilities),
+    ).toBe(true);
+  });
+
+  it("should return true when the plan is in compatiblePlanIds", () => {
+    expect(
+      isAddOnCompatibleWithPlan("addon-restricted", "plan-b", compatibilities),
+    ).toBe(true);
+  });
+
+  it("should return false when the plan is not in compatiblePlanIds", () => {
+    expect(
+      isAddOnCompatibleWithPlan("addon-restricted", "plan-c", compatibilities),
+    ).toBe(false);
+  });
+
+  it("should return false for a restricted add-on when no plan is provided", () => {
+    expect(
+      isAddOnCompatibleWithPlan("addon-restricted", undefined, compatibilities),
+    ).toBe(false);
+  });
+
+  it("should treat any add-on as compatible when no compatibilities are provided", () => {
+    expect(isAddOnCompatibleWithPlan("addon-restricted", "plan-a")).toBe(true);
   });
 });
 

--- a/components/src/utils/api/checkout.ts
+++ b/components/src/utils/api/checkout.ts
@@ -1,5 +1,6 @@
 import {
   PlanCreditGrantView,
+  type CompatiblePlans,
   type UpdateAddOnRequestBody,
   type UpdateAutoTopupOverrideRequestBody,
   type UpdateCreditBundleRequestBody,
@@ -12,6 +13,7 @@ import type {
   UsageBasedEntitlement,
 } from "../../types";
 import { getAddOnPrice, getEntitlementPrice } from "./billing";
+import { isAutoTopupOff } from "./credit";
 
 export function buildAutoTopupRequestBody(options: {
   creditGrants: PlanCreditGrantView[];
@@ -21,7 +23,7 @@ export function buildAutoTopupRequestBody(options: {
 
   return creditGrants.reduce(
     (acc: UpdateAutoTopupOverrideRequestBody[], grant) => {
-      if (autoTopupConfigs?.has(grant.id)) {
+      if (!isAutoTopupOff(grant) && autoTopupConfigs?.has(grant.id)) {
         const config = autoTopupConfigs.get(grant.id);
 
         acc.push({
@@ -36,6 +38,24 @@ export function buildAutoTopupRequestBody(options: {
     },
     [],
   );
+}
+
+// An add-on is compatible with a plan when it declares no compatibility
+// restrictions (no entry, or an empty `compatiblePlanIds`) or when the plan is
+// explicitly listed. Used both to render the available add-ons and to filter
+// add-ons out of a checkout preview for the plan being previewed.
+export function isAddOnCompatibleWithPlan(
+  addOnId: string,
+  planId: string | undefined,
+  compatibilities: CompatiblePlans[] = [],
+): boolean {
+  const compat = compatibilities.find((c) => c.sourcePlanId === addOnId);
+
+  if (!compat || !compat.compatiblePlanIds?.length) {
+    return true;
+  }
+
+  return !!planId && compat.compatiblePlanIds.includes(planId);
 }
 
 export function buildPayInAdvanceRequestBody(options: {

--- a/components/src/utils/api/checkout.ts
+++ b/components/src/utils/api/checkout.ts
@@ -40,10 +40,6 @@ export function buildAutoTopupRequestBody(options: {
   );
 }
 
-// An add-on is compatible with a plan when it declares no compatibility
-// restrictions (no entry, or an empty `compatiblePlanIds`) or when the plan is
-// explicitly listed. Used both to render the available add-ons and to filter
-// add-ons out of a checkout preview for the plan being previewed.
 export function isAddOnCompatibleWithPlan(
   addOnId: string,
   planId: string | undefined,

--- a/components/src/utils/api/checkout.ts
+++ b/components/src/utils/api/checkout.ts
@@ -71,18 +71,6 @@ export function isAddOnCompatibleWithLookup(
   return !!planId && compatiblePlanIds.includes(planId);
 }
 
-export function isAddOnCompatibleWithPlan(
-  addOnId: string,
-  planId: string | undefined,
-  compatibilities: CompatiblePlans[] = [],
-): boolean {
-  return isAddOnCompatibleWithLookup(
-    buildAddOnCompatibilityLookup(compatibilities),
-    addOnId,
-    planId,
-  );
-}
-
 export function buildPayInAdvanceRequestBody(options: {
   entitlements: UsageBasedEntitlement[];
   period: string;

--- a/components/src/utils/api/checkout.ts
+++ b/components/src/utils/api/checkout.ts
@@ -40,18 +40,47 @@ export function buildAutoTopupRequestBody(options: {
   );
 }
 
+/**
+ * Builds an add-on-id → compatible-plan-ids lookup so repeated compatibility
+ * checks against the same `addOnCompatibilities` are O(1) instead of re-scanning
+ * the list per add-on. First entry wins, matching the prior `.find` semantics.
+ */
+export function buildAddOnCompatibilityLookup(
+  compatibilities: CompatiblePlans[] = [],
+): Map<string, string[]> {
+  const lookup = new Map<string, string[]>();
+  for (const compat of compatibilities) {
+    if (!lookup.has(compat.sourcePlanId)) {
+      lookup.set(compat.sourcePlanId, compat.compatiblePlanIds ?? []);
+    }
+  }
+  return lookup;
+}
+
+export function isAddOnCompatibleWithLookup(
+  lookup: Map<string, string[]>,
+  addOnId: string,
+  planId: string | undefined,
+): boolean {
+  const compatiblePlanIds = lookup.get(addOnId);
+
+  if (!compatiblePlanIds || compatiblePlanIds.length === 0) {
+    return true;
+  }
+
+  return !!planId && compatiblePlanIds.includes(planId);
+}
+
 export function isAddOnCompatibleWithPlan(
   addOnId: string,
   planId: string | undefined,
   compatibilities: CompatiblePlans[] = [],
 ): boolean {
-  const compat = compatibilities.find((c) => c.sourcePlanId === addOnId);
-
-  if (!compat || !compat.compatiblePlanIds?.length) {
-    return true;
-  }
-
-  return !!planId && compat.compatiblePlanIds.includes(planId);
+  return isAddOnCompatibleWithLookup(
+    buildAddOnCompatibilityLookup(compatibilities),
+    addOnId,
+    planId,
+  );
 }
 
 export function buildPayInAdvanceRequestBody(options: {

--- a/components/src/utils/api/credit.test.ts
+++ b/components/src/utils/api/credit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { BillingCreditAutoTopupAvailability } from "../../api/checkoutexternal";
+import { isTopupOff } from "./credit";
+
+describe("isTopupOff", () => {
+  it("returns true when availability is off", () => {
+    expect(
+      isTopupOff({
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Off,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for automatic and user_controlled", () => {
+    expect(
+      isTopupOff({
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Automatic,
+      }),
+    ).toBe(false);
+    expect(
+      isTopupOff({
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.UserControlled,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a missing availability as not off (legacy grants)", () => {
+    expect(isTopupOff(undefined)).toBe(false);
+    expect(isTopupOff({})).toBe(false);
+    expect(isTopupOff({ billingCreditAutoTopupAvailability: null })).toBe(
+      false,
+    );
+  });
+});

--- a/components/src/utils/api/credit.test.ts
+++ b/components/src/utils/api/credit.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { BillingCreditAutoTopupAvailability } from "../../api/checkoutexternal";
-import { isAutoTopupOff, isBundlePurchaseOff } from "./credit";
+import {
+  deriveCreditBundles,
+  filterCreditBundles,
+  getBundleOffCreditIds,
+  isAutoTopupOff,
+  isBundlePurchaseOff,
+  isSelfServiceAutoTopupAvailable,
+} from "./credit";
 
 describe("isAutoTopupOff", () => {
   it("returns true when availability is off", () => {
@@ -75,5 +82,101 @@ describe("bundle purchase and auto top-up are independent", () => {
     };
     expect(isBundlePurchaseOff(grant)).toBe(false);
     expect(isAutoTopupOff(grant)).toBe(true);
+  });
+});
+
+describe("isSelfServiceAutoTopupAvailable", () => {
+  it("is true only when self-service and not off", () => {
+    expect(
+      isSelfServiceAutoTopupAvailable({
+        billingCreditAutoTopupSelfService: true,
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.UserControlled,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when availability is off, even with self-service", () => {
+    expect(
+      isSelfServiceAutoTopupAvailable({
+        billingCreditAutoTopupSelfService: true,
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Off,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false without self-service, and for missing grants", () => {
+    expect(
+      isSelfServiceAutoTopupAvailable({
+        billingCreditAutoTopupSelfService: false,
+        billingCreditAutoTopupAvailability:
+          BillingCreditAutoTopupAvailability.Automatic,
+      }),
+    ).toBe(false);
+    expect(isSelfServiceAutoTopupAvailable(undefined)).toBe(false);
+  });
+});
+
+describe("getBundleOffCreditIds", () => {
+  const grants = [
+    { creditId: "credit-off", billingCreditCanBuyBundles: false },
+    { creditId: "credit-on", billingCreditCanBuyBundles: true },
+    { creditId: "credit-legacy" } as { creditId: string },
+  ];
+
+  it("collects only the credit ids whose bundle purchase is off", () => {
+    const ids = getBundleOffCreditIds(grants);
+    expect(ids.has("credit-off")).toBe(true);
+    expect(ids.has("credit-on")).toBe(false);
+    expect(ids.has("credit-legacy")).toBe(false);
+  });
+
+  it("returns an empty set for missing grants", () => {
+    expect(getBundleOffCreditIds(undefined).size).toBe(0);
+  });
+});
+
+describe("filterCreditBundles", () => {
+  const grants = [
+    { creditId: "credit-off", billingCreditCanBuyBundles: false },
+    { creditId: "credit-on", billingCreditCanBuyBundles: true },
+  ];
+  const bundles = [
+    { id: "b1", creditId: "credit-off", count: 3 },
+    { id: "b2", creditId: "credit-on", count: 1 },
+  ];
+
+  it("drops bundles whose credit is bundle-off and preserves counts", () => {
+    expect(filterCreditBundles(grants, bundles)).toEqual([
+      { id: "b2", creditId: "credit-on", count: 1 },
+    ]);
+  });
+
+  it("filters nothing when grants are missing (helper fails open)", () => {
+    expect(filterCreditBundles(undefined, bundles)).toEqual(bundles);
+  });
+});
+
+describe("deriveCreditBundles", () => {
+  const grants = [
+    { creditId: "credit-off", billingCreditCanBuyBundles: false },
+    { creditId: "credit-on", billingCreditCanBuyBundles: true },
+  ];
+  const bundles = [
+    { id: "b1", creditId: "credit-off" },
+    { id: "b2", creditId: "credit-on" },
+  ];
+
+  it("filters bundle-off credits and applies counts from the map", () => {
+    expect(deriveCreditBundles(grants, bundles, { b2: 4 })).toEqual([
+      { id: "b2", creditId: "credit-on", count: 4 },
+    ]);
+  });
+
+  it("defaults a surviving bundle's count to 0 when absent from the map", () => {
+    expect(deriveCreditBundles(grants, bundles, {})).toEqual([
+      { id: "b2", creditId: "credit-on", count: 0 },
+    ]);
   });
 });

--- a/components/src/utils/api/credit.test.ts
+++ b/components/src/utils/api/credit.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { BillingCreditAutoTopupAvailability } from "../../api/checkoutexternal";
-import { isTopupOff } from "./credit";
+import { isAutoTopupOff, isBundlePurchaseOff } from "./credit";
 
-describe("isTopupOff", () => {
+describe("isAutoTopupOff", () => {
   it("returns true when availability is off", () => {
     expect(
-      isTopupOff({
+      isAutoTopupOff({
         billingCreditAutoTopupAvailability:
           BillingCreditAutoTopupAvailability.Off,
       }),
@@ -15,13 +15,13 @@ describe("isTopupOff", () => {
 
   it("returns false for automatic and user_controlled", () => {
     expect(
-      isTopupOff({
+      isAutoTopupOff({
         billingCreditAutoTopupAvailability:
           BillingCreditAutoTopupAvailability.Automatic,
       }),
     ).toBe(false);
     expect(
-      isTopupOff({
+      isAutoTopupOff({
         billingCreditAutoTopupAvailability:
           BillingCreditAutoTopupAvailability.UserControlled,
       }),
@@ -29,10 +29,51 @@ describe("isTopupOff", () => {
   });
 
   it("treats a missing availability as not off (legacy grants)", () => {
-    expect(isTopupOff(undefined)).toBe(false);
-    expect(isTopupOff({})).toBe(false);
-    expect(isTopupOff({ billingCreditAutoTopupAvailability: null })).toBe(
+    expect(isAutoTopupOff(undefined)).toBe(false);
+    expect(isAutoTopupOff({})).toBe(false);
+    expect(isAutoTopupOff({ billingCreditAutoTopupAvailability: null })).toBe(
       false,
     );
+  });
+});
+
+describe("isBundlePurchaseOff", () => {
+  it("returns true when can buy bundles is false", () => {
+    expect(isBundlePurchaseOff({ billingCreditCanBuyBundles: false })).toBe(
+      true,
+    );
+  });
+
+  it("returns false when can buy bundles is true", () => {
+    expect(isBundlePurchaseOff({ billingCreditCanBuyBundles: true })).toBe(
+      false,
+    );
+  });
+
+  it("treats a missing value as not off (legacy grants)", () => {
+    expect(isBundlePurchaseOff(undefined)).toBe(false);
+    expect(isBundlePurchaseOff({})).toBe(false);
+  });
+});
+
+describe("bundle purchase and auto top-up are independent", () => {
+  it("bundle purchase off does not imply auto top-up off", () => {
+    const grant = {
+      billingCreditCanBuyBundles: false,
+      billingCreditAutoTopupAvailability:
+        BillingCreditAutoTopupAvailability.Automatic,
+    };
+    expect(isBundlePurchaseOff(grant)).toBe(true);
+    expect(isAutoTopupOff(grant)).toBe(false);
+  });
+
+  it("auto top-up off does not imply bundle purchase off", () => {
+    const grant = {
+      billingCreditCanBuyBundles: true,
+      billingCreditAutoTopupAvailability:
+        BillingCreditAutoTopupAvailability.Off,
+    };
+    expect(isBundlePurchaseOff(grant)).toBe(false);
+    expect(isAutoTopupOff(grant)).toBe(true);
   });
 });

--- a/components/src/utils/api/credit.ts
+++ b/components/src/utils/api/credit.ts
@@ -6,11 +6,7 @@ import {
   type CreditCompanyGrantView,
   type PlanCreditGrantView,
 } from "../../api/checkoutexternal";
-import type {
-  Credit,
-  CreditBundle,
-  CreditWithCompanyContext,
-} from "../../types";
+import type { Credit, CreditWithCompanyContext } from "../../types";
 
 function getResetCadencePeriod(cadence: PlanCreditGrantView["resetCadence"]) {
   switch (cadence) {
@@ -140,6 +136,21 @@ export function isAutoTopupOff(
   );
 }
 
+/**
+ * A credit grant's self-service auto top-up controls are available only when the
+ * grant opts into self-service *and* its availability isn't `off`. Centralized so
+ * every surface (PlanManager notice/rows, AutoTopup card, checkout stage) gates
+ * identically and can't drift if the semantics change.
+ */
+export function isSelfServiceAutoTopupAvailable(
+  grant?: Pick<
+    CompanyPlanCreditGrantView,
+    "billingCreditAutoTopupSelfService" | "billingCreditAutoTopupAvailability"
+  >,
+) {
+  return !!grant?.billingCreditAutoTopupSelfService && !isAutoTopupOff(grant);
+}
+
 export function isBundlePurchaseOff(
   grant?: Partial<
     Pick<CompanyPlanCreditGrantView, "billingCreditCanBuyBundles">
@@ -148,25 +159,47 @@ export function isBundlePurchaseOff(
   return grant?.billingCreditCanBuyBundles === false;
 }
 
-export function deriveCreditBundles(
-  grants:
-    | Pick<PlanCreditGrantView, "creditId" | "billingCreditCanBuyBundles">[]
-    | undefined,
-  bundles: (BillingCreditBundleView & { count?: number })[] | undefined,
-  counts?: Record<string, number>,
-): CreditBundle[] {
-  const bundleOffCreditIds = new Set(
-    (grants ?? [])
-      .filter((grant) => isBundlePurchaseOff(grant))
-      .map((grant) => grant.creditId),
-  );
+type BundleGatingGrant = Pick<PlanCreditGrantView, "creditId"> &
+  Partial<Pick<PlanCreditGrantView, "billingCreditCanBuyBundles">>;
 
-  return (bundles ?? [])
-    .filter((bundle) => !bundleOffCreditIds.has(bundle.creditId))
-    .map((bundle) => ({
-      ...bundle,
-      count: counts ? (counts[bundle.id] ?? 0) : (bundle.count ?? 0),
-    }));
+/** The set of credit ids whose grant has bundle purchase turned off. */
+export function getBundleOffCreditIds(
+  grants?: BundleGatingGrant[],
+): Set<string> {
+  const ids = new Set<string>();
+  (grants ?? []).forEach((grant) => {
+    if (isBundlePurchaseOff(grant)) {
+      ids.add(grant.creditId);
+    }
+  });
+  return ids;
+}
+
+/** Drops bundles whose credit has bundle purchase off on the given plan's grants. */
+export function filterCreditBundles<
+  T extends Pick<BillingCreditBundleView, "creditId">,
+>(grants: BundleGatingGrant[] | undefined, bundles: T[] | undefined): T[] {
+  const bundleOffCreditIds = getBundleOffCreditIds(grants);
+  return (bundles ?? []).filter(
+    (bundle) => !bundleOffCreditIds.has(bundle.creditId),
+  );
+}
+
+/**
+ * Filters bundles by the plan's bundle-off gating and resolves each surviving
+ * bundle's `count` from the supplied counts map (keyed by bundle id).
+ */
+export function deriveCreditBundles<
+  T extends Pick<BillingCreditBundleView, "id" | "creditId">,
+>(
+  grants: BundleGatingGrant[] | undefined,
+  bundles: T[] | undefined,
+  counts: Record<string, number>,
+): (T & { count: number })[] {
+  return filterCreditBundles(grants, bundles).map((bundle) => ({
+    ...bundle,
+    count: counts[bundle.id] ?? 0,
+  }));
 }
 
 export function getAutoTopupThresholdCredits(

--- a/components/src/utils/api/credit.ts
+++ b/components/src/utils/api/credit.ts
@@ -123,22 +123,24 @@ export function isAutoTopupEnabled(grant?: CompanyPlanCreditGrantView) {
   return grant?.billingCreditAutoTopupEnabled ?? false;
 }
 
-// isTopupOff reports whether a plan credit grant has top-up availability set to
-// "off", in which case buyers cannot purchase more credits or manage auto
-// top-up. The field is nullable on the wire; a missing value is treated as not
-// off so legacy grants keep their existing behavior. The grant's legacy
-// enabled/self_service booleans (which the self-service surfaces gate on) are
-// already derived to false when availability is off.
-export function isTopupOff(
+export function isAutoTopupOff(
   grant?: Pick<
     CompanyPlanCreditGrantView,
     "billingCreditAutoTopupAvailability"
   >,
-): boolean {
+) {
   return (
     grant?.billingCreditAutoTopupAvailability ===
     BillingCreditAutoTopupAvailability.Off
   );
+}
+
+export function isBundlePurchaseOff(
+  grant?: Partial<
+    Pick<CompanyPlanCreditGrantView, "billingCreditCanBuyBundles">
+  >,
+) {
+  return grant?.billingCreditCanBuyBundles === false;
 }
 
 export function getAutoTopupThresholdCredits(

--- a/components/src/utils/api/credit.ts
+++ b/components/src/utils/api/credit.ts
@@ -1,11 +1,16 @@
 import {
+  type BillingCreditBundleView,
   BillingCreditAutoTopupAvailability,
   BillingPlanCreditGrantResetCadence,
   type CompanyPlanCreditGrantView,
   type CreditCompanyGrantView,
   type PlanCreditGrantView,
 } from "../../api/checkoutexternal";
-import type { Credit, CreditWithCompanyContext } from "../../types";
+import type {
+  Credit,
+  CreditBundle,
+  CreditWithCompanyContext,
+} from "../../types";
 
 function getResetCadencePeriod(cadence: PlanCreditGrantView["resetCadence"]) {
   switch (cadence) {
@@ -141,6 +146,27 @@ export function isBundlePurchaseOff(
   >,
 ) {
   return grant?.billingCreditCanBuyBundles === false;
+}
+
+export function deriveCreditBundles(
+  grants:
+    | Pick<PlanCreditGrantView, "creditId" | "billingCreditCanBuyBundles">[]
+    | undefined,
+  bundles: (BillingCreditBundleView & { count?: number })[] | undefined,
+  counts?: Record<string, number>,
+): CreditBundle[] {
+  const bundleOffCreditIds = new Set(
+    (grants ?? [])
+      .filter((grant) => isBundlePurchaseOff(grant))
+      .map((grant) => grant.creditId),
+  );
+
+  return (bundles ?? [])
+    .filter((bundle) => !bundleOffCreditIds.has(bundle.creditId))
+    .map((bundle) => ({
+      ...bundle,
+      count: counts ? (counts[bundle.id] ?? 0) : (bundle.count ?? 0),
+    }));
 }
 
 export function getAutoTopupThresholdCredits(

--- a/components/src/utils/api/credit.ts
+++ b/components/src/utils/api/credit.ts
@@ -1,4 +1,5 @@
 import {
+  BillingCreditAutoTopupAvailability,
   BillingPlanCreditGrantResetCadence,
   type CompanyPlanCreditGrantView,
   type CreditCompanyGrantView,
@@ -120,6 +121,24 @@ export function isAutoTopupEnabled(grant?: CompanyPlanCreditGrantView) {
   }
 
   return grant?.billingCreditAutoTopupEnabled ?? false;
+}
+
+// isTopupOff reports whether a plan credit grant has top-up availability set to
+// "off", in which case buyers cannot purchase more credits or manage auto
+// top-up. The field is nullable on the wire; a missing value is treated as not
+// off so legacy grants keep their existing behavior. The grant's legacy
+// enabled/self_service booleans (which the self-service surfaces gate on) are
+// already derived to false when availability is off.
+export function isTopupOff(
+  grant?: Pick<
+    CompanyPlanCreditGrantView,
+    "billingCreditAutoTopupAvailability"
+  >,
+): boolean {
+  return (
+    grant?.billingCreditAutoTopupAvailability ===
+    BillingCreditAutoTopupAvailability.Off
+  );
 }
 
 export function getAutoTopupThresholdCredits(


### PR DESCRIPTION
Components follow-up for SchematicHQ/schematic-api#6098 (SCHY-436).

Regenerates the `checkoutexternal` / `componentspublic` clients for the new `BillingCreditAutoTopupAvailability` enum and `billingCreditCanBuyBundles` flag, then gates the credit purchase and auto top-up surfaces on the two settings independently.

A plan credit grant now exposes two separate controls:

- **`can_buy_bundles`** — one-time credit bundle purchase
- **`auto_topup_availability`** — threshold-based auto top-up (`off` disables it)

These are independent: bundles can be on while auto top-up is off, and vice versa.

## Helpers

Three predicates/derivations in `utils/api/credit.ts` (unit-tested in `credit.test.ts`):

- **`isBundlePurchaseOff(grant)`** — `billingCreditCanBuyBundles === false` (a missing flag defaults to on).
- **`isAutoTopupOff(grant)`** — `billingCreditAutoTopupAvailability === off`.
- **`deriveCreditBundles(grants, bundles, counts?)`** — drops bundles whose credit has purchase off on the given plan's grants and resolves each surviving bundle's `count`. With a `counts` map the count comes from it (keyed by bundle id); without one, the count already on the bundle is preserved. Single source of truth for the three bundle-filter sites in `CheckoutDialog`.

## Surface gating

- **Buy-more button** (`MeteredFeatures`) and **checkout bundle step** (`CheckoutDialog`) are hidden when `can_buy_bundles` is `false`.
- **Auto top-up indicator** (`PlanManager`), **auto top-up edit card** (`AutoTopup`), and **checkout auto top-up step** (`CheckoutDialog`) are hidden when `auto_topup_availability` is `off`. In `PlanManager` the gate is applied consistently — the block-level `hasAutoTopupSelfService`, the per-credit `AutoTopupNotice`, and the inner per-grant reduce all combine `billingCreditAutoTopupSelfService && !isAutoTopupOff(grant)`, so an `off` grant can't leak a row in a mixed grant set.

## Checkout request hygiene

Hiding a surface in the UI isn't enough — the preview/checkout request bodies must not include disabled items either. These fixes keep the request scoped to the plan actually being previewed/purchased:

1. **Credit bundles are derived from the selected plan.** `CheckoutDialog` derives the available `creditBundles` from `selectedPlan` (via `deriveCreditBundles`) and re-derives as the selection changes, instead of computing once from the company's current plan. User-entered counts are tracked separately so they survive re-renders.
2. **Bundles are filtered against the plan being previewed.** `handlePreviewCheckout` re-filters `creditBundles` by the resolved `plan`'s grants, so a stale debounced update can't carry a bundle for a credit that's bundle-off on the newly selected plan. `selectPlan` re-derives the same way.
3. **Auto top-up overrides skip `off` grants.** `buildAutoTopupRequestBody` skips grants whose `auto_topup_availability` is `off`, closing the same leak for the auto top-up half — covers both the preview (`CheckoutDialog`) and the real purchase (`SubscriptionSidebar`) at the shared builder.
4. **Add-ons are filtered against the plan being previewed.** A shared `isAddOnCompatibleWithPlan` helper (also used by the `addOns` memo) filters `resolvedAddOns` in `handlePreviewCheckout` against the resolved `plan`, so a plan switch no longer sends add-ons incompatible with the newly selected plan.

Unit tests added in `checkout.test.ts` for `buildAutoTopupRequestBody` (off-grant skipping) and `isAddOnCompatibleWithPlan`.

## Checkout input hardening

Fixes found while reviewing the checkout dialog's React state/effects:

- **Quantity and auto top-up rows are keyed by entity id, not list index.** These inputs are uncontrolled (`defaultValue`, applied only on mount). An index key let React reuse one input's DOM node for a different entitlement on a plan switch, leaving the previous row's typed value next to a different feature. Keying by `entitlement.id` / `grant.id` keeps a surviving row's node intact while remounting a genuinely different row so `defaultValue` re-applies. Adds a `Quantity` render test covering the plan-switch identity change.

## Defensive display-setting guards

Optional-chaining the `displaySettings` access in the spots that read it directly, so a hydrate payload with `data` present but `displaySettings` absent resolves to the default instead of throwing:

- `Entitlement` — `showFeatureDescription`
- `MeteredFeatures` — `showCredits`
- `HardLimitTooltip` — `showHardLimit` (its test now asserts it renders nothing rather than throwing)

`MeteredFeatures` `creditGroups` is also memoized to match the adjacent `bundleOffCreditIds` memo.
