### PR TITLE
Fix checkout renewal date to use period end, not period start

### DIFF
--- a/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
+++ b/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
@@ -285,6 +285,7 @@ export const SubscriptionSidebar = forwardRef<
       dueNow,
       newCharges,
       percentOff,
+      periodEnd,
       periodStart,
       proration,
       taxAmount,
@@ -295,12 +296,20 @@ export const SubscriptionSidebar = forwardRef<
         dueNow: charges?.dueNow ?? 0,
         newCharges: charges?.newCharges ?? 0,
         percentOff: charges?.percentOff ?? 0,
+        periodEnd: charges?.periodEnd,
         periodStart: charges?.periodStart,
         proration: charges?.proration ?? 0,
         taxAmount: charges?.taxAmount ?? 0,
         taxDescription: charges?.taxDisplayName,
       };
     }, [charges]);
+
+    // The subscription renews on its billing-cycle anchor (period end), not the
+    // start of the current period. These differ once a mid-cycle change made via
+    // a Stripe subscription schedule shortens the current period while keeping
+    // the original anchor. Fall back to periodStart for older API responses that
+    // predate period_end.
+    const renewDate = periodEnd ?? periodStart;
 
     const updatedUsageBasedEntitlements = useMemo(() => {
       const changedUsageBasedEntitlements: {
@@ -1407,7 +1416,7 @@ export const SubscriptionSidebar = forwardRef<
                   : subscriptionPrice &&
                     // TODO: localize
                     `You will be billed ${subscriptionPrice} ${usageBasedEntitlements.length > 0 ? "plus usage based costs" : ""} for this subscription
-                every ${planPeriod} ${periodStart ? `on the ${formatOrdinal(periodStart.getDate())}` : ""} ${planPeriod === "year" && periodStart ? `of ${getMonthName(periodStart)}` : ""} unless you unsubscribe.`}
+                every ${planPeriod} ${renewDate ? `on the ${formatOrdinal(renewDate.getDate())}` : ""} ${planPeriod === "year" && renewDate ? `of ${getMonthName(renewDate)}` : ""} unless you unsubscribe.`}
               </Text>
             </Box>
           )}

--- a/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
+++ b/components/src/components/shared/subscription-sidebar/SubscriptionSidebar.tsx
@@ -307,9 +307,12 @@ export const SubscriptionSidebar = forwardRef<
     // The subscription renews on its billing-cycle anchor (period end), not the
     // start of the current period. These differ once a mid-cycle change made via
     // a Stripe subscription schedule shortens the current period while keeping
-    // the original anchor. Fall back to periodStart for older API responses that
-    // predate period_end.
-    const renewDate = periodEnd ?? periodStart;
+    // the original anchor. Fall back to periodStart for API responses that predate
+    // period_end: the generated model always calls `new Date(json["period_end"])`,
+    // so an absent field deserializes to an Invalid Date (not undefined) — guard on
+    // validity rather than nullishness.
+    const renewDate =
+      periodEnd && !Number.isNaN(periodEnd.getTime()) ? periodEnd : periodStart;
 
     const updatedUsageBasedEntitlements = useMemo(() => {
       const changedUsageBasedEntitlements: {


### PR DESCRIPTION
The subscription-sidebar "billed every <period> on <date>" copy used the current period start, which is wrong once a subscription-schedule change shortens the current period while keeping the original billing-cycle anchor. Uses `period_end` (the renewal anchor), falling back to `period_start` when it's absent.

Depends on the API exposing `period_end` on the checkout preview: SchematicHQ/schematic-api#6542 (the fallback preserves current behavior until that ships).