### PR TITLE
fix warning threshold display in provider context and included features

### DIFF
--- a/components/src/components/elements/included-features/UsageDetails.tsx
+++ b/components/src/components/elements/included-features/UsageDetails.tsx
@@ -192,9 +192,13 @@ export const UsageDetails = ({ entitlement, layout }: UsageDetailsProps) => {
     }
 
     if (!priceBehavior && typeof allocation === "number") {
+      // When a warning threshold is configured and enabled, `limit` from
+      // getUsageDetails is that threshold; otherwise it falls back to the
+      // allocation (the hard limit).
+      const numericLimit = limit ?? allocation;
       return t("X units", {
-        amount: formatNumber(allocation),
-        units: getFeatureName(feature, allocation),
+        amount: formatNumber(numericLimit),
+        units: getFeatureName(feature, numericLimit),
       });
     }
 
@@ -317,7 +321,7 @@ export const UsageDetails = ({ entitlement, layout }: UsageDetailsProps) => {
       return typeof allocation === "number"
         ? t("usage.limited", {
             amount: formatNumber(usage),
-            allocation: formatNumber(allocation),
+            allocation: formatNumber(limit ?? allocation),
           })
         : t("usage.unlimited", {
             amount: formatNumber(usage),
@@ -332,6 +336,7 @@ export const UsageDetails = ({ entitlement, layout }: UsageDetailsProps) => {
     priceBehavior,
     packageSize,
     allocation,
+    limit,
     usage,
     metricResetAt,
     cost,

--- a/components/src/context/EmbedProvider.tsx
+++ b/components/src/context/EmbedProvider.tsx
@@ -672,6 +672,7 @@ export const EmbedProvider = ({
         layout: state.layout,
         checkoutState: state.checkoutState,
         currencyFilter: state.currencyFilter,
+        warningThresholdConfig: state.warningThresholdConfig,
         checkoutPrefill: state.checkoutPrefill,
         hydratePublic: debouncedHydratePublic,
         hydrate: debouncedHydrate,


### PR DESCRIPTION
Expose warningThresholdConfig through the EmbedContext value so useEmbed().warningThresholdConfig is defined for consuming elements; it was stored in state but never passed through, making the showAsLimit option a no-op on every surface.

Also honor the override in included-features UsageDetails for plain numeric entitlements: the main limit text and usage denominator rendered `allocation` (the hard limit) instead of the overridden `limit` from getUsageDetails, matching the pattern already used in Meter and plan-manager UsageDetails.