### PR TITLE
SCHY-455 Allow prefill of pay-in-advance quantities in programmatic checkout

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -48,23 +48,33 @@ selection stage.
 initializeWithPlan('plan_VBXv4bHjSf3');
 ```
 
-Passing a config object allows pre-selecting Add-ons as well as hiding
-specific stages.
+Passing a config object allows pre-selecting Add-ons and pay-in-advance
+quantities, as well as hiding specific stages.
 
 ```ts
 const config = {
   planId: 'plan_VBXv4bHjSf3',      // pre-select a Plan
   addOnIds: ['plan_AWv7bPjSx2'],   // pre-select 1 or more Add-ons
   period: 'month',                 // pre-select 'month' or 'year' for the billing period (optional)
+  payInAdvanceQuantities: {        // pre-fill pay-in-advance quantities, keyed by feature id (optional)
+    feat_seats: 3,
+  },
   skipped: {
     planStage: true,               // if true, skip Plan selection
-    addOnStage: true               // if true, skip Add-on selection
-  }
-  hideSkipped:  true               // if true, hide skipped stages from breadcrumb navigation
+    addOnStage: true,              // if true, skip Add-on selection
+    usageStage: true,              // if true, skip the pay-in-advance Quantity stage
+    addOnUsageStage: true,         // if true, skip the add-on Quantity stage
+  },
+  hideSkipped: true,               // if true, hide skipped stages from breadcrumb navigation
 };
 
 initializeWithPlan(config);
 ```
+
+`payInAdvanceQuantities` only applies to entitlements with pay-in-advance
+pricing; entries for other (or unknown) features are ignored. Combine it with
+`skipped.usageStage` / `skipped.addOnUsageStage` to send the customer straight to
+the final checkout step with the quantities already set.
 
 The Plans and Add-ons available to the checkout flows must be live in your
 Schematic account [Catalog configuration](https://docs.schematichq.com/catalog/overview).

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-components",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "main": "dist/schematic-components.cjs.js",
   "module": "dist/schematic-components.esm.js",
   "types": "dist/schematic-components.d.ts",

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -112,6 +112,29 @@ export const createActiveUsageBasedEntitlementsReducer =
     return acc;
   };
 
+// Overlay host-provided prefill quantities (keyed by feature id) onto
+// pay-in-advance entitlements. Entries for non-pay-in-advance or unknown
+// features are ignored; values are clamped to whole numbers >= 0.
+export const applyPrefilledQuantities = (
+  entitlements: UsageBasedEntitlement[],
+  prefill?: Record<string, number>,
+): UsageBasedEntitlement[] => {
+  if (!prefill) {
+    return entitlements;
+  }
+
+  return entitlements.map((entitlement) => {
+    const prefilled = prefill[entitlement.featureId];
+    if (
+      entitlement.priceBehavior === EntitlementPriceBehavior.PayInAdvance &&
+      typeof prefilled === "number"
+    ) {
+      return { ...entitlement, quantity: Math.max(0, Math.floor(prefilled)) };
+    }
+    return entitlement;
+  });
+};
+
 export interface CheckoutStage {
   id: string;
   name: string;
@@ -501,9 +524,12 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
   ]);
 
   const [usageBasedEntitlements, setUsageBasedEntitlements] = useState(() =>
-    (selectedPlan?.entitlements || []).reduce(
-      createActiveUsageBasedEntitlementsReducer(featureUsage, planPeriod),
-      [],
+    applyPrefilledQuantities(
+      (selectedPlan?.entitlements || []).reduce(
+        createActiveUsageBasedEntitlementsReducer(featureUsage, planPeriod),
+        [] as UsageBasedEntitlement[],
+      ),
+      checkoutState?.payInAdvanceQuantities,
     ),
   );
 
@@ -558,7 +584,10 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
         }
       }
 
-      return allEntitlements;
+      return applyPrefilledQuantities(
+        allEntitlements,
+        checkoutState?.payInAdvanceQuantities,
+      );
     });
 
   const payInAdvanceEntitlements = useMemo(
@@ -763,7 +792,9 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     () =>
       checkoutState?.bypassPlanSelection ||
       checkoutState?.bypassAddOnSelection ||
-      checkoutState?.bypassCreditsSelection,
+      checkoutState?.bypassCreditsSelection ||
+      checkoutState?.bypassUsageSelection ||
+      checkoutState?.bypassAddOnUsageSelection,
   );
 
   const [checkoutStage, setCheckoutStage] = useState(() => {
@@ -796,7 +827,9 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     let id = checkoutStage;
     while (
       (id === "plan" && checkoutState?.bypassPlanSelection) ||
+      (id === "usage" && checkoutState?.bypassUsageSelection) ||
       (id === "addons" && checkoutState?.bypassAddOnSelection) ||
+      (id === "addonsUsage" && checkoutState?.bypassAddOnUsageSelection) ||
       (id === "credits" && checkoutState?.bypassCreditsSelection)
     ) {
       const idx = checkoutStages.findIndex((s) => s.id === id);
@@ -1145,9 +1178,19 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
               ? BillingProductPriceInterval.Year
               : BillingProductPriceInterval.Month;
 
-      const updatedUsageBasedEntitlements = (plan.entitlements ?? []).reduce(
-        createActiveUsageBasedEntitlementsReducer(featureUsage, period),
-        [],
+      // Overlay any host-provided prefill so the initial price preview reflects
+      // it. On the very first selection (mount) the merge block below is skipped
+      // because the plan/period are unchanged, so without this overlay the first
+      // preview would price default quantities even though the committed
+      // checkout state is prefilled. On later selections the merge block prefers
+      // the user's existing quantity, so this overlay only takes effect when no
+      // prior value exists (i.e. the initial render).
+      const updatedUsageBasedEntitlements = applyPrefilledQuantities(
+        (plan.entitlements ?? []).reduce(
+          createActiveUsageBasedEntitlementsReducer(featureUsage, period),
+          [] as UsageBasedEntitlement[],
+        ),
+        checkoutState?.payInAdvanceQuantities,
       );
 
       if (period !== planPeriod || plan.id !== selectedPlan?.id) {
@@ -1210,6 +1253,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       shouldTrial,
       willTrialWithoutPaymentMethod,
       handlePreviewCheckout,
+      checkoutState?.payInAdvanceQuantities,
     ],
   );
 
@@ -1524,7 +1568,16 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       if (stage.id === "plan" && checkoutState.bypassPlanSelection) {
         return false;
       }
+      if (stage.id === "usage" && checkoutState.bypassUsageSelection) {
+        return false;
+      }
       if (stage.id === "addons" && checkoutState.bypassAddOnSelection) {
+        return false;
+      }
+      if (
+        stage.id === "addonsUsage" &&
+        checkoutState.bypassAddOnUsageSelection
+      ) {
         return false;
       }
       if (stage.id === "credits" && checkoutState.bypassCreditsSelection) {
@@ -1540,7 +1593,16 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
       if (stage.id === "plan" && checkoutState?.bypassPlanSelection) {
         return false;
       }
+      if (stage.id === "usage" && checkoutState?.bypassUsageSelection) {
+        return false;
+      }
       if (stage.id === "addons" && checkoutState?.bypassAddOnSelection) {
+        return false;
+      }
+      if (
+        stage.id === "addonsUsage" &&
+        checkoutState?.bypassAddOnUsageSelection
+      ) {
         return false;
       }
       if (stage.id === "credits" && checkoutState?.bypassCreditsSelection) {
@@ -1551,7 +1613,9 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
   }, [
     checkoutStages,
     checkoutState?.bypassPlanSelection,
+    checkoutState?.bypassUsageSelection,
     checkoutState?.bypassAddOnSelection,
+    checkoutState?.bypassAddOnUsageSelection,
     checkoutState?.bypassCreditsSelection,
   ]);
 

--- a/components/src/context/embedReducer.test.ts
+++ b/components/src/context/embedReducer.test.ts
@@ -352,6 +352,105 @@ describe("embedReducer - SET_PLANID_BYPASS", () => {
       expect(result.checkoutState?.showCurrencySelector).toBeUndefined();
     });
   });
+
+  describe("Usage stage skip configuration", () => {
+    it("should skip the usage stages when explicitly configured", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+        skipped: {
+          usageStage: true,
+          addOnUsageStage: true,
+        },
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState).toMatchObject({
+        bypassUsageSelection: true,
+        bypassAddOnUsageSelection: true,
+      });
+    });
+
+    it("should default usage bypass flags to false in explicit skip mode", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+        skipped: { planStage: true },
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState).toMatchObject({
+        bypassUsageSelection: false,
+        bypassAddOnUsageSelection: false,
+      });
+    });
+
+    it("should default usage bypass flags to false in pre-selection mode", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState).toMatchObject({
+        bypassUsageSelection: false,
+        bypassAddOnUsageSelection: false,
+      });
+    });
+
+    it("should default usage bypass flags to false for legacy string format", () => {
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config: "plan_xyz",
+      });
+
+      expect(result.checkoutState).toMatchObject({
+        bypassUsageSelection: false,
+        bypassAddOnUsageSelection: false,
+      });
+    });
+  });
+
+  describe("payInAdvanceQuantities configuration", () => {
+    it("should pass payInAdvanceQuantities through verbatim", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+        payInAdvanceQuantities: { feat_seats: 3, feat_api: 2 },
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.payInAdvanceQuantities).toEqual({
+        feat_seats: 3,
+        feat_api: 2,
+      });
+    });
+
+    it("should leave payInAdvanceQuantities undefined when not provided", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.payInAdvanceQuantities).toBeUndefined();
+    });
+  });
 });
 
 describe("embedReducer - SET_CHECKOUT_PREFILL", () => {

--- a/components/src/context/embedReducer.ts
+++ b/components/src/context/embedReducer.ts
@@ -265,6 +265,8 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
       let bypassPlanSelection: boolean;
       let bypassAddOnSelection: boolean;
       let bypassCreditsSelection: boolean;
+      let bypassUsageSelection: boolean;
+      let bypassAddOnUsageSelection: boolean;
 
       if (config.skipped !== undefined) {
         // Mode 2: Explicit skip configuration provided
@@ -272,18 +274,24 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
         bypassPlanSelection = config.skipped.planStage ?? false;
         bypassAddOnSelection = config.skipped.addOnStage ?? false;
         bypassCreditsSelection = config.skipped.creditStage ?? false;
+        bypassUsageSelection = config.skipped.usageStage ?? false;
+        bypassAddOnUsageSelection = config.skipped.addOnUsageStage ?? false;
       } else if (isStringFormat) {
         // Mode 3: Legacy string format
         // Maintains backwards compatibility by skipping plan stage
         bypassPlanSelection = true;
         bypassAddOnSelection = false;
         bypassCreditsSelection = false;
+        bypassUsageSelection = false;
+        bypassAddOnUsageSelection = false;
       } else {
         // Mode 1: Pre-selection without explicit skip config
         // Show all stages with pre-selected values for user review
         bypassPlanSelection = false;
         bypassAddOnSelection = false;
         bypassCreditsSelection = false;
+        bypassUsageSelection = false;
+        bypassAddOnUsageSelection = false;
       }
 
       return {
@@ -295,7 +303,12 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
           bypassPlanSelection,
           bypassAddOnSelection,
           bypassCreditsSelection,
+          bypassUsageSelection,
+          bypassAddOnUsageSelection,
           ...(config.addOnIds && { addOnIds: config.addOnIds }),
+          ...(config.payInAdvanceQuantities && {
+            payInAdvanceQuantities: config.payInAdvanceQuantities,
+          }),
           ...(config.currency && {
             selectedCurrency: config.currency.toUpperCase(),
           }),

--- a/components/src/context/embedState.ts
+++ b/components/src/context/embedState.ts
@@ -174,6 +174,22 @@ export interface CheckoutStageSkipConfig {
    * - undefined: Defaults to false (show stage)
    */
   creditStage?: boolean;
+
+  /**
+   * Skip the pay-in-advance quantity stage for the plan.
+   * - true: Skip directly to next stage (uses prefilled or current quantities)
+   * - false: Show quantity stage (user can review/change quantities)
+   * - undefined: Defaults to false (show stage)
+   */
+  usageStage?: boolean;
+
+  /**
+   * Skip the pay-in-advance quantity stage for add-ons.
+   * - true: Skip directly to next stage (uses prefilled or current quantities)
+   * - false: Show add-on quantity stage (user can review/change quantities)
+   * - undefined: Defaults to false (show stage)
+   */
+  addOnUsageStage?: boolean;
 }
 
 /**
@@ -303,6 +319,19 @@ export interface BypassConfig {
    * currency is locked (the selector is already hidden in those cases).
    */
   showCurrencySelector?: boolean;
+  /**
+   * Pre-fill pay-in-advance quantities, keyed by feature id.
+   *
+   * Only applies to entitlements whose price behavior is pay-in-advance; entries
+   * for other features (or unknown feature ids) are ignored. Values are clamped
+   * to whole numbers >= 0. Combine with `skipped.usageStage` /
+   * `skipped.addOnUsageStage` to land the customer directly on the checkout step
+   * with the quantities already set.
+   *
+   * @example
+   * { planId: "plan_abc", payInAdvanceQuantities: { feat_seats: 3 } }
+   */
+  payInAdvanceQuantities?: Record<string, number>;
 }
 
 /**
@@ -341,11 +370,14 @@ export type CheckoutState = {
   bypassPlanSelection?: boolean;
   bypassAddOnSelection?: boolean;
   bypassCreditsSelection?: boolean;
+  bypassUsageSelection?: boolean;
+  bypassAddOnUsageSelection?: boolean;
   addOnIds?: string[];
   hideSkippedStages?: boolean;
   selectedCurrency?: string;
   showCurrencySelector?: boolean;
   startTrialIfAvailable?: boolean;
+  payInAdvanceQuantities?: Record<string, number>;
 };
 
 export type EmbedMode = "edit" | "view";


### PR DESCRIPTION
Add two capabilities to the BypassConfig passed to initializeWithPlan:

- payInAdvanceQuantities: a map of feature id -> quantity that pre-fills
  pay-in-advance quantity fields when checkout opens. Only applies to
  pay-in-advance entitlements; unknown/other features are ignored and
  values are clamped to whole numbers >= 0.
- skipped.usageStage / skipped.addOnUsageStage: skip the quantity stages
  so a host can land the customer directly on the final checkout step.

The prefill is overlaid at the entitlement seeds and in selectPlan's
initial preview computation, so the first price preview reflects the
prefilled quantities rather than defaults. The two new bypass flags are
wired into effectiveCheckoutStage, visibleStages, navigableStages and
the bypass loading state, mirroring the existing plan/addon/credit skips.

Adds reducer tests for the new flags and quantity passthrough, updates
the components README, and bumps components to 2.17.0.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
