### PR TITLE
Fix double /public/plans fetch in PricingTable

### DIFF
--- a/components/src/components/elements/pricing-table/PricingTable.test.tsx
+++ b/components/src/components/elements/pricing-table/PricingTable.test.tsx
@@ -1,14 +1,17 @@
 import {
   act,
   fireEvent,
+  render as rtlRender,
   screen,
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
 import cloneDeep from "lodash/cloneDeep";
 import { HttpResponse, delay, http } from "msw";
+import { useReducer } from "react";
 import { vi } from "vitest";
 
+import { EmbedProvider } from "../../../context/EmbedProvider";
 import hydrateJson from "../../../test/mocks/handlers/response/hydrate.json";
 import plansJson from "../../../test/mocks/handlers/response/plans.json";
 import { server } from "../../../test/mocks/node";
@@ -63,6 +66,48 @@ describe("`PricingTable`", () => {
       for (const button of buttons) {
         expect(button).toBeEnabled();
       }
+    });
+
+    test("Fetches public plans only once when the consumer re-renders with a new inline `apiConfig`", async () => {
+      let requestCount = 0;
+      server.use(
+        http.get("https://api.schematichq.com/public/plans", async () => {
+          requestCount += 1;
+          return HttpResponse.json(plansJson);
+        }),
+      );
+
+      // Mirrors the marketing-site integration: an inline `apiConfig={{}}` (new
+      // reference each render) in a parent that re-renders after mount. Guards
+      // against the public hydration effect re-firing into a duplicate fetch.
+      const Consumer = () => {
+        const [tick, rerender] = useReducer((n: number) => n + 1, 0);
+        return (
+          <>
+            <button data-testid="rerender" onClick={() => rerender()}>
+              {tick}
+            </button>
+            <EmbedProvider apiKey="api_0" apiConfig={{}}>
+              <PricingTable callToActionUrl="/" />
+            </EmbedProvider>
+          </>
+        );
+      };
+
+      rtlRender(<Consumer />);
+
+      const wrapper = await screen.findByTestId("sch-pricing-table");
+      expect(wrapper).toBeInTheDocument();
+      expect(requestCount).toBe(1);
+
+      // Force the consumer to re-render with fresh inline `apiConfig` references.
+      fireEvent.click(screen.getByTestId("rerender"));
+      fireEvent.click(screen.getByTestId("rerender"));
+
+      // Allow any debounced/trailing fetch to settle.
+      await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+
+      expect(requestCount).toBe(1);
     });
 
     test("Should hide plans when `plans.isVisible` is false", async () => {

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -91,6 +91,19 @@ export const EmbedProvider = ({
   const sessionId = useMemo(() => uuidv4(), []);
   const styleRef = useRef<HTMLLinkElement>(null);
 
+  // Stabilize `apiConfig` against inline object props (e.g. `apiConfig={{}}`): a
+  // new-but-equal reference each render would otherwise rebuild the API clients
+  // (and the debounced methods derived from them), re-firing the pricing table's
+  // public hydration into a duplicate `/public/plans` fetch. Keying on the
+  // serialized contents ignores that churn; function-typed fields drop out, as
+  // intended.
+  const apiConfigKey = JSON.stringify(apiConfig ?? {});
+  const stableApiConfig = useMemo(
+    () => apiConfig ?? {},
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on contents, not reference
+    [apiConfigKey],
+  );
+
   const [state, dispatch] = useReducer(reducer, options, (opts) => {
     const providedState = {
       settings: opts.settings || {},
@@ -104,21 +117,21 @@ export const EmbedProvider = ({
 
   const publicApi = useMemo(() => {
     if (!apiKey) return undefined;
-    const configParams = merge({}, apiConfig, {
+    const configParams = merge({}, stableApiConfig, {
       apiKey,
       headers: getCustomHeaders(sessionId),
     });
     return new ComponentspublicApi(new PublicConfiguration(configParams));
-  }, [apiKey, apiConfig, sessionId]);
+  }, [apiKey, stableApiConfig, sessionId]);
 
   const checkoutApi = useMemo(() => {
     if (!state.accessToken) return undefined;
-    const configParams = merge({}, apiConfig, {
+    const configParams = merge({}, stableApiConfig, {
       apiKey: state.accessToken,
       headers: getCustomHeaders(sessionId),
     });
     return new CheckoutexternalApi(new CheckoutConfiguration(configParams));
-  }, [state.accessToken, apiConfig, sessionId]);
+  }, [state.accessToken, stableApiConfig, sessionId]);
 
   const debug = useCallback(
     (message: string, ...args: unknown[]) => {


### PR DESCRIPTION
The PricingTable hydration effect re-fetches `/public/plans` whenever its `hydratePublic` dependency changes identity. `hydratePublic` is rebuilt whenever `publicApi` is, and `publicApi` is memoized on the `apiConfig` prop by reference. Consumers commonly pass an inline object literal (e.g. `apiConfig={{}}`), so any consumer re-render hands `EmbedProvider` a new reference, recreates the client + debounced methods, and re-runs the effect — firing a second, redundant request (the leading-edge debounce cannot dedupe across fresh debounce instances).

Key the client memos on a serialization of `apiConfig`s contents so a new-but-equal reference is ignored; only an actual content change rebuilds the clients. Adds a regression test reproducing the inline-prop re-render.