### PR TITLE
chore(ci): group react and react-dom dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
     labels:
       - "npm"
       - "Dependabot"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
     ignore:
       - dependency-name: "react-i18next"
         update-types:


### PR DESCRIPTION
React asserts that `react` and `react-dom` resolve to the exact same version, so a Dependabot PR bumping only `react` fails the test suite (PRs #1512 and #1513 both did, and needed a manual companion bump).

Grouping the two means Dependabot opens one PR per directory that moves them together.