### PR TITLE
SSR-safe + browser styled-components builds via export conditions

### DIFF
--- a/components/esbuild.mjs
+++ b/components/esbuild.mjs
@@ -1,0 +1,103 @@
+// Build entry for the bundled library (replaces the inline esbuild CLI calls).
+//
+// We emit TWO variants of each format, because styled-components ships two
+// builds and neither one is correct in both environments:
+//
+//   * The `browser` build injects styles client-side (via useLayoutEffect) but
+//     references `document` while injecting, so it throws
+//     "ReferenceError: document is not defined" if it renders during SSR /
+//     static prerender.
+//
+//   * The `universal` build (styled-components' `main`/`module` fields) is
+//     SSR-safe — it guards DOM access at runtime — but its `createGlobalStyle`
+//     only injects during a server render (ServerStyleSheet) and has no
+//     client-side effect path, so on a pure client render it injects nothing.
+//     Our icon font is delivered via `createGlobalStyle` (`<IconStyles />`), so
+//     under the universal build every icon renders as an empty/fallback glyph.
+//
+// So we build:
+//   * a `browser` variant that bundles styled-components' browser build — used
+//     when a consumer bundles for the browser (the `browser` export condition).
+//   * a `server` variant that bundles styled-components' universal build — used
+//     for SSR / Node (the default `import`/`require` conditions).
+//
+// package.json `exports` maps the `browser` condition to the browser variant and
+// everything else to the server variant, so each environment gets the build that
+// works there. The server variant forces resolution of styled-components to its
+// universal build via an absolute path (bypassing the `browser` field remap) and
+// shims Node's `stream` (lazily required by an SSR streaming helper we never
+// call) to keep it out of the bundle.
+
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+import esbuild from "esbuild";
+
+const require = createRequire(import.meta.url);
+const { version } = require("./package.json");
+
+const args = process.argv.slice(2);
+const format = args.includes("--format=cjs") ? "cjs" : "esm";
+const variant = args.includes("--variant=browser") ? "browser" : "server";
+const watch = args.includes("--watch");
+
+const ext = format === "cjs" ? "cjs.js" : "esm.js";
+const outfile =
+  variant === "browser"
+    ? `dist/schematic-components.browser.${ext}`
+    : `dist/schematic-components.${ext}`;
+
+// Resolve styled-components' universal build (the package's `main`/`module`
+// fields, not its `browser` remap) to an absolute path. Used by the server
+// variant only.
+const scPkgPath = require.resolve("styled-components/package.json");
+const scPkgDir = dirname(scPkgPath);
+const scPkg = require(scPkgPath);
+const styledComponentsUniversal = resolve(
+  scPkgDir,
+  format === "cjs" ? scPkg.main : scPkg.module,
+);
+
+// Plugin that pins styled-components to its universal (SSR-safe) build for the
+// server variant. The browser variant omits this plugin so esbuild's default
+// `browser` platform picks up styled-components' browser build.
+const ssrSafeStyledComponents = {
+  name: "ssr-safe-styled-components",
+  setup(build) {
+    build.onResolve({ filter: /^styled-components$/ }, () => ({
+      path: styledComponentsUniversal,
+    }));
+
+    // The universal build lazily requires Node's `stream` for streaming SSR,
+    // which we never use. Shim it to an empty module so it stays out of the
+    // bundle.
+    build.onResolve({ filter: /^(node:)?stream$/ }, () => ({
+      path: "stream",
+      namespace: "empty-shim",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "empty-shim" }, () => ({
+      contents: "export default {};",
+      loader: "js",
+    }));
+  },
+};
+
+const options = {
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  format,
+  outfile,
+  external: ["react", "react-dom", "@stripe/react-stripe-js"],
+  define: {
+    "process.env.SCHEMATIC_COMPONENTS_VERSION": JSON.stringify(version),
+  },
+  plugins: variant === "server" ? [ssrSafeStyledComponents] : [],
+};
+
+if (watch) {
+  const ctx = await esbuild.context(options);
+  await ctx.watch();
+  console.log(`[esbuild] watching (${variant}/${format})…`);
+} else {
+  await esbuild.build(options);
+}

--- a/components/esbuild.mjs
+++ b/components/esbuild.mjs
@@ -1,32 +1,15 @@
-// Build entry for the bundled library (replaces the inline esbuild CLI calls).
-//
-// We emit TWO variants of each format, because styled-components ships two
-// builds and neither one is correct in both environments:
-//
-//   * The `browser` build injects styles client-side (via useLayoutEffect) but
-//     references `document` while injecting, so it throws
-//     "ReferenceError: document is not defined" if it renders during SSR /
-//     static prerender.
-//
-//   * The `universal` build (styled-components' `main`/`module` fields) is
-//     SSR-safe — it guards DOM access at runtime — but its `createGlobalStyle`
-//     only injects during a server render (ServerStyleSheet) and has no
-//     client-side effect path, so on a pure client render it injects nothing.
-//     Our icon font is delivered via `createGlobalStyle` (`<IconStyles />`), so
-//     under the universal build every icon renders as an empty/fallback glyph.
-//
-// So we build:
-//   * a `browser` variant that bundles styled-components' browser build — used
-//     when a consumer bundles for the browser (the `browser` export condition).
-//   * a `server` variant that bundles styled-components' universal build — used
-//     for SSR / Node (the default `import`/`require` conditions).
-//
-// package.json `exports` maps the `browser` condition to the browser variant and
-// everything else to the server variant, so each environment gets the build that
-// works there. The server variant forces resolution of styled-components to its
-// universal build via an absolute path (bypassing the `browser` field remap) and
-// shims Node's `stream` (lazily required by an SSR streaming helper we never
-// call) to keep it out of the bundle.
+// Emits two variants because styled-components ships two builds and neither
+// works in both environments:
+//   * its `browser` build injects global styles on the client but touches
+//     `document`, crashing during SSR;
+//   * its `universal` build is SSR-safe but its `createGlobalStyle` never
+//     injects on the client — which blanks our icon font (<IconStyles />).
+// So we build a `browser` variant (browser build) and a `server` variant
+// (universal build); package.json `exports` routes the `browser` condition to
+// the former and default/node to the latter.
+// The server variant pins styled-components to its universal build by absolute
+// path (bypassing the `browser` remap) and shims `stream` (pulled in only by an
+// SSR streaming helper we never call).
 
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
@@ -59,8 +42,7 @@ const styledComponentsUniversal = resolve(
 );
 
 // Plugin that pins styled-components to its universal (SSR-safe) build for the
-// server variant. The browser variant omits this plugin so esbuild's default
-// `browser` platform picks up styled-components' browser build.
+// server variant.
 const ssrSafeStyledComponents = {
   name: "ssr-safe-styled-components",
   setup(build) {

--- a/components/package.json
+++ b/components/package.json
@@ -4,9 +4,27 @@
   "main": "dist/schematic-components.cjs.js",
   "module": "dist/schematic-components.esm.js",
   "types": "dist/schematic-components.d.ts",
+  "browser": {
+    "./dist/schematic-components.cjs.js": "./dist/schematic-components.browser.cjs.js",
+    "./dist/schematic-components.esm.js": "./dist/schematic-components.browser.esm.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/schematic-components.d.ts",
+      "browser": {
+        "import": "./dist/schematic-components.browser.esm.js",
+        "require": "./dist/schematic-components.browser.cjs.js"
+      },
+      "import": "./dist/schematic-components.esm.js",
+      "require": "./dist/schematic-components.cjs.js",
+      "default": "./dist/schematic-components.esm.js"
+    }
+  },
   "files": [
     "dist/schematic-components.cjs.js",
     "dist/schematic-components.esm.js",
+    "dist/schematic-components.browser.cjs.js",
+    "dist/schematic-components.browser.esm.js",
     "dist/schematic-components.d.ts"
   ],
   "author": "Schematic <engineering@schematichq.com>",
@@ -16,12 +34,15 @@
     "url": "git+ssh://git@github.com/SchematicHQ/schematic-js.git"
   },
   "scripts": {
-    "dev": "yarn dev:esm",
-    "dev:cjs": "npx esbuild src/index.ts --watch --bundle --external:react --external:react-dom --external:@stripe/react-stripe-js --format=cjs --outfile=dist/schematic-components.cjs.js --define:process.env.SCHEMATIC_COMPONENTS_VERSION=$(cat package.json | jq .version)",
-    "dev:esm": "npx esbuild src/index.ts --watch --bundle --external:react --external:react-dom --external:@stripe/react-stripe-js --format=esm --outfile=dist/schematic-components.esm.js --define:process.env.SCHEMATIC_COMPONENTS_VERSION=$(cat package.json | jq .version)",
-    "build": "yarn tsc && yarn openapi && yarn format && yarn lint && yarn clean && yarn build:cjs && yarn build:esm && yarn build:types",
-    "build:cjs": "npx esbuild src/index.ts --bundle --external:react --external:react-dom --external:@stripe/react-stripe-js --format=cjs --outfile=dist/schematic-components.cjs.js --define:process.env.SCHEMATIC_COMPONENTS_VERSION=$(cat package.json | jq .version)",
-    "build:esm": "npx esbuild src/index.ts --bundle --external:react --external:react-dom --external:@stripe/react-stripe-js --format=esm --outfile=dist/schematic-components.esm.js --define:process.env.SCHEMATIC_COMPONENTS_VERSION=$(cat package.json | jq .version)",
+    "dev": "yarn dev:browser:esm",
+    "dev:cjs": "node esbuild.mjs --format=cjs --variant=server --watch",
+    "dev:esm": "node esbuild.mjs --format=esm --variant=server --watch",
+    "dev:browser:esm": "node esbuild.mjs --format=esm --variant=browser --watch",
+    "build": "yarn tsc && yarn openapi && yarn format && yarn lint && yarn clean && yarn build:cjs && yarn build:esm && yarn build:browser:cjs && yarn build:browser:esm && yarn build:types",
+    "build:cjs": "node esbuild.mjs --format=cjs --variant=server",
+    "build:esm": "node esbuild.mjs --format=esm --variant=server",
+    "build:browser:cjs": "node esbuild.mjs --format=cjs --variant=browser",
+    "build:browser:esm": "node esbuild.mjs --format=esm --variant=browser",
     "build:types": "npx tsc && npx api-extractor run",
     "clean": "rm -rf dist",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",


### PR DESCRIPTION
Fix-forward for the icon regression that forced the revert of #1413 (via #1440).

#1413 bundled styled-components' universal build everywhere to avoid a `document is not defined` SSR crash, but the universal build's `createGlobalStyle` never injects on the client — so our icon font (shipped via `<IconStyles />`) rendered blank. The revert restored the browser build, which injects client-side but crashes on SSR.

This builds both variants and lets the consumer pick via `exports`: the `browser` condition gets the browser build (injects icons client-side), and default/`node` gets the universal build (SSR-safe). Same split styled-components uses for its own `browser` field.