### PR TITLE
Render a monogram fallback for unknown icon names

### DIFF
--- a/components/src/components/ui/icon/Icon.test.tsx
+++ b/components/src/components/ui/icon/Icon.test.tsx
@@ -1,0 +1,60 @@
+import "@testing-library/dom";
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { render } from "../../../test/setup";
+
+import { ICON_FALLBACK_CLASS, Icon } from "./Icon";
+
+describe("`Icon` component", () => {
+  test("renders a known icon name as a font glyph, not literal text", () => {
+    render(<Icon name="check" data-testid="icon" />);
+
+    const icon = screen.getByTestId("icon");
+    // schematic-icons renders the glyph on an <i> via `icon-{name}` + :before.
+    expect(icon.tagName).toBe("I");
+    expect(icon).toHaveClass("icon-check");
+    // The literal slug must never leak into the rendered text.
+    expect(screen.queryByText("check")).not.toBeInTheDocument();
+  });
+
+  test("renders an emoji value as-is", () => {
+    render(<Icon name="📈" />);
+
+    expect(screen.getByText("📈")).toBeInTheDocument();
+  });
+
+  describe("unknown icon name", () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
+    test("falls back to a monogram instead of the raw name", () => {
+      render(<Icon name="workos-but-newer" data-testid="icon" />);
+
+      const icon = screen.getByTestId("icon");
+      // First letter, uppercased — never the overflowing raw slug.
+      expect(icon).toHaveTextContent("W");
+      expect(screen.queryByText("workos-but-newer")).not.toBeInTheDocument();
+      expect(icon).toHaveClass(ICON_FALLBACK_CLASS);
+      // Keep the full name accessible / hover-discoverable.
+      expect(icon).toHaveAttribute("title", "workos-but-newer");
+    });
+
+    test("warns once for the missing icon", () => {
+      // Distinct name: the warn dedupes per-name across the module's lifetime.
+      render(<Icon name="freshly-added-icon" />);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown icon "freshly-added-icon"'),
+      );
+    });
+  });
+});

--- a/components/src/components/ui/icon/Icon.tsx
+++ b/components/src/components/ui/icon/Icon.tsx
@@ -10,8 +10,49 @@ export { iconsList, type IconNames };
 
 const iconNames = new Set(Object.keys(iconsList));
 const isIconName = (value: string): value is IconNames => iconNames.has(value);
-const getNameProps = (name: string) =>
-  isIconName(name) ? { name } : { as: "span", children: name };
+
+// Pictographic emoji (📈, 🪜, …) are valid icon values and should render as-is.
+// Use Extended_Pictographic — not \p{Emoji}, which also matches digits, #, *.
+const isEmoji = (value: string) => /\p{Extended_Pictographic}/u.test(value);
+
+export const ICON_FALLBACK_CLASS = "icon-fallback-monogram";
+
+// Warn at most once per unknown name so a missing icon repeated across a list
+// doesn't flood the console.
+const warnedNames = new Set<string>();
+
+const getNameProps = (name: string) => {
+  // Known icon: render the font glyph.
+  if (isIconName(name)) {
+    return { name };
+  }
+
+  // Emoji/symbol: render the whole string (never slice multi-codepoint emoji).
+  if (isEmoji(name)) {
+    return { as: "span" as const, children: name };
+  }
+
+  // Unknown named icon — e.g. a slug whose glyph isn't in this bundle's icon
+  // set, usually because the icon was added after this build of
+  // @schematichq/schematic-components. Render a compact monogram instead of the
+  // raw name (which overflows the icon box), and warn so the missing icon is
+  // discoverable.
+  if (!warnedNames.has(name)) {
+    warnedNames.add(name);
+    console.warn(
+      `[schematic] Unknown icon "${name}"; rendering a monogram fallback. ` +
+        `It may have been added after this @schematichq/schematic-components build.`,
+    );
+  }
+
+  const monogram = name.trim().charAt(0).toUpperCase();
+  return {
+    as: "span" as const,
+    className: ICON_FALLBACK_CLASS,
+    title: name,
+    children: monogram || name,
+  };
+};
 
 export interface IconProps extends Omit<SchematicIconProps, "name"> {
   name: IconNames | string; // allow for emoji unicode characters

--- a/components/src/components/ui/icon/styles.ts
+++ b/components/src/components/ui/icon/styles.ts
@@ -94,4 +94,13 @@ export const Icon = styled(SchematicIcon).attrs(({ name, title, onClick }) => ({
           background-color: ${$background};
         `;
   }}
+
+  /* Fallback monogram for an unknown icon name (see Icon.tsx getNameProps).
+     Font-size is left to the $size scale above so the letter tracks the icon
+     box; only weight/casing differ from a real glyph. */
+  &.icon-fallback-monogram {
+    font-weight: 600;
+    text-transform: uppercase;
+    line-height: 1;
+  }
 `;


### PR DESCRIPTION
When an icon name isn't in the bundled icon set, `Icon` rendered the raw slug as text, which overflows the icon box.

Here, we change this fallback behavior so that emoji pass through unchanged (as before) but non-emoji unknown named slugs render an uppercased first-letter monogram,  so it fits better in the icon box.