### PR TITLE
feat(components): programmatic unsubscribe with new function requestUnsubscribe

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -79,6 +79,32 @@ the final checkout step with the quantities already set.
 The Plans and Add-ons available to the checkout flows must be live in your
 Schematic account [Catalog configuration](https://docs.schematichq.com/catalog/overview).
 
+## Programmatic Unsubscribe
+
+We provide a function `triggerUnsubscribeModal` for opening the unsubscribe
+modal from your own UI, without using the built-in `UnsubscribeButton`. Like
+`initializeWithPlan`, it's suitable for click handlers and must be extracted
+from the library's embedded context.
+
+```ts
+const { triggerUnsubscribeModal } = useEmbed();
+```
+
+This lets developers create their own button — for example, a custom
+"are you sure?" retention flow — that opens the same unsubscribe modal the
+built-in component uses.
+
+```ts
+triggerUnsubscribeModal();
+```
+
+The function takes no arguments. If there is no active subscription to cancel,
+the call is ignored and a warning is logged to the console.
+
+The modal is rendered by the embed itself, so a Schematic embed (the `Viewport`
+that hosts the modal) must be mounted on the page where you call
+`triggerUnsubscribeModal`. This is the same requirement as `initializeWithPlan`.
+
 ## License
 
 MIT

--- a/components/README.md
+++ b/components/README.md
@@ -81,29 +81,29 @@ Schematic account [Catalog configuration](https://docs.schematichq.com/catalog/o
 
 ## Programmatic Unsubscribe
 
-We provide a function `triggerUnsubscribeModal` for opening the unsubscribe
-modal from your own UI, without using the built-in `UnsubscribeButton`. Like
+We provide a function `requestUnsubscribe` for starting the unsubscribe flow
+from your own UI, without using the built-in `UnsubscribeButton`. Like
 `initializeWithPlan`, it's suitable for click handlers and must be extracted
 from the library's embedded context.
 
 ```ts
-const { triggerUnsubscribeModal } = useEmbed();
+const { requestUnsubscribe } = useEmbed();
 ```
 
 This lets developers create their own button — for example, a custom
-"are you sure?" retention flow — that opens the same unsubscribe modal the
-built-in component uses.
+"are you sure?" retention flow — that hands off to the same unsubscribe
+experience the built-in component uses.
 
 ```ts
-triggerUnsubscribeModal();
+requestUnsubscribe();
 ```
 
 The function takes no arguments. If there is no active subscription to cancel,
-the call is ignored and a warning is logged to the console.
+the request is ignored and a warning is logged to the console.
 
-The modal is rendered by the embed itself, so a Schematic embed (the `Viewport`
-that hosts the modal) must be mounted on the page where you call
-`triggerUnsubscribeModal`. This is the same requirement as `initializeWithPlan`.
+The unsubscribe flow is rendered by the embed itself, so a Schematic embed (the
+`Viewport` that hosts it) must be mounted on the page where you call
+`requestUnsubscribe`. This is the same requirement as `initializeWithPlan`.
 
 ## License
 

--- a/components/src/context/EmbedContext.tsx
+++ b/components/src/context/EmbedContext.tsx
@@ -66,7 +66,7 @@ export interface EmbedContextProps extends EmbedState {
   setCheckoutState: (state: CheckoutState) => void;
   clearCheckoutState: () => void;
   initializeWithPlan: (config: string | BypassConfig) => void;
-  triggerUnsubscribeModal: () => void;
+  requestUnsubscribe: () => void;
   setData: (data: HydrateDataWithCompanyContext) => void;
   updateSettings: (
     settings: DeepPartial<EmbedSettings>,
@@ -101,7 +101,7 @@ export const initialContext = {
   setCheckoutState: stub,
   clearCheckoutState: stub,
   initializeWithPlan: stub,
-  triggerUnsubscribeModal: stub,
+  requestUnsubscribe: stub,
   setData: stub,
   updateSettings: stub,
   debug: stub,

--- a/components/src/context/EmbedContext.tsx
+++ b/components/src/context/EmbedContext.tsx
@@ -66,6 +66,7 @@ export interface EmbedContextProps extends EmbedState {
   setCheckoutState: (state: CheckoutState) => void;
   clearCheckoutState: () => void;
   initializeWithPlan: (config: string | BypassConfig) => void;
+  triggerUnsubscribeModal: () => void;
   setData: (data: HydrateDataWithCompanyContext) => void;
   updateSettings: (
     settings: DeepPartial<EmbedSettings>,
@@ -100,6 +101,7 @@ export const initialContext = {
   setCheckoutState: stub,
   clearCheckoutState: stub,
   initializeWithPlan: stub,
+  triggerUnsubscribeModal: stub,
   setData: stub,
   updateSettings: stub,
   debug: stub,

--- a/components/src/context/EmbedProvider.test.tsx
+++ b/components/src/context/EmbedProvider.test.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { useEmbed } from "../hooks";
+import type { HydrateDataWithCompanyContext } from "../types";
+
+import { EmbedProvider } from "./EmbedProvider";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <EmbedProvider apiKey="api_0">{children}</EmbedProvider>
+);
+
+// The unsubscribe guard only reads `data.subscription.{status,cancelAt}`, so we
+// seed a minimal `data` shape rather than a full hydrate payload.
+const dataWithSubscription = (subscription: Record<string, unknown>) =>
+  ({ subscription }) as unknown as HydrateDataWithCompanyContext;
+
+describe("triggerUnsubscribeModal", () => {
+  test("opens the unsubscribe modal for an active subscription", () => {
+    const { result } = renderHook(() => useEmbed(), { wrapper });
+
+    act(() => {
+      result.current.setData(
+        dataWithSubscription({ status: "active", cancelAt: null }),
+      );
+    });
+    act(() => {
+      result.current.triggerUnsubscribeModal();
+    });
+
+    expect(result.current.layout).toBe("unsubscribe");
+  });
+
+  test("warns and stays put when there is no subscription", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() => useEmbed(), { wrapper });
+
+    act(() => {
+      result.current.triggerUnsubscribeModal();
+    });
+
+    expect(result.current.layout).toBe("portal");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no active subscription"),
+    );
+
+    warn.mockRestore();
+  });
+
+  test("warns and stays put when the subscription is already cancelling", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() => useEmbed(), { wrapper });
+
+    act(() => {
+      result.current.setData(
+        dataWithSubscription({ status: "active", cancelAt: new Date() }),
+      );
+    });
+    act(() => {
+      result.current.triggerUnsubscribeModal();
+    });
+
+    expect(result.current.layout).toBe("portal");
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+});

--- a/components/src/context/EmbedProvider.test.tsx
+++ b/components/src/context/EmbedProvider.test.tsx
@@ -15,7 +15,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 const dataWithSubscription = (subscription: Record<string, unknown>) =>
   ({ subscription }) as unknown as HydrateDataWithCompanyContext;
 
-describe("triggerUnsubscribeModal", () => {
+describe("requestUnsubscribe", () => {
   test("opens the unsubscribe modal for an active subscription", () => {
     const { result } = renderHook(() => useEmbed(), { wrapper });
 
@@ -25,7 +25,7 @@ describe("triggerUnsubscribeModal", () => {
       );
     });
     act(() => {
-      result.current.triggerUnsubscribeModal();
+      result.current.requestUnsubscribe();
     });
 
     expect(result.current.layout).toBe("unsubscribe");
@@ -36,7 +36,7 @@ describe("triggerUnsubscribeModal", () => {
     const { result } = renderHook(() => useEmbed(), { wrapper });
 
     act(() => {
-      result.current.triggerUnsubscribeModal();
+      result.current.requestUnsubscribe();
     });
 
     expect(result.current.layout).toBe("portal");
@@ -57,7 +57,7 @@ describe("triggerUnsubscribeModal", () => {
       );
     });
     act(() => {
-      result.current.triggerUnsubscribeModal();
+      result.current.requestUnsubscribe();
     });
 
     expect(result.current.layout).toBe("portal");

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -540,6 +540,25 @@ export const EmbedProvider = ({
     dispatch({ type: "SET_PLANID_BYPASS", config });
   }, []);
 
+  const triggerUnsubscribeModal = useCallback(() => {
+    // Mirror the guard the built-in `UnsubscribeButton` applies before it
+    // renders: there is nothing to cancel unless a live subscription exists.
+    const subscription = state.data?.subscription;
+    const hasActiveSubscription =
+      subscription &&
+      subscription.status !== "cancelled" &&
+      !subscription.cancelAt;
+
+    if (!hasActiveSubscription) {
+      console.warn(
+        "[Schematic] `triggerUnsubscribeModal` was called, but there is no active subscription to cancel; ignoring.",
+      );
+      return;
+    }
+
+    dispatch({ type: "CHANGE_LAYOUT", layout: "unsubscribe" });
+  }, [state.data?.subscription]);
+
   useEffect(() => {
     const element = document.getElementById(
       "schematic-fonts",
@@ -666,6 +685,7 @@ export const EmbedProvider = ({
         setCheckoutState,
         clearCheckoutState,
         initializeWithPlan,
+        triggerUnsubscribeModal,
         setData,
         updateSettings,
         debug,

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -540,7 +540,7 @@ export const EmbedProvider = ({
     dispatch({ type: "SET_PLANID_BYPASS", config });
   }, []);
 
-  const triggerUnsubscribeModal = useCallback(() => {
+  const requestUnsubscribe = useCallback(() => {
     // Mirror the guard the built-in `UnsubscribeButton` applies before it
     // renders: there is nothing to cancel unless a live subscription exists.
     const subscription = state.data?.subscription;
@@ -551,7 +551,7 @@ export const EmbedProvider = ({
 
     if (!hasActiveSubscription) {
       console.warn(
-        "[Schematic] `triggerUnsubscribeModal` was called, but there is no active subscription to cancel; ignoring.",
+        "[Schematic] `requestUnsubscribe` was called, but there is no active subscription to cancel; ignoring.",
       );
       return;
     }
@@ -685,7 +685,7 @@ export const EmbedProvider = ({
         setCheckoutState,
         clearCheckoutState,
         initializeWithPlan,
-        triggerUnsubscribeModal,
+        requestUnsubscribe,
         setData,
         updateSettings,
         debug,


### PR DESCRIPTION
Adds a `triggerUnsubscribeModal` function to the embed context (exposed via `useEmbed()`) so customers can open the unsubscribe modal from an alternative button without relying on our own `UnsubscribeButton` component.

This mirrors the existing `initializeWithPlan` entrypoint pattern, but is thinner: the unsubscribe modal already self-opens off layout state, so no new reducer action or config object is needed.