### PR TITLE
Release schematic-components 2.17.1

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schematichq/schematic-components",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "main": "dist/schematic-components.cjs.js",
   "module": "dist/schematic-components.esm.js",
   "types": "dist/schematic-components.d.ts",


### PR DESCRIPTION
Allows pre-filling pay-in-advance entitlements via `initializeWithPlan`, and a fix for Apple Pay
