### PR TITLE
feat(components): support pre-applying a promo code via BypassConfig

### DIFF
--- a/components/src/components/shared/checkout-dialog/Checkout.tsx
+++ b/components/src/components/shared/checkout-dialog/Checkout.tsx
@@ -33,6 +33,7 @@ interface CheckoutProps {
   optInAccepted: boolean;
   setOptInAccepted: (accepted: boolean) => void;
   setPaymentMethodId: (id: string) => void;
+  promoCode?: string | null;
   updatePromoCode: (code: string) => void;
   confirmPaymentIntentProps?: ConfirmPaymentIntentProps | null | undefined;
   financeData?: PreviewSubscriptionFinanceResponseData | null;
@@ -59,6 +60,7 @@ export const Checkout = ({
   optInAccepted,
   setOptInAccepted,
   setPaymentMethodId,
+  promoCode,
   updatePromoCode,
   confirmPaymentIntentProps,
   financeData,
@@ -68,7 +70,7 @@ export const Checkout = ({
 
   const isLightBackground = useIsLightBackground();
 
-  const [discount, setDiscount] = useState("");
+  const [discount, setDiscount] = useState(promoCode ?? "");
 
   const hasCustomFields =
     !!customCheckoutFields && customCheckoutFields.length > 0;

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -628,7 +628,9 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     [addOnUsageBasedEntitlements],
   );
 
-  const [promoCode, setPromoCode] = useState<string | null>(null);
+  const [promoCode, setPromoCode] = useState<string | null>(
+    () => checkoutState?.promoCode ?? null,
+  );
 
   const [customFieldValues, setCustomFieldValues] = useState<
     Record<string, string>
@@ -1935,6 +1937,7 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
                 optInAccepted={optInAccepted}
                 setOptInAccepted={setOptInAccepted}
                 setPaymentMethodId={(id) => setPaymentMethodId(id)}
+                promoCode={promoCode}
                 updatePromoCode={updatePromoCode}
                 confirmPaymentIntentProps={confirmPaymentIntentProps}
                 financeData={charges}

--- a/components/src/context/embedReducer.test.ts
+++ b/components/src/context/embedReducer.test.ts
@@ -451,6 +451,49 @@ describe("embedReducer - SET_PLANID_BYPASS", () => {
       expect(result.checkoutState?.payInAdvanceQuantities).toBeUndefined();
     });
   });
+
+  describe("promoCode configuration", () => {
+    it("should pass promoCode through verbatim", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+        promoCode: "SUMMER20",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.promoCode).toBe("SUMMER20");
+    });
+
+    it("should leave promoCode undefined when not provided", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.promoCode).toBeUndefined();
+    });
+
+    it("should not set promoCode for an empty string", () => {
+      const config: BypassConfig = {
+        planId: "plan_xyz",
+        promoCode: "",
+      };
+
+      const result = reducer(initialState, {
+        type: "SET_PLANID_BYPASS",
+        config,
+      });
+
+      expect(result.checkoutState?.promoCode).toBeUndefined();
+    });
+  });
 });
 
 describe("embedReducer - SET_CHECKOUT_PREFILL", () => {

--- a/components/src/context/embedReducer.ts
+++ b/components/src/context/embedReducer.ts
@@ -309,6 +309,7 @@ export const reducer = (state: EmbedState, action: EmbedAction): EmbedState => {
           ...(config.payInAdvanceQuantities && {
             payInAdvanceQuantities: config.payInAdvanceQuantities,
           }),
+          ...(config.promoCode && { promoCode: config.promoCode }),
           ...(config.currency && {
             selectedCurrency: config.currency.toUpperCase(),
           }),

--- a/components/src/context/embedState.ts
+++ b/components/src/context/embedState.ts
@@ -328,6 +328,19 @@ export interface BypassConfig {
    * { planId: "plan_abc", payInAdvanceQuantities: { feat_seats: 3 } }
    */
   payInAdvanceQuantities?: Record<string, number>;
+  /**
+   * Promotion code to pre-apply to the checkout (a Stripe promotion code such
+   * as "SUMMER20" — the customer-facing code, not the underlying coupon id).
+   *
+   * The discount is applied on load: the previewed charges reflect it and it is
+   * sent with the final checkout request. The customer can still change or
+   * clear it via the discount field in the checkout form. Invalid codes are
+   * rejected by the backend the same way a manually entered code would be.
+   *
+   * @example
+   * { planId: "plan_abc", promoCode: "SUMMER20" }
+   */
+  promoCode?: string;
 }
 
 /**
@@ -374,6 +387,7 @@ export type CheckoutState = {
   showCurrencySelector?: boolean;
   startTrialIfAvailable?: boolean;
   payInAdvanceQuantities?: Record<string, number>;
+  promoCode?: string;
 };
 
 export type EmbedMode = "edit" | "view";


### PR DESCRIPTION
Adds a `promoCode` field to `BypassConfig` so a host application can pre-apply a Stripe promotion code (the human friendly ones) when launching checkout via `initializeWithPlan(...)`:

```ts
initializeWithPlan({ planId: "plan_abc", promoCode: "SUMMER20" });
```

Our API provides another path for setting coupons: `external_coupon_id`, but that uses raw IDs and is not needed here.