### PR TITLE
initial headless components

### DIFF
--- a/components/src/components/headless/index.ts
+++ b/components/src/components/headless/index.ts
@@ -1,0 +1,3 @@
+export * from "./trial-pill";
+export * from "./usage-meter";
+export * from "./utils";

--- a/components/src/components/headless/trial-pill/README.md
+++ b/components/src/components/headless/trial-pill/README.md
@@ -1,0 +1,69 @@
+# TrialPill (headless)
+
+An unstyled, accessible, composable pill/badge for showing plan trial
+information. Like the other headless components it is **controlled**: pass the
+trial fields from `useSchematicPlan`; it fetches nothing and renders no visual
+styling of its own.
+
+`Root` renders **nothing** when there is no trial to display — i.e. no
+`trialEndDate`/`trialStatus`, or once `trialStatus` is `"converted"`.
+
+## Usage
+
+### Compound components
+
+```tsx
+import { TrialPill } from "@schematichq/schematic-components";
+import { useSchematicPlan } from "@schematichq/schematic-react";
+
+function TrialBadge() {
+  const plan = useSchematicPlan();
+
+  return (
+    <TrialPill.Root
+      trialEndDate={plan?.trialEndDate}
+      trialStatus={plan?.trialStatus}
+    >
+      <TrialPill.Label>Trial</TrialPill.Label>
+      <TrialPill.TimeRemaining /> left · ends <TrialPill.EndDate />
+    </TrialPill.Root>
+  );
+}
+```
+
+- `TrialPill.TimeRemaining` renders `"<amount> <units>"` (e.g. `"5 days"`),
+  using the same day → hour → minute → second ladder as `useTrialEnd`.
+- `TrialPill.EndDate` renders as a `<time datetime="…">` with the formatted end
+  date (e.g. `"July 7, 2026"`).
+- Both accept custom `children` to override their default text.
+
+### Hook-only (custom markup / i18n)
+
+The compound parts emit plain, un-localized strings. For translation or fully
+custom rendering, use the hook and format the raw values yourself:
+
+```tsx
+import { useTrialPill } from "@schematichq/schematic-components";
+
+const { hasTrial, isExpired, amount, units, endDateLabel } = useTrialPill({
+  trialEndDate: plan?.trialEndDate,
+  trialStatus: plan?.trialStatus,
+});
+
+if (!hasTrial) return null;
+return <span>{t("X time left in trial", { amount, units })}</span>;
+```
+
+## Styling hooks
+
+Every part exposes `data-schematic` / `data-part` attributes and BEM-style
+classes: `schematic-trial-pill`, `__label`, `__time-remaining`, `__end-date`.
+The root additionally carries `data-trial-status="active|converted|expired"`
+and, when the trial has ended, `data-expired="true"` — handy for state-based
+styling:
+
+```css
+.schematic-trial-pill[data-expired="true"] {
+  color: var(--schematic-color-danger, crimson);
+}
+```

--- a/components/src/components/headless/trial-pill/TrialPill.test.tsx
+++ b/components/src/components/headless/trial-pill/TrialPill.test.tsx
@@ -1,0 +1,169 @@
+import { render, renderHook, screen } from "@testing-library/react";
+import { createRef } from "react";
+
+import { toPrettyDate } from "../../../utils";
+
+import { TrialPill } from "./TrialPill";
+import { useTrialPill } from "./useTrialPill";
+
+const NOW = new Date("2026-07-02T00:00:00.000Z");
+const IN_FIVE_DAYS = new Date("2026-07-07T00:00:00.000Z");
+const FIVE_DAYS_AGO = new Date("2026-06-27T00:00:00.000Z");
+
+describe("useTrialPill", () => {
+  test("computes time remaining for an active trial", () => {
+    const { result } = renderHook(() =>
+      useTrialPill({
+        trialEndDate: IN_FIVE_DAYS,
+        trialStatus: "active",
+        now: NOW,
+      }),
+    );
+    expect(result.current.hasTrial).toBe(true);
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.isExpired).toBe(false);
+    expect(result.current.amount).toBe(5);
+    expect(result.current.units).toBe("days");
+    expect(result.current.endDateLabel).toBe(toPrettyDate(IN_FIVE_DAYS));
+  });
+
+  test("marks a past end date as expired with a positive magnitude", () => {
+    const { result } = renderHook(() =>
+      useTrialPill({ trialEndDate: FIVE_DAYS_AGO, now: NOW }),
+    );
+    expect(result.current.isExpired).toBe(true);
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.amount).toBe(5);
+    expect(result.current.units).toBe("days");
+  });
+
+  test("expired status without a date still has a trial", () => {
+    const { result } = renderHook(() =>
+      useTrialPill({ trialStatus: "expired", now: NOW }),
+    );
+    expect(result.current.hasTrial).toBe(true);
+    expect(result.current.isExpired).toBe(true);
+    expect(result.current.amount).toBeUndefined();
+  });
+
+  test("converted plans have no trial to show", () => {
+    const { result } = renderHook(() =>
+      useTrialPill({
+        trialEndDate: IN_FIVE_DAYS,
+        trialStatus: "converted",
+        now: NOW,
+      }),
+    );
+    expect(result.current.hasTrial).toBe(false);
+  });
+
+  test("no data yields no trial", () => {
+    const { result } = renderHook(() => useTrialPill({ now: NOW }));
+    expect(result.current.hasTrial).toBe(false);
+  });
+
+  test("uses singular units for a single remaining day", () => {
+    const oneDay = new Date("2026-07-03T00:00:00.000Z");
+    const { result } = renderHook(() =>
+      useTrialPill({ trialEndDate: oneDay, now: NOW }),
+    );
+    expect(result.current.amount).toBe(1);
+    expect(result.current.units).toBe("day");
+  });
+});
+
+describe("TrialPill compound components", () => {
+  const renderPill = (
+    props?: Partial<{
+      trialEndDate: Date;
+      trialStatus: "active" | "converted" | "expired";
+    }>,
+  ) =>
+    render(
+      <TrialPill.Root
+        trialEndDate={props?.trialEndDate ?? IN_FIVE_DAYS}
+        trialStatus={props?.trialStatus ?? "active"}
+        now={NOW}
+      >
+        <TrialPill.Label>Trial</TrialPill.Label>
+        <TrialPill.TimeRemaining />
+        <TrialPill.EndDate />
+      </TrialPill.Root>,
+    );
+
+  test("renders the pill with status/state data attributes", () => {
+    const { container } = renderPill();
+    const root = container.querySelector('[data-schematic="trial-pill"]');
+    expect(root).not.toBeNull();
+    expect(root).toHaveClass("schematic-trial-pill");
+    expect(root).toHaveAttribute("data-trial-status", "active");
+    expect(root).not.toHaveAttribute("data-expired");
+  });
+
+  test("renders nothing when the plan has converted", () => {
+    const { container } = renderPill({ trialStatus: "converted" });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("TimeRemaining renders the amount and units by default", () => {
+    renderPill();
+    expect(screen.getByText("5 days")).toBeInTheDocument();
+  });
+
+  test("EndDate renders a <time> with a machine-readable datetime", () => {
+    const { container } = renderPill();
+    const time = container.querySelector('[data-part="end-date"]');
+    expect(time?.tagName).toBe("TIME");
+    expect(time).toHaveAttribute("datetime", IN_FIVE_DAYS.toISOString());
+    expect(time).toHaveTextContent(toPrettyDate(IN_FIVE_DAYS));
+  });
+
+  test("marks an expired trial with data-expired", () => {
+    const { container } = render(
+      <TrialPill.Root trialEndDate={FIVE_DAYS_AGO} now={NOW}>
+        <TrialPill.TimeRemaining />
+      </TrialPill.Root>,
+    );
+    const root = container.querySelector('[data-schematic="trial-pill"]');
+    expect(root).toHaveAttribute("data-expired", "true");
+  });
+
+  test("parts accept custom children that override the defaults", () => {
+    render(
+      <TrialPill.Root trialEndDate={IN_FIVE_DAYS} now={NOW}>
+        <TrialPill.TimeRemaining>5 days left in trial</TrialPill.TimeRemaining>
+      </TrialPill.Root>,
+    );
+    expect(screen.getByText("5 days left in trial")).toBeInTheDocument();
+    expect(screen.queryByText("5 days")).not.toBeInTheDocument();
+  });
+
+  test("asChild renders the consumer element and merges props/ref", () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <TrialPill.Root
+        asChild
+        trialEndDate={IN_FIVE_DAYS}
+        trialStatus="active"
+        now={NOW}
+        className="mine"
+      >
+        <div ref={ref}>content</div>
+      </TrialPill.Root>,
+    );
+    const root = screen.getByText("content");
+    expect(root.tagName).toBe("DIV");
+    expect(root).toHaveClass("schematic-trial-pill");
+    expect(root).toHaveClass("mine");
+    expect(root).toHaveAttribute("data-trial-status", "active");
+    expect(ref.current).toBe(root);
+  });
+
+  test("throws when a part is used outside Root", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<TrialPill.TimeRemaining />)).toThrow(
+      /must be used within <TrialPill.Root>/,
+    );
+    spy.mockRestore();
+  });
+});

--- a/components/src/components/headless/trial-pill/TrialPill.tsx
+++ b/components/src/components/headless/trial-pill/TrialPill.tsx
@@ -1,0 +1,145 @@
+import { forwardRef, type ElementType } from "react";
+
+import { Slot, createHeadlessContext, mergeProps } from "../utils";
+
+import {
+  useTrialPill,
+  type TrialPillApi,
+  type TrialStatus,
+} from "./useTrialPill";
+
+const [TrialPillProvider, useTrialPillContext] =
+  createHeadlessContext<TrialPillApi>(
+    "TrialPill parts must be used within <TrialPill.Root>",
+  );
+
+/** Props shared by every non-root part. */
+export interface TrialPillPartProps extends React.HTMLAttributes<HTMLElement> {
+  /** Render as the single child element instead of the default DOM node. */
+  asChild?: boolean;
+}
+
+export interface TrialPillRootProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Trial end date (e.g. `useSchematicPlan().trialEndDate`). */
+  trialEndDate?: Date;
+  /** Trial status (e.g. `useSchematicPlan().trialStatus`). */
+  trialStatus?: TrialStatus;
+  /** Reference "now" for time-remaining math; defaults to the current time. */
+  now?: Date;
+  asChild?: boolean;
+}
+
+const Root = forwardRef<HTMLSpanElement, TrialPillRootProps>(
+  (
+    { trialEndDate, trialStatus, now, asChild, className, children, ...rest },
+    ref,
+  ) => {
+    const api = useTrialPill({ trialEndDate, trialStatus, now });
+
+    // No trial to display (e.g. no data yet, or the trial has converted).
+    if (!api.hasTrial) {
+      return null;
+    }
+
+    const props = mergeProps(
+      { ...api.getRootProps(), className: "schematic-trial-pill" },
+      { className, ...rest },
+    );
+    const Comp = (asChild ? Slot : "span") as ElementType;
+
+    return (
+      <TrialPillProvider value={api}>
+        <Comp ref={ref} {...props}>
+          {children}
+        </Comp>
+      </TrialPillProvider>
+    );
+  },
+);
+
+Root.displayName = "TrialPill.Root";
+
+const Label = forwardRef<HTMLSpanElement, TrialPillPartProps>(
+  ({ asChild, className, children, ...rest }, ref) => {
+    const { getLabelProps } = useTrialPillContext();
+    const props = mergeProps(
+      { ...getLabelProps(), className: "schematic-trial-pill__label" },
+      { className, ...rest },
+    );
+    const Comp = (asChild ? Slot : "span") as ElementType;
+    return (
+      <Comp ref={ref} {...props}>
+        {children}
+      </Comp>
+    );
+  },
+);
+
+Label.displayName = "TrialPill.Label";
+
+const TimeRemaining = forwardRef<HTMLSpanElement, TrialPillPartProps>(
+  ({ asChild, className, children, ...rest }, ref) => {
+    const { getTimeRemainingProps } = useTrialPillContext();
+    const props = mergeProps(
+      {
+        ...getTimeRemainingProps(),
+        className: "schematic-trial-pill__time-remaining",
+      },
+      {
+        className,
+        // only override the default ("<amount> <units>") text when provided
+        ...(children !== undefined ? { children } : {}),
+        ...rest,
+      },
+    );
+    const Comp = (asChild ? Slot : "span") as ElementType;
+    return <Comp ref={ref} {...props} />;
+  },
+);
+
+TimeRemaining.displayName = "TrialPill.TimeRemaining";
+
+const EndDate = forwardRef<HTMLTimeElement, TrialPillPartProps>(
+  ({ asChild, className, children, ...rest }, ref) => {
+    const { getEndDateProps } = useTrialPillContext();
+    const props = mergeProps(
+      { ...getEndDateProps(), className: "schematic-trial-pill__end-date" },
+      {
+        className,
+        // only override the default (formatted date) text when provided
+        ...(children !== undefined ? { children } : {}),
+        ...rest,
+      },
+    );
+    const Comp = (asChild ? Slot : "time") as ElementType;
+    return <Comp ref={ref} {...props} />;
+  },
+);
+
+EndDate.displayName = "TrialPill.EndDate";
+
+/**
+ * Headless, composable trial pill/badge. Controlled and unstyled: pass the
+ * `trialEndDate`/`trialStatus` from `useSchematicPlan`; `Root` renders nothing
+ * when there is no trial to show (e.g. once the plan has converted). Theme it
+ * with the `schematic-trial-pill*` classes or the `data-part` /
+ * `data-trial-status` / `data-expired` attributes.
+ *
+ * @example
+ * ```tsx
+ * const plan = useSchematicPlan();
+ * <TrialPill.Root trialEndDate={plan?.trialEndDate} trialStatus={plan?.trialStatus}>
+ *   <TrialPill.Label>Trial</TrialPill.Label>
+ *   <TrialPill.TimeRemaining /> left · ends <TrialPill.EndDate />
+ * </TrialPill.Root>
+ * ```
+ */
+export const TrialPill = {
+  Root,
+  Label,
+  TimeRemaining,
+  EndDate,
+};
+
+export { useTrialPillContext };

--- a/components/src/components/headless/trial-pill/TrialPill.tsx
+++ b/components/src/components/headless/trial-pill/TrialPill.tsx
@@ -19,8 +19,7 @@ export interface TrialPillPartProps extends React.HTMLAttributes<HTMLElement> {
   asChild?: boolean;
 }
 
-export interface TrialPillRootProps
-  extends React.HTMLAttributes<HTMLSpanElement> {
+export interface TrialPillRootProps extends React.HTMLAttributes<HTMLSpanElement> {
   /** Trial end date (e.g. `useSchematicPlan().trialEndDate`). */
   trialEndDate?: Date;
   /** Trial status (e.g. `useSchematicPlan().trialStatus`). */

--- a/components/src/components/headless/trial-pill/index.ts
+++ b/components/src/components/headless/trial-pill/index.ts
@@ -1,0 +1,2 @@
+export * from "./TrialPill";
+export * from "./useTrialPill";

--- a/components/src/components/headless/trial-pill/useTrialPill.ts
+++ b/components/src/components/headless/trial-pill/useTrialPill.ts
@@ -1,0 +1,133 @@
+import { useMemo } from "react";
+
+import {
+  DAYS_IN_MS,
+  HOURS_IN_MS,
+  MINUTES_IN_MS,
+  SECONDS_IN_MS,
+} from "../../../const";
+import { pluralize, toPrettyDate } from "../../../utils";
+
+/** Trial lifecycle, structurally matching `CheckPlanReturn["trialStatus"]`. */
+export type TrialStatus = "active" | "converted" | "expired";
+
+export interface UseTrialPillProps {
+  /** Trial end date (e.g. `useSchematicPlan().trialEndDate`). */
+  trialEndDate?: Date;
+  /** Trial status (e.g. `useSchematicPlan().trialStatus`). */
+  trialStatus?: TrialStatus;
+  /**
+   * Reference "now" used for the time-remaining math. Defaults to the current
+   * time; inject a fixed value for deterministic SSR/tests.
+   */
+  now?: Date;
+}
+
+type PropGetter = () => React.HTMLAttributes<HTMLElement> &
+  Record<string, unknown>;
+
+export interface TrialPillApi {
+  status?: TrialStatus;
+  /** Whether there is trial information worth displaying (false once converted). */
+  hasTrial: boolean;
+  isActive: boolean;
+  isExpired: boolean;
+  /**
+   * Whole-unit magnitude of time until (or since, when expired) the end date,
+   * using a day → hour → minute → second ladder. Undefined without an end date.
+   */
+  amount?: number;
+  /** Pluralized unit label matching `amount` (e.g. `"days"`). */
+  units?: string;
+  /** Human-formatted end date (e.g. `"July 7, 2026"`). Undefined without an end date. */
+  endDateLabel?: string;
+  getRootProps: PropGetter;
+  getLabelProps: PropGetter;
+  getTimeRemainingProps: PropGetter;
+  getEndDateProps: PropGetter;
+}
+
+/**
+ * Headless logic for a trial pill/badge. Pure and controlled — it fetches
+ * nothing; the caller supplies `trialEndDate`/`trialStatus` (typically from
+ * `useSchematicPlan`) and spreads the returned prop-getters onto their own
+ * markup, or lets the `TrialPill.*` compound components do it.
+ */
+export function useTrialPill({
+  trialEndDate,
+  trialStatus,
+  now,
+}: UseTrialPillProps): TrialPillApi {
+  return useMemo(() => {
+    const reference = now ?? new Date();
+    const status = trialStatus;
+
+    let amount: number | undefined;
+    let units: string | undefined;
+    let remainingMs: number | undefined;
+
+    if (trialEndDate) {
+      remainingMs = trialEndDate.getTime() - reference.getTime();
+      const magnitude = Math.abs(remainingMs);
+
+      let unit: string;
+      if (magnitude >= DAYS_IN_MS) {
+        amount = Math.floor(magnitude / DAYS_IN_MS);
+        unit = "day";
+      } else if (magnitude >= HOURS_IN_MS) {
+        amount = Math.floor(magnitude / HOURS_IN_MS);
+        unit = "hour";
+      } else if (magnitude >= MINUTES_IN_MS) {
+        amount = Math.floor(magnitude / MINUTES_IN_MS);
+        unit = "minute";
+      } else {
+        amount = Math.floor(magnitude / SECONDS_IN_MS);
+        unit = "second";
+      }
+
+      units = pluralize(unit, amount);
+    }
+
+    const isExpired =
+      status === "expired" || (remainingMs !== undefined && remainingMs <= 0);
+    const isActive =
+      status === "active" ||
+      (status === undefined && remainingMs !== undefined && remainingMs > 0);
+    const hasTrial =
+      status !== "converted" &&
+      (Boolean(trialEndDate) || status === "active" || status === "expired");
+    const endDateLabel = trialEndDate ? toPrettyDate(trialEndDate) : undefined;
+
+    return {
+      status,
+      hasTrial,
+      isActive,
+      isExpired,
+      amount,
+      units,
+      endDateLabel,
+      getRootProps: () => ({
+        "data-schematic": "trial-pill",
+        "data-part": "root",
+        ...(status ? { "data-trial-status": status } : {}),
+        ...(isExpired ? { "data-expired": "true" } : {}),
+      }),
+      getLabelProps: () => ({
+        "data-schematic": "trial-pill-label",
+        "data-part": "label",
+      }),
+      getTimeRemainingProps: () => ({
+        "data-schematic": "trial-pill-time-remaining",
+        "data-part": "time-remaining",
+        children:
+          amount !== undefined && units ? `${amount} ${units}` : undefined,
+      }),
+      getEndDateProps: () => ({
+        "data-schematic": "trial-pill-end-date",
+        "data-part": "end-date",
+        ...(trialEndDate ? { dateTime: trialEndDate.toISOString() } : {}),
+        children: endDateLabel,
+      }),
+    };
+  }, [trialEndDate, trialStatus, now]);
+}

--- a/components/src/components/headless/trial-pill/useTrialPill.ts
+++ b/components/src/components/headless/trial-pill/useTrialPill.ts
@@ -119,14 +119,14 @@ export function useTrialPill({
       getTimeRemainingProps: () => ({
         "data-schematic": "trial-pill-time-remaining",
         "data-part": "time-remaining",
-        children:
+        "children":
           amount !== undefined && units ? `${amount} ${units}` : undefined,
       }),
       getEndDateProps: () => ({
         "data-schematic": "trial-pill-end-date",
         "data-part": "end-date",
         ...(trialEndDate ? { dateTime: trialEndDate.toISOString() } : {}),
-        children: endDateLabel,
+        "children": endDateLabel,
       }),
     };
   }, [trialEndDate, trialStatus, now]);

--- a/components/src/components/headless/usage-meter/README.md
+++ b/components/src/components/headless/usage-meter/README.md
@@ -1,0 +1,78 @@
+# UsageMeter (headless)
+
+An unstyled, accessible, composable usage meter. Unlike the styled `elements/`
+components, it ships no visual styling of its own — you own the markup and CSS.
+It is **controlled**: pass `value`/`max` (and optionally `min`); it fetches
+nothing.
+
+## Usage
+
+### Compound components
+
+```tsx
+import { UsageMeter } from "@schematichq/schematic-components";
+import { useSchematicEntitlement } from "@schematichq/schematic-react";
+
+function SeatsMeter() {
+  const e = useSchematicEntitlement("seats");
+  if (typeof e.featureUsage !== "number" || typeof e.featureAllocation !== "number") {
+    return null;
+  }
+
+  return (
+    <UsageMeter.Root value={e.featureUsage} max={e.featureAllocation}>
+      <UsageMeter.Label>Seats</UsageMeter.Label>
+      <UsageMeter.Track>
+        <UsageMeter.Fill />
+      </UsageMeter.Track>
+      <UsageMeter.ValueText />
+    </UsageMeter.Root>
+  );
+}
+```
+
+### `asChild` (polymorphism)
+
+Any part can render as your own element via `asChild`; the headless props,
+attributes, and ref are merged onto the child.
+
+```tsx
+<UsageMeter.Root asChild value={usage} max={limit}>
+  <section className="card">…</section>
+</UsageMeter.Root>
+```
+
+### Hook-only (fully custom markup)
+
+```tsx
+import { useUsageMeter } from "@schematichq/schematic-components";
+
+const meter = useUsageMeter({ value: usage, max: limit });
+<div {...meter.getRootProps()}>
+  <div {...meter.getTrackProps()}>
+    <div {...meter.getFillProps()} />
+  </div>
+</div>;
+```
+
+## Accessibility
+
+The root renders `role="meter"` with `aria-valuenow` / `aria-valuemin` /
+`aria-valuemax` / `aria-valuetext`. Provide an accessible name either with the
+`label` prop (→ `aria-label`) or by rendering `<UsageMeter.Label>` (→
+`aria-labelledby`, wired automatically).
+
+## Styling hooks
+
+Every part exposes `data-schematic` / `data-part` attributes and BEM-style
+classes: `schematic-usage-meter`, `__track`, `__fill`, `__label`,
+`__value-text`. The only inline style applied is the functional
+`width: <percent>%` on the fill. Suggested CSS custom properties (you supply the
+stylesheet):
+
+| Variable                            | Applies to      |
+| ----------------------------------- | --------------- |
+| `--schematic-meter-height`          | track height    |
+| `--schematic-meter-track-background`| track background|
+| `--schematic-meter-fill-background` | fill background |
+| `--schematic-meter-fill-transition` | fill transition |

--- a/components/src/components/headless/usage-meter/UsageMeter.test.tsx
+++ b/components/src/components/headless/usage-meter/UsageMeter.test.tsx
@@ -1,0 +1,141 @@
+import { render, renderHook, screen } from "@testing-library/react";
+import { createRef } from "react";
+
+
+import { UsageMeter } from "./UsageMeter";
+import { useUsageMeter } from "./useUsageMeter";
+
+describe("useUsageMeter", () => {
+  test("computes percent for a value within range", () => {
+    const { result } = renderHook(() => useUsageMeter({ value: 25, max: 100 }));
+    expect(result.current.percent).toBe(25);
+    expect(result.current.value).toBe(25);
+  });
+
+  test("clamps value above max to 100%", () => {
+    const { result } = renderHook(() => useUsageMeter({ value: 150, max: 100 }));
+    expect(result.current.percent).toBe(100);
+    expect(result.current.value).toBe(100);
+  });
+
+  test("clamps value below min to 0%", () => {
+    const { result } = renderHook(() =>
+      useUsageMeter({ value: -10, max: 100, min: 0 }),
+    );
+    expect(result.current.percent).toBe(0);
+    expect(result.current.value).toBe(0);
+  });
+
+  test("returns 0% when max is not greater than min", () => {
+    const { result } = renderHook(() => useUsageMeter({ value: 5, max: 0 }));
+    expect(result.current.percent).toBe(0);
+  });
+
+  test("honors a non-zero min", () => {
+    const { result } = renderHook(() =>
+      useUsageMeter({ value: 75, max: 100, min: 50 }),
+    );
+    expect(result.current.percent).toBe(50);
+  });
+});
+
+describe("UsageMeter compound components", () => {
+  const renderMeter = (props?: Partial<{ value: number; max: number }>) =>
+    render(
+      <UsageMeter.Root value={props?.value ?? 30} max={props?.max ?? 120}>
+        <UsageMeter.Track>
+          <UsageMeter.Fill />
+        </UsageMeter.Track>
+        <UsageMeter.ValueText />
+      </UsageMeter.Root>,
+    );
+
+  test("renders an accessible meter with correct aria attributes", () => {
+    renderMeter({ value: 30, max: 120 });
+    const meter = screen.getByRole("meter");
+    expect(meter).toHaveAttribute("aria-valuenow", "30");
+    expect(meter).toHaveAttribute("aria-valuemin", "0");
+    expect(meter).toHaveAttribute("aria-valuemax", "120");
+    expect(meter).toHaveAttribute("aria-valuetext", "25%");
+    expect(meter).toHaveAttribute("data-schematic", "usage-meter");
+    expect(meter).toHaveClass("schematic-usage-meter");
+  });
+
+  test("Fill gets a functional width and its part attributes", () => {
+    const { container } = renderMeter({ value: 30, max: 120 });
+    const fill = container.querySelector('[data-part="fill"]');
+    expect(fill).not.toBeNull();
+    expect(fill).toHaveStyle({ width: "25%" });
+    expect(fill).toHaveClass("schematic-usage-meter__fill");
+  });
+
+  test("ValueText renders the rounded percent by default", () => {
+    renderMeter({ value: 30, max: 120 });
+    expect(screen.getByText("25%")).toBeInTheDocument();
+  });
+
+  test("ValueText renders custom children when provided", () => {
+    render(
+      <UsageMeter.Root value={30} max={120}>
+        <UsageMeter.ValueText>30 of 120</UsageMeter.ValueText>
+      </UsageMeter.Root>,
+    );
+    expect(screen.getByText("30 of 120")).toBeInTheDocument();
+    expect(screen.queryByText("25%")).not.toBeInTheDocument();
+  });
+
+  test("Label wires aria-labelledby on the root", () => {
+    render(
+      <UsageMeter.Root value={30} max={120}>
+        <UsageMeter.Label>Seats</UsageMeter.Label>
+      </UsageMeter.Root>,
+    );
+    const meter = screen.getByRole("meter");
+    const label = screen.getByText("Seats");
+    expect(label.id).toBeTruthy();
+    expect(meter).toHaveAttribute("aria-labelledby", label.id);
+  });
+
+  test("label prop sets aria-label", () => {
+    render(<UsageMeter.Root value={30} max={120} label="Seats used" />);
+    expect(screen.getByRole("meter")).toHaveAttribute(
+      "aria-label",
+      "Seats used",
+    );
+  });
+
+  test("asChild renders the consumer element and merges props/ref", () => {
+    const ref = createRef<HTMLElement>();
+    const onClick = vi.fn();
+    render(
+      <UsageMeter.Root
+        asChild
+        value={30}
+        max={120}
+        className="mine"
+        onClick={onClick}
+      >
+        <section ref={ref}>content</section>
+      </UsageMeter.Root>,
+    );
+
+    const meter = screen.getByRole("meter");
+    expect(meter.tagName).toBe("SECTION");
+    // base class merged with the caller's class, not clobbered
+    expect(meter).toHaveClass("schematic-usage-meter");
+    expect(meter).toHaveClass("mine");
+    expect(ref.current).toBe(meter);
+
+    meter.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when a part is used outside Root", () => {
+    // suppress the expected React error boundary console noise
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<UsageMeter.Fill />)).toThrow(
+      /must be used within <UsageMeter.Root>/,
+    );
+    spy.mockRestore();
+  });
+});

--- a/components/src/components/headless/usage-meter/UsageMeter.test.tsx
+++ b/components/src/components/headless/usage-meter/UsageMeter.test.tsx
@@ -1,7 +1,6 @@
 import { render, renderHook, screen } from "@testing-library/react";
 import { createRef } from "react";
 
-
 import { UsageMeter } from "./UsageMeter";
 import { useUsageMeter } from "./useUsageMeter";
 
@@ -13,7 +12,9 @@ describe("useUsageMeter", () => {
   });
 
   test("clamps value above max to 100%", () => {
-    const { result } = renderHook(() => useUsageMeter({ value: 150, max: 100 }));
+    const { result } = renderHook(() =>
+      useUsageMeter({ value: 150, max: 100 }),
+    );
     expect(result.current.percent).toBe(100);
     expect(result.current.value).toBe(100);
   });

--- a/components/src/components/headless/usage-meter/UsageMeter.tsx
+++ b/components/src/components/headless/usage-meter/UsageMeter.tsx
@@ -1,0 +1,189 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type ElementType,
+} from "react";
+
+import { Slot, createHeadlessContext, mergeProps } from "../utils";
+
+import { useUsageMeter, type UsageMeterApi } from "./useUsageMeter";
+
+interface UsageMeterContextValue extends UsageMeterApi {
+  /** Registers/clears the id of the `<Label>` for `aria-labelledby` wiring. */
+  registerLabel: (id: string | undefined) => void;
+}
+
+const [UsageMeterProvider, useUsageMeterContext] =
+  createHeadlessContext<UsageMeterContextValue>(
+    "UsageMeter parts must be used within <UsageMeter.Root>",
+  );
+
+/** Props shared by every non-root part. */
+export interface UsageMeterPartProps
+  extends React.HTMLAttributes<HTMLElement> {
+  /** Render as the single child element instead of the default DOM node. */
+  asChild?: boolean;
+}
+
+export interface UsageMeterRootProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /** Current usage value (e.g. `entitlement.featureUsage`). */
+  value: number;
+  /** Maximum/allocation value (e.g. `entitlement.featureAllocation`). */
+  max: number;
+  /** Minimum of the range. Defaults to `0`. */
+  min?: number;
+  /** Accessible name applied as `aria-label` when no `<Label>` is used. */
+  label?: string;
+  asChild?: boolean;
+}
+
+const Root = forwardRef<HTMLDivElement, UsageMeterRootProps>(
+  (
+    { value, max, min, label, asChild, className, children, ...rest },
+    ref,
+  ) => {
+    const [labelId, setLabelId] = useState<string>();
+    const api = useUsageMeter({ value, max, min, label, labelId });
+    const registerLabel = useCallback(
+      (id: string | undefined) => setLabelId(id),
+      [],
+    );
+    const contextValue = useMemo<UsageMeterContextValue>(
+      () => ({ ...api, registerLabel }),
+      [api, registerLabel],
+    );
+
+    const props = mergeProps(
+      { ...api.getRootProps(), className: "schematic-usage-meter" },
+      { className, ...rest },
+    );
+
+    const Comp = (asChild ? Slot : "div") as ElementType;
+
+    return (
+      <UsageMeterProvider value={contextValue}>
+        <Comp ref={ref} {...props}>
+          {children}
+        </Comp>
+      </UsageMeterProvider>
+    );
+  },
+);
+
+Root.displayName = "UsageMeter.Root";
+
+const Track = forwardRef<HTMLDivElement, UsageMeterPartProps>(
+  ({ asChild, className, children, ...rest }, ref) => {
+    const { getTrackProps } = useUsageMeterContext();
+    const props = mergeProps(
+      { ...getTrackProps(), className: "schematic-usage-meter__track" },
+      { className, ...rest },
+    );
+    const Comp = (asChild ? Slot : "div") as ElementType;
+    return (
+      <Comp ref={ref} {...props}>
+        {children}
+      </Comp>
+    );
+  },
+);
+
+Track.displayName = "UsageMeter.Track";
+
+const Fill = forwardRef<HTMLDivElement, UsageMeterPartProps>(
+  ({ asChild, className, style, children, ...rest }, ref) => {
+    const { getFillProps } = useUsageMeterContext();
+    const props = mergeProps(
+      { ...getFillProps(), className: "schematic-usage-meter__fill" },
+      { className, style, ...rest },
+    );
+    const Comp = (asChild ? Slot : "div") as ElementType;
+    return (
+      <Comp ref={ref} {...props}>
+        {children}
+      </Comp>
+    );
+  },
+);
+
+Fill.displayName = "UsageMeter.Fill";
+
+const Label = forwardRef<HTMLSpanElement, UsageMeterPartProps>(
+  ({ asChild, className, children, id: idProp, ...rest }, ref) => {
+    const { getLabelProps, registerLabel } = useUsageMeterContext();
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
+
+    useEffect(() => {
+      registerLabel(id);
+      return () => registerLabel(undefined);
+    }, [registerLabel, id]);
+
+    const props = mergeProps(
+      { ...getLabelProps(), id, className: "schematic-usage-meter__label" },
+      { className, ...rest },
+    );
+    const Comp = (asChild ? Slot : "span") as ElementType;
+    return (
+      <Comp ref={ref} {...props}>
+        {children}
+      </Comp>
+    );
+  },
+);
+
+Label.displayName = "UsageMeter.Label";
+
+const ValueText = forwardRef<HTMLSpanElement, UsageMeterPartProps>(
+  ({ asChild, className, children, ...rest }, ref) => {
+    const { getValueTextProps } = useUsageMeterContext();
+    const props = mergeProps(
+      {
+        ...getValueTextProps(),
+        className: "schematic-usage-meter__value-text",
+      },
+      {
+        className,
+        // only override the default (percent) text when children are provided
+        ...(children !== undefined ? { children } : {}),
+        ...rest,
+      },
+    );
+    const Comp = (asChild ? Slot : "span") as ElementType;
+    return <Comp ref={ref} {...props} />;
+  },
+);
+
+ValueText.displayName = "UsageMeter.ValueText";
+
+/**
+ * Headless, composable usage meter. Unstyled by default — theme it with the
+ * `schematic-usage-meter*` classes, `data-part` attributes, or the documented
+ * CSS custom properties (see the folder README).
+ *
+ * @example
+ * ```tsx
+ * const e = useSchematicEntitlement("seats");
+ * <UsageMeter.Root value={e.featureUsage} max={e.featureAllocation}>
+ *   <UsageMeter.Label>Seats</UsageMeter.Label>
+ *   <UsageMeter.Track>
+ *     <UsageMeter.Fill />
+ *   </UsageMeter.Track>
+ *   <UsageMeter.ValueText />
+ * </UsageMeter.Root>
+ * ```
+ */
+export const UsageMeter = {
+  Root,
+  Track,
+  Fill,
+  Label,
+  ValueText,
+};
+
+export { useUsageMeterContext };

--- a/components/src/components/headless/usage-meter/UsageMeter.tsx
+++ b/components/src/components/headless/usage-meter/UsageMeter.tsx
@@ -23,14 +23,12 @@ const [UsageMeterProvider, useUsageMeterContext] =
   );
 
 /** Props shared by every non-root part. */
-export interface UsageMeterPartProps
-  extends React.HTMLAttributes<HTMLElement> {
+export interface UsageMeterPartProps extends React.HTMLAttributes<HTMLElement> {
   /** Render as the single child element instead of the default DOM node. */
   asChild?: boolean;
 }
 
-export interface UsageMeterRootProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+export interface UsageMeterRootProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Current usage value (e.g. `entitlement.featureUsage`). */
   value: number;
   /** Maximum/allocation value (e.g. `entitlement.featureAllocation`). */
@@ -43,10 +41,7 @@ export interface UsageMeterRootProps
 }
 
 const Root = forwardRef<HTMLDivElement, UsageMeterRootProps>(
-  (
-    { value, max, min, label, asChild, className, children, ...rest },
-    ref,
-  ) => {
+  ({ value, max, min, label, asChild, className, children, ...rest }, ref) => {
     const [labelId, setLabelId] = useState<string>();
     const api = useUsageMeter({ value, max, min, label, labelId });
     const registerLabel = useCallback(

--- a/components/src/components/headless/usage-meter/index.ts
+++ b/components/src/components/headless/usage-meter/index.ts
@@ -1,0 +1,2 @@
+export * from "./UsageMeter";
+export * from "./useUsageMeter";

--- a/components/src/components/headless/usage-meter/useUsageMeter.ts
+++ b/components/src/components/headless/usage-meter/useUsageMeter.ts
@@ -64,7 +64,7 @@ export function useUsageMeter({
       max,
       percent,
       getRootProps: () => ({
-        role: "meter",
+        "role": "meter",
         "aria-valuenow": clampedValue,
         "aria-valuemin": min,
         "aria-valuemax": max,
@@ -82,7 +82,7 @@ export function useUsageMeter({
         "data-schematic": "usage-meter-fill",
         "data-part": "fill",
         // functional style only — visual styling is left to CSS
-        style: { width: `${percent}%` },
+        "style": { width: `${percent}%` },
       }),
       getLabelProps: () => ({
         "data-schematic": "usage-meter-label",
@@ -91,7 +91,7 @@ export function useUsageMeter({
       getValueTextProps: () => ({
         "data-schematic": "usage-meter-value-text",
         "data-part": "value-text",
-        children: `${roundedPercent}%`,
+        "children": `${roundedPercent}%`,
       }),
     };
   }, [value, max, min, label, labelId]);

--- a/components/src/components/headless/usage-meter/useUsageMeter.ts
+++ b/components/src/components/headless/usage-meter/useUsageMeter.ts
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+
+export interface UseUsageMeterProps {
+  /** The current usage value (e.g. `entitlement.featureUsage`). */
+  value: number;
+  /** The maximum/allocation value (e.g. `entitlement.featureAllocation`). */
+  max: number;
+  /** The minimum of the range. Defaults to `0`. */
+  min?: number;
+  /** Optional accessible name applied as `aria-label` on the root. */
+  label?: string;
+  /**
+   * Id of an element labelling the meter, applied as `aria-labelledby` on the
+   * root. The `<UsageMeter.Label>` part wires this automatically; hook-only
+   * consumers can pass it directly.
+   */
+  labelId?: string;
+}
+
+type PropGetter = () => React.HTMLAttributes<HTMLElement> &
+  Record<string, unknown>;
+
+export interface UsageMeterApi {
+  /** The `value` clamped into `[min, max]`. */
+  value: number;
+  min: number;
+  max: number;
+  /** Fill percentage in `[0, 100]`, rounded to two decimals. */
+  percent: number;
+  getRootProps: PropGetter;
+  getTrackProps: PropGetter;
+  getFillProps: PropGetter;
+  getLabelProps: PropGetter;
+  getValueTextProps: PropGetter;
+}
+
+const clamp = (n: number, lo: number, hi: number) =>
+  Math.min(hi, Math.max(lo, n));
+
+/**
+ * Headless logic for a usage meter. Pure and controlled — it fetches nothing;
+ * the caller supplies `value`/`max`/`min` (typically from
+ * `useSchematicEntitlement`) and spreads the returned prop-getters onto their
+ * own markup, or lets the `UsageMeter.*` compound components do it.
+ */
+export function useUsageMeter({
+  value,
+  max,
+  min = 0,
+  label,
+  labelId,
+}: UseUsageMeterProps): UsageMeterApi {
+  return useMemo(() => {
+    const clampedValue = clamp(value, min, max);
+    const percent =
+      max > min
+        ? Math.round(((clampedValue - min) / (max - min)) * 100 * 100) / 100
+        : 0;
+    const roundedPercent = Math.round(percent);
+
+    return {
+      value: clampedValue,
+      min,
+      max,
+      percent,
+      getRootProps: () => ({
+        role: "meter",
+        "aria-valuenow": clampedValue,
+        "aria-valuemin": min,
+        "aria-valuemax": max,
+        "aria-valuetext": `${roundedPercent}%`,
+        ...(label ? { "aria-label": label } : {}),
+        ...(labelId ? { "aria-labelledby": labelId } : {}),
+        "data-schematic": "usage-meter",
+        "data-part": "root",
+      }),
+      getTrackProps: () => ({
+        "data-schematic": "usage-meter-track",
+        "data-part": "track",
+      }),
+      getFillProps: () => ({
+        "data-schematic": "usage-meter-fill",
+        "data-part": "fill",
+        // functional style only — visual styling is left to CSS
+        style: { width: `${percent}%` },
+      }),
+      getLabelProps: () => ({
+        "data-schematic": "usage-meter-label",
+        "data-part": "label",
+      }),
+      getValueTextProps: () => ({
+        "data-schematic": "usage-meter-value-text",
+        "data-part": "value-text",
+        children: `${roundedPercent}%`,
+      }),
+    };
+  }, [value, max, min, label, labelId]);
+}

--- a/components/src/components/headless/utils/Slot.tsx
+++ b/components/src/components/headless/utils/Slot.tsx
@@ -1,0 +1,68 @@
+import {
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type ReactNode,
+  type Ref,
+} from "react";
+
+import { mergeProps } from "./mergeProps";
+
+function setRef<T>(ref: Ref<T> | undefined, value: T | null) {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref != null) {
+    (ref as React.MutableRefObject<T | null>).current = value;
+  }
+}
+
+/**
+ * Combine multiple refs into a single ref callback so the same node can be
+ * forwarded to several owners (e.g. the part's own ref plus the child's ref
+ * when composing with `asChild`).
+ */
+export function composeRefs<T>(
+  ...refs: (Ref<T> | undefined)[]
+): (node: T | null) => void {
+  return (node) => {
+    refs.forEach((ref) => setRef(ref, node));
+  };
+}
+
+export interface SlotProps {
+  children?: ReactNode;
+}
+
+/**
+ * Renders no DOM of its own: clones its single child element and merges the
+ * injected props (and ref) onto it via {@link mergeProps}. This powers the
+ * `asChild` pattern, letting consumers render a part as their own element while
+ * still receiving the headless behavior/attributes.
+ *
+ * Ref handling supports both React 18 (`element.ref`) and React 19 (ref passed
+ * as a normal `props.ref`).
+ */
+export const Slot = forwardRef<HTMLElement, SlotProps & Record<string, unknown>>(
+  ({ children, ...slotProps }, ref) => {
+    if (!isValidElement(children)) {
+      return null;
+    }
+
+    const { ref: childRef, ...childProps } = children.props as Record<
+      string,
+      unknown
+    > & { ref?: Ref<HTMLElement> };
+
+    const merged = mergeProps(slotProps, childProps);
+
+    return cloneElement(children, {
+      ...merged,
+      ref: composeRefs(
+        ref,
+        childRef ?? (children as { ref?: Ref<HTMLElement> }).ref,
+      ),
+    } as Record<string, unknown>);
+  },
+);
+
+Slot.displayName = "Slot";

--- a/components/src/components/headless/utils/Slot.tsx
+++ b/components/src/components/headless/utils/Slot.tsx
@@ -42,27 +42,28 @@ export interface SlotProps {
  * Ref handling supports both React 18 (`element.ref`) and React 19 (ref passed
  * as a normal `props.ref`).
  */
-export const Slot = forwardRef<HTMLElement, SlotProps & Record<string, unknown>>(
-  ({ children, ...slotProps }, ref) => {
-    if (!isValidElement(children)) {
-      return null;
-    }
+export const Slot = forwardRef<
+  HTMLElement,
+  SlotProps & Record<string, unknown>
+>(({ children, ...slotProps }, ref) => {
+  if (!isValidElement(children)) {
+    return null;
+  }
 
-    const { ref: childRef, ...childProps } = children.props as Record<
-      string,
-      unknown
-    > & { ref?: Ref<HTMLElement> };
+  const { ref: childRef, ...childProps } = children.props as Record<
+    string,
+    unknown
+  > & { ref?: Ref<HTMLElement> };
 
-    const merged = mergeProps(slotProps, childProps);
+  const merged = mergeProps(slotProps, childProps);
 
-    return cloneElement(children, {
-      ...merged,
-      ref: composeRefs(
-        ref,
-        childRef ?? (children as { ref?: Ref<HTMLElement> }).ref,
-      ),
-    } as Record<string, unknown>);
-  },
-);
+  return cloneElement(children, {
+    ...merged,
+    ref: composeRefs(
+      ref,
+      childRef ?? (children as { ref?: Ref<HTMLElement> }).ref,
+    ),
+  } as Record<string, unknown>);
+});
 
 Slot.displayName = "Slot";

--- a/components/src/components/headless/utils/createHeadlessContext.tsx
+++ b/components/src/components/headless/utils/createHeadlessContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, type Provider } from "react";
+
+/**
+ * Create a lightweight, strongly-typed context for a headless compound
+ * component. The returned hook throws a descriptive error when a part is
+ * rendered outside its provider (mirrors the throw-on-missing-provider idiom
+ * used by `EmbedContext`, but scoped to a single component).
+ *
+ * @param errorMessage - thrown when the hook is used outside the provider.
+ * @returns a tuple of `[Provider, useContext]`.
+ */
+export function createHeadlessContext<T>(
+  errorMessage: string,
+): [Provider<T | null>, () => T] {
+  const Context = createContext<T | null>(null);
+
+  const useHeadlessContext = (): T => {
+    const context = useContext(Context);
+    if (context === null) {
+      throw new Error(errorMessage);
+    }
+    return context;
+  };
+
+  return [Context.Provider, useHeadlessContext];
+}

--- a/components/src/components/headless/utils/index.ts
+++ b/components/src/components/headless/utils/index.ts
@@ -1,0 +1,3 @@
+export * from "./createHeadlessContext";
+export * from "./mergeProps";
+export * from "./Slot";

--- a/components/src/components/headless/utils/mergeProps.ts
+++ b/components/src/components/headless/utils/mergeProps.ts
@@ -1,0 +1,48 @@
+type UnknownProps = Record<string, unknown>;
+
+/**
+ * Merge two props objects, giving precedence to `overrides` while intelligently
+ * combining the props that should never be clobbered:
+ *
+ * - `on*` event handlers are chained (both run; the override runs first),
+ * - `className` values are concatenated,
+ * - `style` objects are shallow-merged (override wins per-property),
+ * - everything else takes the override value when it is defined, otherwise base.
+ *
+ * This mirrors the `mergeProps` semantics used by Radix/Zag and is the basis for
+ * both the compound-component prop-getters and the `Slot` (`asChild`) merging.
+ */
+export function mergeProps<T extends UnknownProps, U extends UnknownProps>(
+  base: T,
+  overrides: U,
+): T & U {
+  const result: UnknownProps = { ...base };
+
+  for (const key in overrides) {
+    const baseValue = result[key];
+    const overrideValue = overrides[key];
+
+    if (
+      /^on[A-Z]/.test(key) &&
+      typeof baseValue === "function" &&
+      typeof overrideValue === "function"
+    ) {
+      // chain event handlers: the caller's handler runs, then the getter's
+      result[key] = (...args: unknown[]) => {
+        (overrideValue as (...a: unknown[]) => void)(...args);
+        (baseValue as (...a: unknown[]) => void)(...args);
+      };
+    } else if (key === "className") {
+      result[key] = [baseValue, overrideValue].filter(Boolean).join(" ");
+    } else if (key === "style") {
+      result[key] = {
+        ...(baseValue as object | undefined),
+        ...(overrideValue as object | undefined),
+      };
+    } else {
+      result[key] = overrideValue ?? baseValue;
+    }
+  }
+
+  return result as T & U;
+}

--- a/components/src/components/index.ts
+++ b/components/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./elements";
 export * from "./embed";
+export * from "./headless";
 export * from "./layout";
 export * from "./shared/checkout-dialog";
 export * from "./ui";


### PR DESCRIPTION
## Summary

Introduces the first two **headless components** to `@schematichq/schematic-components`: `UsageMeter` and `TrialPill`. Unlike the existing styled `elements/`, these ship no visual styling of their own — consumers own the markup and CSS while the library provides the accessible, composable behavior. All components are **controlled**: they fetch nothing and take their data as props (typically from `useSchematicEntitlement` / `useSchematicPlan`).

Resolves [SCHY-437](https://linear.app/schematic/issue/SCHY-437/add-support-for-composableheadless-components).

## What's included

### `UsageMeter`
- `role="meter"` with `aria-valuenow/min/max/valuetext` wired from `value`/`max`/`min`.
- Compound parts: `UsageMeter.Root`, `.Track`, `.Fill`, `.Label`, `.ValueText`.
- Accessible name via the `label` prop (→ `aria-label`) or `<UsageMeter.Label>` (→ `aria-labelledby`, wired automatically).
- Fill applies the single functional inline style (`width: <percent>%`); all other styling is left to CSS.

### `TrialPill`
- Unstyled pill/badge for plan trial state. `Root` renders **nothing** when there is no trial to show (no `trialEndDate`/`trialStatus`, or once `trialStatus` is `"converted"`).
- Compound parts: `TrialPill.Root`, `.Label`, `.TimeRemaining`, `.EndDate`.
- `TimeRemaining` uses the same day → hour → minute → second ladder as `useTrialEnd`; `EndDate` renders as `<time datetime="…">`.

### Headless primitives (`utils/`)
- `Slot` + `composeRefs` + `mergeProps` to power the `asChild` polymorphism pattern (render any part as your own element while keeping the headless props, attributes, and ref). Ref handling supports both React 18 and 19.
- `createHeadlessContext` helper for the compound-component context.

## API surface

Each component ships three ways to consume it:
1. **Compound components** — `<UsageMeter.Root>…</UsageMeter.Root>` for the common case.
2. **`asChild`** — merge headless behavior onto your own element.
3. **Hook-only** — `useUsageMeter` / `useTrialPill` return prop-getters (`getRootProps`, etc.) for fully custom markup and i18n.

Every part exposes `data-schematic` / `data-part` attributes and BEM-style classes (`schematic-usage-meter__fill`, `schematic-trial-pill__label`, …) as styling hooks. See the per-component `README.md` files for usage and CSS custom properties.

## Testing

Adds unit tests: `UsageMeter.test.tsx` and `TrialPill.test.tsx`.
