### PR TITLE
Truncate credit lists with inline expansion, add top-ups section (SCHY-495)

### DIFF
--- a/components/src/components/elements/metered-features/MeteredFeatures.test.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.test.tsx
@@ -35,8 +35,8 @@ vi.mock("../../../hooks", async (importOriginal) => {
   };
 });
 
-// All grants share a `billingCreditId`, so `groupCreditGrants({groupBy:
-// "credit"})` collapses them into a single ledger.
+// All grants share a `billingCreditId`, so `aggregateActiveGrantsByCredit`
+// collapses them into a single ledger.
 const createGrant = (index: number): CreditCompanyGrantView =>
   ({
     id: `grant-${index}`,

--- a/components/src/components/elements/metered-features/MeteredFeatures.test.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  BillingCreditGrantReason,
+  type CreditCompanyGrantView,
+} from "../../../api/checkoutexternal";
+import { defaultSettings } from "../../../context";
+import { render } from "../../../test/setup";
+import { toPrettyDate } from "../../../utils";
+
+import { MeteredFeatures } from "./MeteredFeatures";
+
+const state = vi.hoisted(() => ({
+  creditGrants: [] as unknown[],
+}));
+
+vi.mock("../../../hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../hooks")>();
+  return {
+    ...actual,
+    useEmbed: () => ({
+      data: {
+        company: { plan: { includedCreditGrants: [] } },
+        featureUsage: { features: [] },
+        creditGrants: state.creditGrants,
+        capabilities: { checkout: false },
+        displaySettings: { showCredits: true },
+      },
+      settings: defaultSettings,
+      setCheckoutState: vi.fn(),
+    }),
+    useIsLightBackground: () => true,
+    useWrapChildren: () => ({ ref: { current: null }, isWrapped: false }),
+  };
+});
+
+// All grants share a `billingCreditId`, so `groupCreditGrants({groupBy:
+// "credit"})` collapses them into a single ledger.
+const createGrant = (index: number): CreditCompanyGrantView =>
+  ({
+    id: `grant-${index}`,
+    billingCreditId: "token-credit",
+    billingCreditBundleId: `bundle-${index}`,
+    creditName: "Tokens",
+    creditDescription: "",
+    creditIcon: "bolt",
+    singularName: "credit",
+    pluralName: "credits",
+    grantReason: BillingCreditGrantReason.Purchased,
+    quantity: 100,
+    quantityRemaining: 100,
+    quantityUsed: 0,
+    createdAt: new Date(2026, 0, index + 1),
+    expiresAt: null,
+    zeroedOutDate: null,
+  }) as unknown as CreditCompanyGrantView;
+
+const grantsFor = (count: number) =>
+  Array.from({ length: count }, (_, index) => createGrant(index));
+
+const grantRows = () => screen.queryAllByText(/bundle purchased/);
+
+beforeEach(() => {
+  state.creditGrants = [];
+});
+
+describe("`MeteredFeatures` grant ledger truncation", () => {
+  test("keeps the ledger toggle out of reach until balance details open", () => {
+    state.creditGrants = grantsFor(18);
+
+    render(<MeteredFeatures />);
+
+    expect(screen.getByText("See balance details")).toBeInTheDocument();
+    // The rows and their toggle are rendered but hidden inside the collapsed
+    // TransitionBox, so assert on the balance-details control instead.
+    expect(screen.queryByText("Hide balance details")).not.toBeInTheDocument();
+  });
+
+  test("caps the open ledger at the visible limit", () => {
+    state.creditGrants = grantsFor(18);
+
+    render(<MeteredFeatures />);
+    fireEvent.click(screen.getByText("See balance details"));
+
+    expect(grantRows()).toHaveLength(3);
+    expect(screen.getByText("See all (18)")).toBeInTheDocument();
+  });
+
+  test("orders the ledger newest-first", () => {
+    state.creditGrants = grantsFor(18);
+
+    render(<MeteredFeatures />);
+    fireEvent.click(screen.getByText("See balance details"));
+
+    // `createGrant` dates ascend with the index, so grant 18 is the newest.
+    const expected = [17, 16, 15].map((index) =>
+      toPrettyDate(new Date(2026, 0, index + 1), {
+        day: "2-digit",
+        month: "2-digit",
+        year: "2-digit",
+      }),
+    );
+
+    expect(grantRows().map((node) => node.textContent)).toEqual(
+      expected.map((date) => `100 credit bundle purchased ${date}`),
+    );
+  });
+
+  test("expands to every grant and collapses back", () => {
+    state.creditGrants = grantsFor(18);
+
+    render(<MeteredFeatures />);
+    fireEvent.click(screen.getByText("See balance details"));
+
+    fireEvent.click(screen.getByText("See all (18)"));
+    expect(grantRows()).toHaveLength(18);
+    expect(screen.getByText("Hide all")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Hide all"));
+    expect(grantRows()).toHaveLength(3);
+  });
+
+  test("resets the ledger when balance details are closed and reopened", () => {
+    state.creditGrants = grantsFor(18);
+
+    render(<MeteredFeatures />);
+    fireEvent.click(screen.getByText("See balance details"));
+    fireEvent.click(screen.getByText("See all (18)"));
+    expect(grantRows()).toHaveLength(18);
+
+    fireEvent.click(screen.getByText("Hide balance details"));
+    fireEvent.click(screen.getByText("See balance details"));
+
+    expect(grantRows()).toHaveLength(3);
+    expect(screen.getByText("See all (18)")).toBeInTheDocument();
+  });
+
+  test("renders no ledger toggle when the grant count is at the limit", () => {
+    state.creditGrants = grantsFor(3);
+
+    render(<MeteredFeatures />);
+    fireEvent.click(screen.getByText("See balance details"));
+
+    expect(grantRows()).toHaveLength(3);
+    expect(screen.queryByText(/See all/)).not.toBeInTheDocument();
+  });
+});

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -8,7 +8,7 @@ import {
   FeatureType,
   type FeatureUsageResponseData,
 } from "../../../api/checkoutexternal";
-import { TEXT_BASE_SIZE } from "../../../const";
+import { TEXT_BASE_SIZE, VISIBLE_CREDIT_COUNT } from "../../../const";
 import { type FontStyle } from "../../../context";
 import {
   useEmbed,
@@ -27,11 +27,12 @@ import {
   getUsageDetails,
   groupCreditGrants,
   modifyDate,
+  sortGrantsByRecency,
   toPrettyDate,
   type UsageDetails,
 } from "../../../utils";
 import { Element } from "../../layout";
-import { HardLimitTooltip } from "../../shared";
+import { ExpandListToggle, HardLimitTooltip } from "../../shared";
 import {
   Box,
   Button,
@@ -233,7 +234,10 @@ export const MeteredFeatures = forwardRef<
   }, [props.visibleFeatures, data?.featureUsage?.features]);
 
   const creditGroups = useMemo(
-    () => groupCreditGrants(data?.creditGrants || [], { groupBy: "credit" }),
+    () =>
+      groupCreditGrants(data?.creditGrants || [], { groupBy: "credit" }).map(
+        (credit) => ({ ...credit, grants: sortGrantsByRecency(credit.grants) }),
+      ),
     [data?.creditGrants],
   );
 
@@ -249,6 +253,24 @@ export const MeteredFeatures = forwardRef<
     () => new Set(),
   );
 
+  // Within an open balance details panel, the grant ledger itself is truncated
+  // until the user asks for the full list.
+  const [fullLedgerCreditIds, setFullLedgerCreditIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleFullLedger = useCallback((id: string) => {
+    setFullLedgerCreditIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
   const toggleBalanceDetails = useCallback((id: string) => {
     setExpandedCreditIds((prev) => {
       const next = new Set(prev);
@@ -257,6 +279,19 @@ export const MeteredFeatures = forwardRef<
       } else {
         next.add(id);
       }
+      return next;
+    });
+
+    // Closing the panel resets its ledger, so reopening always starts
+    // summarized rather than reinstating a full list the user expanded and
+    // forgot about.
+    setFullLedgerCreditIds((prev) => {
+      if (!prev.has(id)) {
+        return prev;
+      }
+
+      const next = new Set(prev);
+      next.delete(id);
       return next;
     });
   }, []);
@@ -408,6 +443,19 @@ export const MeteredFeatures = forwardRef<
         creditGroups.map((credit, index) => {
           const isExpanded = expandedCreditIds.has(credit.id);
 
+          const showAllGrants = fullLedgerCreditIds.has(credit.id);
+          const canExpandLedger = credit.grants.length > VISIBLE_CREDIT_COUNT;
+          const visibleGrants = showAllGrants
+            ? credit.grants
+            : credit.grants.slice(0, VISIBLE_CREDIT_COUNT);
+
+          const paddingX = settings.theme.card.padding / TEXT_BASE_SIZE;
+          // The first row carries the panel's top padding; every other row
+          // carries its own bottom padding, so the last row is what gives the
+          // panel its bottom padding.
+          const getRowPadding = (rowIndex: number) =>
+            rowIndex === 0 ? `1rem ${paddingX}rem` : `0 ${paddingX}rem 1rem`;
+
           return (
             <Element key={index} as={Flex} $flexDirection="column" $gap="1rem">
               <Flex $gap="1.5rem">
@@ -487,13 +535,8 @@ export const MeteredFeatures = forwardRef<
                   }
                   $isExpanded={isExpanded}
                 >
-                  {credit.grants.map((grant, index) => {
-                    const paddingX =
-                      settings.theme.card.padding / TEXT_BASE_SIZE;
-                    const padding =
-                      index > 0
-                        ? `0 ${paddingX}rem 1rem`
-                        : `1rem ${paddingX}rem`;
+                  {visibleGrants.map((grant, index) => {
+                    const padding = getRowPadding(index);
 
                     return (
                       <Box key={grant.id} $display="table-row">
@@ -608,6 +651,26 @@ export const MeteredFeatures = forwardRef<
                       </Box>
                     );
                   })}
+
+                  {canExpandLedger && (
+                    <Box $display="table-row">
+                      <Box $display="table-cell" $padding={getRowPadding(1)}>
+                        <ExpandListToggle
+                          isExpanded={showAllGrants}
+                          onToggle={() => toggleFullLedger(credit.id)}
+                          total={credit.grants.length}
+                          iconColor={
+                            isLightBackground
+                              ? "hsla(0, 0%, 0%, 0.8)"
+                              : "hsla(0, 0%, 100%, 0.4)"
+                          }
+                        />
+                      </Box>
+
+                      {/* keeps the two-column anonymous table intact */}
+                      <Box $display="table-cell" $padding={getRowPadding(1)} />
+                    </Box>
+                  )}
                 </TransitionBox>
               </Box>
 

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../hooks";
 import type { DeepPartial, ElementProps } from "../../../types";
 import {
+  aggregateActiveGrantsByCredit,
   entitlementHasHardLimit,
   formatConsumptionRate,
   formatCurrency,
@@ -25,9 +26,7 @@ import {
   getFeatureName,
   getSubscriptionPeriod,
   getUsageDetails,
-  groupCreditGrants,
   modifyDate,
-  sortGrantsByRecency,
   toPrettyDate,
   type UsageDetails,
 } from "../../../utils";
@@ -234,10 +233,7 @@ export const MeteredFeatures = forwardRef<
   }, [props.visibleFeatures, data?.featureUsage?.features]);
 
   const creditGroups = useMemo(
-    () =>
-      groupCreditGrants(data?.creditGrants || [], { groupBy: "credit" }).map(
-        (credit) => ({ ...credit, grants: sortGrantsByRecency(credit.grants) }),
-      ),
+    () => aggregateActiveGrantsByCredit(data?.creditGrants || []),
     [data?.creditGrants],
   );
 

--- a/components/src/components/elements/plan-manager/PlanManager.test.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.test.tsx
@@ -46,8 +46,8 @@ vi.mock("../../../hooks", async (importOriginal) => {
 });
 
 /**
- * `groupCreditGrants` keys plan/promotional grants by grant id and purchased
- * grants by bundle id, so distinct ids here yield one row per grant.
+ * `aggregateActiveGrantsByBundle` keys on bundle id, falling back to grant id,
+ * so distinct ids here yield one row per grant.
  */
 const createGrant = (
   index: number,

--- a/components/src/components/elements/plan-manager/PlanManager.test.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  BillingCreditGrantReason,
+  type CreditCompanyGrantView,
+} from "../../../api/checkoutexternal";
+import { defaultSettings } from "../../../context";
+import { render } from "../../../test/setup";
+
+import { PlanManager } from "./PlanManager";
+
+const state = vi.hoisted(() => ({
+  creditGrants: [] as unknown[],
+}));
+
+vi.mock("../../../hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../hooks")>();
+  return {
+    ...actual,
+    useEmbed: () => ({
+      data: {
+        company: {
+          plan: {
+            id: "plan-1",
+            name: "Pro",
+            planPrice: 5000,
+            planPeriod: "month",
+            includedCreditGrants: [],
+          },
+          addOns: [],
+        },
+        creditBundles: [],
+        creditGrants: state.creditGrants,
+        capabilities: { checkout: false },
+        displaySettings: { showCredits: true },
+      },
+      settings: defaultSettings,
+      setCheckoutState: vi.fn(),
+      setLayout: vi.fn(),
+    }),
+    useIsLightBackground: () => true,
+    useTrialEnd: () => undefined,
+    useCustomPlanBilling: () => undefined,
+  };
+});
+
+/**
+ * `groupCreditGrants` keys plan/promotional grants by grant id and purchased
+ * grants by bundle id, so distinct ids here yield one row per grant.
+ */
+const createGrant = (
+  index: number,
+  grantReason: BillingCreditGrantReason,
+  creditName: string,
+  overrides: Partial<CreditCompanyGrantView> = {},
+): CreditCompanyGrantView =>
+  ({
+    id: `${grantReason}-grant-${index}`,
+    billingCreditId: `${creditName}-credit`,
+    billingCreditBundleId: `${grantReason}-bundle-${index}`,
+    creditName,
+    singularName: "credit",
+    pluralName: "credits",
+    grantReason,
+    quantity: (index + 1) * 100,
+    quantityRemaining: (index + 1) * 100,
+    quantityUsed: 0,
+    createdAt: new Date(2026, 0, index + 1),
+    expiresAt: null,
+    zeroedOutDate: null,
+    ...overrides,
+  }) as unknown as CreditCompanyGrantView;
+
+const grantsFor = (
+  count: number,
+  grantReason: BillingCreditGrantReason,
+  creditName: string,
+  overrides: (index: number) => Partial<CreditCompanyGrantView> = () => ({}),
+) =>
+  Array.from({ length: count }, (_, index) =>
+    createGrant(index, grantReason, creditName, overrides(index)),
+  );
+
+const sectionFor = (heading: string) => {
+  const label = screen.getByText(heading);
+  // The section wrapper holds the label, the list, and the toggle.
+  return label.parentElement as HTMLElement;
+};
+
+beforeEach(() => {
+  state.creditGrants = [];
+});
+
+describe("`PlanManager` credit list truncation", () => {
+  test("caps a credit section at the visible limit and reports the total", () => {
+    state.creditGrants = grantsFor(5, BillingCreditGrantReason.Plan, "Token");
+
+    render(<PlanManager />);
+
+    const section = sectionFor("Credits in plan");
+    expect(within(section).getAllByText(/^\d+ credits$/)).toHaveLength(3);
+    expect(within(section).getByText("See all (5)")).toBeInTheDocument();
+  });
+
+  test("shows the most recent entries, newest first", () => {
+    // `createGrant` dates ascend with the index, so grant 5 (500 credits) is
+    // the newest and grant 1 (100 credits) the oldest.
+    state.creditGrants = grantsFor(5, BillingCreditGrantReason.Plan, "Token");
+
+    render(<PlanManager />);
+
+    const section = sectionFor("Credits in plan");
+    expect(
+      within(section)
+        .getAllByText(/^\d+ credits$/)
+        .map((node) => node.textContent?.trim()),
+    ).toEqual(["500 credits", "400 credits", "300 credits"]);
+  });
+
+  test("expands to the full list and collapses back", () => {
+    state.creditGrants = grantsFor(5, BillingCreditGrantReason.Plan, "Token");
+
+    render(<PlanManager />);
+
+    const section = sectionFor("Credits in plan");
+
+    fireEvent.click(within(section).getByText("See all (5)"));
+    expect(within(section).getAllByText(/^\d+ credits$/)).toHaveLength(5);
+
+    fireEvent.click(within(section).getByText("Hide all"));
+    expect(within(section).getAllByText(/^\d+ credits$/)).toHaveLength(3);
+  });
+
+  test("renders no toggle when the section is at the limit", () => {
+    state.creditGrants = grantsFor(3, BillingCreditGrantReason.Plan, "Token");
+
+    render(<PlanManager />);
+
+    expect(screen.queryByText(/See all/)).not.toBeInTheDocument();
+  });
+
+  test("expands each section independently", () => {
+    state.creditGrants = [
+      ...grantsFor(5, BillingCreditGrantReason.Plan, "Token"),
+      ...grantsFor(5, BillingCreditGrantReason.Free, "Token"),
+    ];
+
+    render(<PlanManager />);
+
+    const planSection = sectionFor("Credits in plan");
+    const promotionalSection = sectionFor("Promotional credits");
+
+    fireEvent.click(within(planSection).getByText("See all (5)"));
+
+    expect(within(planSection).getAllByText(/^\d+ credits$/)).toHaveLength(5);
+    expect(
+      within(promotionalSection).getAllByText(/^\d+ credits$/),
+    ).toHaveLength(3);
+    expect(
+      within(promotionalSection).getByText("See all (5)"),
+    ).toBeInTheDocument();
+  });
+
+  test("counts every group across multiple credits in one section", () => {
+    state.creditGrants = [
+      ...grantsFor(3, BillingCreditGrantReason.Purchased, "Token"),
+      ...grantsFor(
+        2,
+        BillingCreditGrantReason.Purchased,
+        "API Call",
+        (index) => ({
+          id: `api-grant-${index}`,
+          billingCreditBundleId: `api-bundle-${index}`,
+        }),
+      ),
+    ];
+
+    render(<PlanManager />);
+
+    expect(screen.getByText("See all (5)")).toBeInTheDocument();
+  });
+});

--- a/components/src/components/elements/plan-manager/PlanManager.test.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.test.tsx
@@ -181,3 +181,84 @@ describe("`PlanManager` credit list truncation", () => {
     expect(screen.getByText("See all (5)")).toBeInTheDocument();
   });
 });
+
+describe("`PlanManager` auto top-up section", () => {
+  const autoTopups = (
+    count: number,
+    overrides: (index: number) => Partial<CreditCompanyGrantView> = () => ({}),
+  ) =>
+    grantsFor(
+      count,
+      BillingCreditGrantReason.BillingCreditAutoTopup,
+      "Token",
+      overrides,
+    );
+
+  test("renders auto top-up grants below the plan credits section", () => {
+    state.creditGrants = [
+      ...grantsFor(1, BillingCreditGrantReason.Plan, "Token"),
+      ...autoTopups(2),
+    ];
+
+    render(<PlanManager />);
+
+    const headings = screen
+      .getAllByText(/^(Credits in plan|Top-ups)$/)
+      .map((node) => node.textContent);
+
+    expect(headings).toEqual(["Credits in plan", "Top-ups"]);
+    expect(
+      within(sectionFor("Top-ups")).getAllByText(/^\d+ credits$/),
+    ).toHaveLength(2);
+  });
+
+  test("omits the section when there are no auto top-up grants", () => {
+    state.creditGrants = grantsFor(2, BillingCreditGrantReason.Plan, "Token");
+
+    render(<PlanManager />);
+
+    expect(screen.queryByText("Top-ups")).not.toBeInTheDocument();
+  });
+
+  test("includes auto top-up grants regardless of when they were created", () => {
+    state.creditGrants = autoTopups(4, (index) => ({
+      createdAt: new Date(2020, 0, index + 1),
+    }));
+
+    render(<PlanManager />);
+
+    const section = sectionFor("Top-ups");
+    expect(within(section).getByText("See all (4)")).toBeInTheDocument();
+  });
+
+  test("truncates and expands independently of the other sections", () => {
+    state.creditGrants = [
+      ...grantsFor(5, BillingCreditGrantReason.Plan, "Token"),
+      ...autoTopups(5),
+    ];
+
+    render(<PlanManager />);
+
+    const topupSection = sectionFor("Top-ups");
+    const planSection = sectionFor("Credits in plan");
+
+    expect(within(topupSection).getAllByText(/^\d+ credits$/)).toHaveLength(3);
+
+    fireEvent.click(within(topupSection).getByText("See all (5)"));
+
+    expect(within(topupSection).getAllByText(/^\d+ credits$/)).toHaveLength(5);
+    expect(within(planSection).getAllByText(/^\d+ credits$/)).toHaveLength(3);
+  });
+
+  test("collapses repeated top-ups of the same bundle into one row", () => {
+    state.creditGrants = autoTopups(3, () => ({
+      billingCreditBundleId: "shared-bundle",
+    }));
+
+    render(<PlanManager />);
+
+    const section = sectionFor("Top-ups");
+    expect(within(section).getAllByText(/^\d+ credits$/)).toHaveLength(1);
+    expect(within(section).getByText("(3)")).toBeInTheDocument();
+  });
+});

--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -2,12 +2,14 @@ import { forwardRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { BillingCreditGrantReason } from "../../../api/checkoutexternal";
+import { VISIBLE_CREDIT_COUNT } from "../../../const";
 import { type FontStyle } from "../../../context";
 import {
   useCustomPlanBilling,
   useEmbed,
   useIsLightBackground,
   useTrialEnd,
+  useTruncatedList,
 } from "../../../hooks";
 import type {
   CreditWithCompanyContext,
@@ -27,10 +29,11 @@ import {
   isSelfServiceAutoTopupAvailable,
   lighten,
   shortenPeriod,
+  sortCreditGroupsByRecency,
   toPrettyDate,
 } from "../../../utils";
 import { Element, Notice } from "../../layout";
-import { AutoTopupNotice } from "../../shared";
+import { AutoTopupNotice, ExpandListToggle } from "../../shared";
 import { Box, Button, Flex, Text } from "../../ui";
 
 import { AddOn } from "./AddOn";
@@ -133,36 +136,43 @@ export const PlanManager = forwardRef<
     showZeroPriceAsFree,
     trialPaymentMethodRequired,
   } = useMemo(() => {
+    const groupsByReason = groupCreditGrants(data?.creditGrants || [], {
+      groupBy: "bundle",
+    }).reduce(
+      (
+        acc: {
+          plan: CreditWithCompanyContext[];
+          bundles: CreditWithCompanyContext[];
+          promotional: CreditWithCompanyContext[];
+        },
+        grant,
+      ) => {
+        switch (grant.grantReason) {
+          case BillingCreditGrantReason.Plan:
+            acc.plan.push(grant);
+            break;
+          case BillingCreditGrantReason.Purchased:
+            acc.bundles.push(grant);
+            break;
+          case BillingCreditGrantReason.Free:
+            acc.promotional.push(grant);
+        }
+
+        return acc;
+      },
+      { plan: [], bundles: [], promotional: [] },
+    );
+
     return {
       currentPlan: data?.company?.plan,
       currentAddOns: data?.company?.addOns || [],
       creditBundles: data?.creditBundles || [],
-      creditGroups: groupCreditGrants(data?.creditGrants || [], {
-        groupBy: "bundle",
-      }).reduce(
-        (
-          acc: {
-            plan: CreditWithCompanyContext[];
-            bundles: CreditWithCompanyContext[];
-            promotional: CreditWithCompanyContext[];
-          },
-          grant,
-        ) => {
-          switch (grant.grantReason) {
-            case BillingCreditGrantReason.Plan:
-              acc.plan.push(grant);
-              break;
-            case BillingCreditGrantReason.Purchased:
-              acc.bundles.push(grant);
-              break;
-            case BillingCreditGrantReason.Free:
-              acc.promotional.push(grant);
-          }
-
-          return acc;
-        },
-        { plan: [], bundles: [], promotional: [] },
-      ),
+      // Newest-first, so a truncated section shows the most recent entries.
+      creditGroups: {
+        plan: sortCreditGroupsByRecency(groupsByReason.plan),
+        bundles: sortCreditGroupsByRecency(groupsByReason.bundles),
+        promotional: sortCreditGroupsByRecency(groupsByReason.promotional),
+      },
       billingSubscription: data?.company?.billingSubscription,
       canCheckout: data?.capabilities?.checkout ?? false,
       postTrialPlan: data?.postTrialPlan,
@@ -190,6 +200,16 @@ export const PlanManager = forwardRef<
       featureUsage.filter((usage) => typeof usage.priceBehavior === "string"),
     [featureUsage],
   );
+
+  const planCredits = useTruncatedList(creditGroups.plan, {
+    limit: VISIBLE_CREDIT_COUNT,
+  });
+  const bundleCredits = useTruncatedList(creditGroups.bundles, {
+    limit: VISIBLE_CREDIT_COUNT,
+  });
+  const promotionalCredits = useTruncatedList(creditGroups.promotional, {
+    limit: VISIBLE_CREDIT_COUNT,
+  });
 
   const {
     subscriptionInterval,
@@ -532,7 +552,7 @@ export const PlanManager = forwardRef<
               )}
 
               <Flex $flexDirection="column" $gap="1rem">
-                {creditGroups.plan.map((group, groupIndex) => {
+                {planCredits.items.map((group, groupIndex) => {
                   const planCreditGrant =
                     currentPlan?.includedCreditGrants.find(
                       (grant) => grant.creditId === group.id,
@@ -590,6 +610,15 @@ export const PlanManager = forwardRef<
                   );
                 })}
               </Flex>
+
+              {planCredits.canExpand && (
+                <ExpandListToggle
+                  isExpanded={planCredits.isExpanded}
+                  onToggle={planCredits.toggle}
+                  total={planCredits.total}
+                  $marginTop="0.5rem"
+                />
+              )}
 
               {hasAutoTopupSelfService && (
                 <Flex
@@ -692,7 +721,7 @@ export const PlanManager = forwardRef<
             )}
 
             <Flex $flexDirection="column" $gap="1rem">
-              {creditGroups.bundles.map((group, groupIndex) => {
+              {bundleCredits.items.map((group, groupIndex) => {
                 const bundle = group?.bundleId
                   ? creditBundles.find((b) => b.id === group.bundleId)
                   : undefined;
@@ -734,6 +763,15 @@ export const PlanManager = forwardRef<
                 );
               })}
             </Flex>
+
+            {bundleCredits.canExpand && (
+              <ExpandListToggle
+                isExpanded={bundleCredits.isExpanded}
+                onToggle={bundleCredits.toggle}
+                total={bundleCredits.total}
+                $marginTop="0.5rem"
+              />
+            )}
           </Flex>
         )}
 
@@ -753,7 +791,7 @@ export const PlanManager = forwardRef<
             )}
 
             <Flex $flexDirection="column" $gap="1rem">
-              {creditGroups.promotional.map((group, groupIndex) => {
+              {promotionalCredits.items.map((group, groupIndex) => {
                 return (
                   <Flex
                     key={groupIndex}
@@ -779,6 +817,15 @@ export const PlanManager = forwardRef<
                 );
               })}
             </Flex>
+
+            {promotionalCredits.canExpand && (
+              <ExpandListToggle
+                isExpanded={promotionalCredits.isExpanded}
+                onToggle={promotionalCredits.toggle}
+                total={promotionalCredits.total}
+                $marginTop="0.5rem"
+              />
+            )}
           </Flex>
         )}
 

--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -144,6 +144,7 @@ export const PlanManager = forwardRef<
           plan: CreditWithCompanyContext[];
           bundles: CreditWithCompanyContext[];
           promotional: CreditWithCompanyContext[];
+          autoTopups: CreditWithCompanyContext[];
         },
         grant,
       ) => {
@@ -156,11 +157,14 @@ export const PlanManager = forwardRef<
             break;
           case BillingCreditGrantReason.Free:
             acc.promotional.push(grant);
+            break;
+          case BillingCreditGrantReason.BillingCreditAutoTopup:
+            acc.autoTopups.push(grant);
         }
 
         return acc;
       },
-      { plan: [], bundles: [], promotional: [] },
+      { plan: [], bundles: [], promotional: [], autoTopups: [] },
     );
 
     return {
@@ -172,6 +176,7 @@ export const PlanManager = forwardRef<
         plan: sortCreditGroupsByRecency(groupsByReason.plan),
         bundles: sortCreditGroupsByRecency(groupsByReason.bundles),
         promotional: sortCreditGroupsByRecency(groupsByReason.promotional),
+        autoTopups: sortCreditGroupsByRecency(groupsByReason.autoTopups),
       },
       billingSubscription: data?.company?.billingSubscription,
       canCheckout: data?.capabilities?.checkout ?? false,
@@ -202,6 +207,9 @@ export const PlanManager = forwardRef<
   );
 
   const planCredits = useTruncatedList(creditGroups.plan, {
+    limit: VISIBLE_CREDIT_COUNT,
+  });
+  const autoTopupCredits = useTruncatedList(creditGroups.autoTopups, {
     limit: VISIBLE_CREDIT_COUNT,
   });
   const bundleCredits = useTruncatedList(creditGroups.bundles, {
@@ -701,6 +709,86 @@ export const PlanManager = forwardRef<
                     {t("Edit")}
                   </Button>
                 </Flex>
+              )}
+            </Flex>
+          )}
+
+        {props.addOns.isVisible &&
+          showCredits &&
+          creditGroups.autoTopups.length > 0 && (
+            <Flex $flexDirection="column" $gap="0.5rem">
+              {props.addOns.showLabel && (
+                <Text
+                  $color={
+                    isLightBackground
+                      ? darken(settings.theme.card.background, 0.46)
+                      : lighten(settings.theme.card.background, 0.46)
+                  }
+                  $leading="none"
+                >
+                  {t("Top-ups")}
+                </Text>
+              )}
+
+              <Flex $flexDirection="column" $gap="1rem">
+                {autoTopupCredits.items.map((group, groupIndex) => {
+                  const bundle = group?.bundleId
+                    ? creditBundles.find((b) => b.id === group.bundleId)
+                    : undefined;
+
+                  return (
+                    <Flex
+                      key={groupIndex}
+                      $justifyContent="space-between"
+                      $alignItems="center"
+                      $flexWrap="wrap"
+                      $gap="0.5rem"
+                    >
+                      {bundle ? (
+                        <Text display={props.addOns.fontStyle}>
+                          {group.grants.length > 1 && (
+                            <Text style={{ opacity: 0.5 }}>
+                              ({group.grants.length}){" "}
+                            </Text>
+                          )}
+                          {bundle.name} ({group.quantity}{" "}
+                          {getFeatureName(group, group.quantity)})
+                        </Text>
+                      ) : (
+                        <Text display={props.addOns.fontStyle}>
+                          {group.grants.length > 1 && (
+                            <Text style={{ opacity: 0.5 }}>
+                              ({group.grants.length}){" "}
+                            </Text>
+                          )}
+                          {group.quantity}{" "}
+                          {getFeatureName(group, group.quantity)}
+                        </Text>
+                      )}
+
+                      {group.total.used > 0 && (
+                        <Text
+                          style={{ opacity: 0.54 }}
+                          $size={
+                            0.875 * settings.theme.typography.text.fontSize
+                          }
+                          $color={settings.theme.typography.text.color}
+                        >
+                          {group.total.used} {t("used")}
+                        </Text>
+                      )}
+                    </Flex>
+                  );
+                })}
+              </Flex>
+
+              {autoTopupCredits.canExpand && (
+                <ExpandListToggle
+                  isExpanded={autoTopupCredits.isExpanded}
+                  onToggle={autoTopupCredits.toggle}
+                  total={autoTopupCredits.total}
+                  $marginTop="0.5rem"
+                />
               )}
             </Flex>
           )}

--- a/components/src/components/elements/plan-manager/PlanManager.tsx
+++ b/components/src/components/elements/plan-manager/PlanManager.tsx
@@ -17,19 +17,18 @@ import type {
   ElementProps,
 } from "../../../types";
 import {
+  aggregateActiveGrantsByBundle,
   darken,
   formatCurrency,
   getAutoTopupAmount,
   getAutoTopupThresholdCredits,
   getFeatureName,
   getSubscriptionPeriod,
-  groupCreditGrants,
   isAutoTopupEnabled,
   isAutoTopupOff,
   isSelfServiceAutoTopupAvailable,
   lighten,
   shortenPeriod,
-  sortCreditGroupsByRecency,
   toPrettyDate,
 } from "../../../utils";
 import { Element, Notice } from "../../layout";
@@ -136,9 +135,9 @@ export const PlanManager = forwardRef<
     showZeroPriceAsFree,
     trialPaymentMethodRequired,
   } = useMemo(() => {
-    const groupsByReason = groupCreditGrants(data?.creditGrants || [], {
-      groupBy: "bundle",
-    }).reduce(
+    const groupsByReason = aggregateActiveGrantsByBundle(
+      data?.creditGrants || [],
+    ).reduce(
       (
         acc: {
           plan: CreditWithCompanyContext[];
@@ -171,13 +170,7 @@ export const PlanManager = forwardRef<
       currentPlan: data?.company?.plan,
       currentAddOns: data?.company?.addOns || [],
       creditBundles: data?.creditBundles || [],
-      // Newest-first, so a truncated section shows the most recent entries.
-      creditGroups: {
-        plan: sortCreditGroupsByRecency(groupsByReason.plan),
-        bundles: sortCreditGroupsByRecency(groupsByReason.bundles),
-        promotional: sortCreditGroupsByRecency(groupsByReason.promotional),
-        autoTopups: sortCreditGroupsByRecency(groupsByReason.autoTopups),
-      },
+      creditGroups: groupsByReason,
       billingSubscription: data?.company?.billingSubscription,
       canCheckout: data?.capabilities?.checkout ?? false,
       postTrialPlan: data?.postTrialPlan,

--- a/components/src/components/shared/expand-list-toggle/ExpandListToggle.test.tsx
+++ b/components/src/components/shared/expand-list-toggle/ExpandListToggle.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { render } from "../../../test/setup";
+
+import { ExpandListToggle } from "./ExpandListToggle";
+
+describe("ExpandListToggle", () => {
+  test("renders the total in the collapsed label", () => {
+    render(
+      <ExpandListToggle isExpanded={false} onToggle={vi.fn()} total={18} />,
+    );
+
+    expect(screen.getByText("See all (18)")).toBeInTheDocument();
+  });
+
+  test("falls back to a bare label when no total is given", () => {
+    render(<ExpandListToggle isExpanded={false} onToggle={vi.fn()} />);
+
+    expect(screen.getByText("See all")).toBeInTheDocument();
+  });
+
+  test("shows the collapse label when expanded", () => {
+    render(<ExpandListToggle isExpanded onToggle={vi.fn()} total={18} />);
+
+    expect(screen.getByText("Hide all")).toBeInTheDocument();
+    expect(screen.queryByText("See all (18)")).not.toBeInTheDocument();
+  });
+
+  test("honors label overrides", () => {
+    const { rerender } = render(
+      <ExpandListToggle
+        isExpanded={false}
+        onToggle={vi.fn()}
+        total={18}
+        expandLabel="See more"
+        collapseLabel="See less"
+      />,
+    );
+
+    expect(screen.getByText("See more")).toBeInTheDocument();
+
+    rerender(
+      <ExpandListToggle
+        isExpanded
+        onToggle={vi.fn()}
+        total={18}
+        expandLabel="See more"
+        collapseLabel="See less"
+      />,
+    );
+
+    expect(screen.getByText("See less")).toBeInTheDocument();
+  });
+
+  test("fires onToggle on click and on Enter/Space, but not other keys", () => {
+    const onToggle = vi.fn();
+    render(
+      <ExpandListToggle isExpanded={false} onToggle={onToggle} total={18} />,
+    );
+
+    const trigger = screen.getByText("See all (18)");
+
+    fireEvent.click(trigger);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(onToggle).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(trigger, { key: " " });
+    expect(onToggle).toHaveBeenCalledTimes(3);
+
+    fireEvent.keyDown(trigger, { key: "a" });
+    expect(onToggle).toHaveBeenCalledTimes(3);
+  });
+
+  test("is focusable and reports its expanded state", () => {
+    const { rerender } = render(
+      <ExpandListToggle isExpanded={false} onToggle={vi.fn()} total={18} />,
+    );
+
+    const collapsed = screen.getByRole("button");
+    expect(collapsed).toHaveAttribute("aria-expanded", "false");
+    expect(collapsed).toHaveAttribute("tabindex", "0");
+
+    rerender(<ExpandListToggle isExpanded onToggle={vi.fn()} total={18} />);
+
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/components/src/components/shared/expand-list-toggle/ExpandListToggle.tsx
+++ b/components/src/components/shared/expand-list-toggle/ExpandListToggle.tsx
@@ -1,0 +1,61 @@
+import { useTranslation } from "react-i18next";
+
+import { createKeyboardExecutionHandler } from "../../../utils";
+import { Flex, Icon, Text, type BoxProps } from "../../ui";
+
+interface ExpandListToggleProps extends BoxProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  /** When provided, the collapsed label reads "See all (18)". */
+  total?: number;
+  /** Override for surfaces with different vocabulary, e.g. "See more". */
+  expandLabel?: string;
+  collapseLabel?: string;
+  iconColor?: string;
+}
+
+/**
+ * Expand/collapse affordance for a truncated list, pairing with
+ * `useTruncatedList`.
+ *
+ * Renders exactly one element and imposes no wrapper, margin, or list
+ * semantics of its own — spacing comes from caller-passed props. That contract
+ * is what lets a CSS-table caller wrap this in its own `table-row`/`table-cell`
+ * without terminating the run of table rows that forms the anonymous table box.
+ */
+export const ExpandListToggle = ({
+  isExpanded,
+  onToggle,
+  total,
+  expandLabel,
+  collapseLabel,
+  iconColor = "#D0D0D0",
+  ...rest
+}: ExpandListToggleProps) => {
+  const { t } = useTranslation();
+
+  const label = isExpanded
+    ? (collapseLabel ?? t("Hide all"))
+    : (expandLabel ??
+      (typeof total === "number" ? t("See all X", { total }) : t("See all")));
+
+  return (
+    <Flex $alignItems="center" $gap="0.25rem" {...rest}>
+      <Icon
+        name={isExpanded ? "chevron-up" : "chevron-down"}
+        color={iconColor}
+        style={{ marginLeft: `-${1 / 3}rem` }}
+      />
+
+      <Text
+        role="button"
+        aria-expanded={isExpanded}
+        onClick={onToggle}
+        onKeyDown={createKeyboardExecutionHandler(onToggle)}
+        display="link"
+      >
+        {label}
+      </Text>
+    </Flex>
+  );
+};

--- a/components/src/components/shared/expand-list-toggle/index.ts
+++ b/components/src/components/shared/expand-list-toggle/index.ts
@@ -1,0 +1,1 @@
+export * from "./ExpandListToggle";

--- a/components/src/components/shared/index.ts
+++ b/components/src/components/shared/index.ts
@@ -3,6 +3,7 @@ export * from "./billing-threshold-tooltip";
 export * from "./checkout-dialog";
 export * from "./currency-period-mismatch-notice";
 export * from "./currency-toggle";
+export * from "./expand-list-toggle";
 export * from "./hard-limit-tooltip";
 export * from "./invalid-currency-notice";
 export * from "./payment-dialog";

--- a/components/src/const/components.ts
+++ b/components/src/const/components.ts
@@ -1,3 +1,5 @@
+export const VISIBLE_CREDIT_COUNT = 3;
+
 export const VISIBLE_ENTITLEMENT_COUNT = 4;
 
 export const MAX_VISIBLE_INVOICE_COUNT = 12;

--- a/components/src/hooks/index.ts
+++ b/components/src/hooks/index.ts
@@ -6,4 +6,5 @@ export * from "./useIsLightBackground";
 export * from "./usePaymentConfirmation";
 export * from "./useRequest";
 export * from "./useTrialEnd";
+export * from "./useTruncatedList";
 export * from "./useWrapChildren";

--- a/components/src/hooks/useTruncatedList.test.ts
+++ b/components/src/hooks/useTruncatedList.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { useTruncatedList } from "./useTruncatedList";
+
+const items = (count: number) =>
+  Array.from({ length: count }, (_, index) => `item-${index}`);
+
+describe("useTruncatedList", () => {
+  test("collapses to the limit by default", () => {
+    const { result } = renderHook(() =>
+      useTruncatedList(items(18), { limit: 3 }),
+    );
+
+    expect(result.current.items).toEqual(["item-0", "item-1", "item-2"]);
+    expect(result.current.total).toBe(18);
+    expect(result.current.hiddenCount).toBe(15);
+    expect(result.current.canExpand).toBe(true);
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  test("toggles between the slice and the full list", () => {
+    const all = items(18);
+    const { result } = renderHook(() => useTruncatedList(all, { limit: 3 }));
+
+    act(() => result.current.toggle());
+
+    expect(result.current.items).toHaveLength(18);
+    expect(result.current.isExpanded).toBe(true);
+
+    act(() => result.current.toggle());
+
+    expect(result.current.items).toHaveLength(3);
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  test("cannot expand when the total equals the limit", () => {
+    const { result } = renderHook(() =>
+      useTruncatedList(items(3), { limit: 3 }),
+    );
+
+    expect(result.current.canExpand).toBe(false);
+    expect(result.current.hiddenCount).toBe(0);
+    expect(result.current.items).toHaveLength(3);
+  });
+
+  test("cannot expand when the list is empty", () => {
+    const { result } = renderHook(() => useTruncatedList([], { limit: 3 }));
+
+    expect(result.current.canExpand).toBe(false);
+    expect(result.current.total).toBe(0);
+    expect(result.current.items).toEqual([]);
+  });
+
+  test("stays expanded when the data refreshes into a new array", () => {
+    const { result, rerender } = renderHook(
+      ({ list }) => useTruncatedList(list, { limit: 3 }),
+      { initialProps: { list: items(18) } },
+    );
+
+    act(() => result.current.toggle());
+    expect(result.current.items).toHaveLength(18);
+
+    // `useEmbed` hands back a fresh array on every poll.
+    rerender({ list: items(18) });
+
+    expect(result.current.isExpanded).toBe(true);
+    expect(result.current.items).toHaveLength(18);
+  });
+
+  test("derives collapsed state when the list shrinks below the limit", () => {
+    const { result, rerender } = renderHook(
+      ({ list }) => useTruncatedList(list, { limit: 3 }),
+      { initialProps: { list: items(18) } },
+    );
+
+    act(() => result.current.toggle());
+    rerender({ list: items(2) });
+
+    expect(result.current.canExpand).toBe(false);
+    expect(result.current.isExpanded).toBe(false);
+    expect(result.current.items).toHaveLength(2);
+  });
+
+  test("never mutates the input array", () => {
+    const all = items(5);
+    const { result } = renderHook(() => useTruncatedList(all, { limit: 3 }));
+
+    act(() => result.current.toggle());
+    act(() => result.current.toggle());
+
+    expect(all).toEqual(items(5));
+    expect(result.current.items).not.toBe(all);
+  });
+});

--- a/components/src/hooks/useTruncatedList.ts
+++ b/components/src/hooks/useTruncatedList.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo, useState } from "react";
+
+export interface TruncatedList<T> {
+  /** The first `limit` items while collapsed, every item while expanded. */
+  items: T[];
+  /** Total number of items before truncation. */
+  total: number;
+  /** How many items are hidden while collapsed. */
+  hiddenCount: number;
+  /** Only render an expand affordance when this is `true`. */
+  canExpand: boolean;
+  isExpanded: boolean;
+  toggle: () => void;
+  expand: () => void;
+  collapse: () => void;
+}
+
+export interface UseTruncatedListOptions {
+  limit: number;
+}
+
+/**
+ * Headless truncation state for long lists.
+ *
+ * Returns a slice rather than rendering anything, so it composes with any
+ * layout — including CSS-table rows, where an extra wrapper element would
+ * break the anonymous table box.
+ */
+export function useTruncatedList<T>(
+  items: T[],
+  { limit }: UseTruncatedListOptions,
+): TruncatedList<T> {
+  const [isExpandedState, setIsExpanded] = useState(false);
+
+  const total = items.length;
+  const canExpand = total > limit;
+  // Derived rather than stored: if the list shrinks below `limit`, a stale
+  // `true` can never leak into the rendered slice.
+  const isExpanded = canExpand && isExpandedState;
+
+  // Deliberately no reset when `items` changes identity: `useEmbed` hands back
+  // a new array on every data refresh, and collapsing there would yank the
+  // list closed under the user's cursor.
+  const visibleItems = useMemo(
+    () => (canExpand && !isExpanded ? items.slice(0, limit) : items),
+    [items, limit, canExpand, isExpanded],
+  );
+
+  const toggle = useCallback(() => setIsExpanded((prev) => !prev), []);
+  const expand = useCallback(() => setIsExpanded(true), []);
+  const collapse = useCallback(() => setIsExpanded(false), []);
+
+  return {
+    items: visibleItems,
+    total,
+    hiddenCount: Math.max(total - limit, 0),
+    canExpand,
+    isExpanded,
+    toggle,
+    expand,
+    collapse,
+  };
+}

--- a/components/src/localization/en.json
+++ b/components/src/localization/en.json
@@ -125,6 +125,7 @@
     "Save with quarterly billing": "Save up to {{percent}}% with quarterly billing",
     "Saving with quarterly billing": "You are saving {{percent}}% with quarterly billing",
     "See all": "See all",
+    "See all X": "See all ({{total}})",
     "See balance details": "See balance details",
     "See less": "See less",
     "See more": "See more",

--- a/components/src/localization/en.json
+++ b/components/src/localization/en.json
@@ -153,6 +153,7 @@
     "Tier-based": "Tier-based",
     "Tiers apply progressively as quantity increases.": "Tiers apply progressively as quantity increases.",
     "Top up balance with:": "Top up balance with:",
+    "Top-ups": "Top-ups",
     "Total": "Total",
     "Trial ends in": "Trial ends in {{amount}} {{units}}",
     "Trial in progress": "Trial in progress",

--- a/components/src/utils/api/credit.test.ts
+++ b/components/src/utils/api/credit.test.ts
@@ -5,15 +5,14 @@ import {
   type CreditCompanyGrantView,
 } from "../../api/checkoutexternal";
 import {
+  aggregateActiveGrantsByBundle,
+  aggregateActiveGrantsByCredit,
   deriveCreditBundles,
   filterCreditBundles,
   getBundleOffCreditIds,
-  getLatestGrantTime,
   isAutoTopupOff,
   isBundlePurchaseOff,
   isSelfServiceAutoTopupAvailable,
-  sortCreditGroupsByRecency,
-  sortGrantsByRecency,
 } from "./credit";
 
 describe("isAutoTopupOff", () => {
@@ -187,56 +186,107 @@ describe("deriveCreditBundles", () => {
   });
 });
 
-describe("grant recency ordering", () => {
-  const grant = (id: string, createdAt: Date) =>
-    ({ id, createdAt }) as unknown as CreditCompanyGrantView;
+describe("aggregating active grants", () => {
+  const grant = (id: string, overrides: Partial<CreditCompanyGrantView> = {}) =>
+    ({
+      id,
+      billingCreditId: "tokens",
+      billingCreditBundleId: null,
+      creditName: "Tokens",
+      quantity: 100,
+      quantityRemaining: 60,
+      quantityUsed: 40,
+      createdAt: new Date(2026, 0, 1),
+      expiresAt: null,
+      zeroedOutDate: null,
+      ...overrides,
+    }) as unknown as CreditCompanyGrantView;
 
-  const oldest = grant("oldest", new Date(2026, 0, 1));
-  const middle = grant("middle", new Date(2026, 3, 1));
-  const newest = grant("newest", new Date(2026, 6, 1));
-
-  it("sorts grants newest-first without mutating the input", () => {
-    const grants = [middle, oldest, newest];
-
-    expect(sortGrantsByRecency(grants).map((g) => g.id)).toEqual([
-      "newest",
-      "middle",
-      "oldest",
+  it("returns each entry's grants newest-first", () => {
+    const result = aggregateActiveGrantsByCredit([
+      grant("b", { createdAt: new Date(2026, 3, 1) }),
+      grant("c", { createdAt: new Date(2026, 6, 1) }),
+      grant("a", { createdAt: new Date(2026, 0, 1) }),
     ]);
-    expect(grants.map((g) => g.id)).toEqual(["middle", "oldest", "newest"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].grants.map((g) => g.id)).toEqual(["c", "b", "a"]);
   });
 
-  it("reports the latest timestamp in a group, or 0 when empty", () => {
-    expect(getLatestGrantTime([oldest, newest, middle])).toBe(
-      +newest.createdAt,
-    );
-    expect(getLatestGrantTime([])).toBe(0);
+  it("returns entries newest-first by their most recent grant", () => {
+    const result = aggregateActiveGrantsByBundle([
+      grant("old-a", {
+        billingCreditBundleId: "stale",
+        createdAt: new Date(2026, 0, 1),
+      }),
+      grant("new", {
+        billingCreditBundleId: "fresh",
+        createdAt: new Date(2026, 6, 1),
+      }),
+      grant("mid", {
+        billingCreditBundleId: "middling",
+        createdAt: new Date(2026, 3, 1),
+      }),
+      // A second, newer grant promotes the otherwise-stale bundle to the front.
+      grant("new-a", {
+        billingCreditBundleId: "stale",
+        createdAt: new Date(2026, 9, 1),
+      }),
+    ]);
+
+    expect(result.map((entry) => entry.bundleId)).toEqual([
+      "stale",
+      "fresh",
+      "middling",
+    ]);
   });
 
-  it("sorts groups by their most recent grant", () => {
-    const groups = [
-      { id: "a", grants: [oldest] },
-      { id: "b", grants: [oldest, newest] },
-      { id: "c", grants: [middle] },
+  it("does not mutate the grants it is given", () => {
+    const grants = [
+      grant("b", { createdAt: new Date(2026, 3, 1) }),
+      grant("a", { createdAt: new Date(2026, 6, 1) }),
     ];
 
-    expect(sortCreditGroupsByRecency(groups).map((g) => g.id)).toEqual([
-      "b",
-      "c",
-      "a",
-    ]);
-    expect(groups.map((g) => g.id)).toEqual(["a", "b", "c"]);
+    aggregateActiveGrantsByCredit(grants);
+
+    expect(grants.map((g) => g.id)).toEqual(["b", "a"]);
   });
 
-  it("puts a group with no grants last", () => {
-    const groups = [
-      { id: "empty", grants: [] },
-      { id: "dated", grants: [oldest] },
-    ];
-
-    expect(sortCreditGroupsByRecency(groups).map((g) => g.id)).toEqual([
-      "dated",
-      "empty",
+  it("drops expired and zeroed-out grants and sums the rest", () => {
+    const result = aggregateActiveGrantsByCredit([
+      grant("live"),
+      grant("expired", { expiresAt: new Date(2020, 0, 1) }),
+      grant("zeroed", { zeroedOutDate: new Date(2026, 0, 2) }),
+      grant("also-live"),
     ]);
+
+    expect(result[0].grants.map((g) => g.id).sort()).toEqual([
+      "also-live",
+      "live",
+    ]);
+    expect(result[0].total).toEqual({ value: 200, remaining: 120, used: 80 });
+  });
+
+  it("collapses one entry per credit regardless of bundle", () => {
+    const result = aggregateActiveGrantsByCredit([
+      grant("a", { billingCreditBundleId: "bundle-1" }),
+      grant("b", { billingCreditBundleId: "bundle-2" }),
+      grant("c", { billingCreditId: "seats", billingCreditBundleId: null }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("keys by bundle, falling back to grant id when there is none", () => {
+    const result = aggregateActiveGrantsByBundle([
+      grant("a", { billingCreditBundleId: "bundle-1" }),
+      grant("b", { billingCreditBundleId: "bundle-1" }),
+      grant("c", { billingCreditBundleId: null }),
+    ]);
+
+    expect(result).toHaveLength(2);
+    const bundled = result.find((entry) => entry.bundleId === "bundle-1");
+    expect(bundled?.grants.map((g) => g.id).sort()).toEqual(["a", "b"]);
+    expect(bundled?.total.value).toBe(200);
   });
 });

--- a/components/src/utils/api/credit.test.ts
+++ b/components/src/utils/api/credit.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import { BillingCreditAutoTopupAvailability } from "../../api/checkoutexternal";
+import {
+  BillingCreditAutoTopupAvailability,
+  type CreditCompanyGrantView,
+} from "../../api/checkoutexternal";
 import {
   deriveCreditBundles,
   filterCreditBundles,
   getBundleOffCreditIds,
+  getLatestGrantTime,
   isAutoTopupOff,
   isBundlePurchaseOff,
   isSelfServiceAutoTopupAvailable,
+  sortCreditGroupsByRecency,
+  sortGrantsByRecency,
 } from "./credit";
 
 describe("isAutoTopupOff", () => {
@@ -177,6 +183,60 @@ describe("deriveCreditBundles", () => {
   it("defaults a surviving bundle's count to 0 when absent from the map", () => {
     expect(deriveCreditBundles(grants, bundles, {})).toEqual([
       { id: "b2", creditId: "credit-on", count: 0 },
+    ]);
+  });
+});
+
+describe("grant recency ordering", () => {
+  const grant = (id: string, createdAt: Date) =>
+    ({ id, createdAt }) as unknown as CreditCompanyGrantView;
+
+  const oldest = grant("oldest", new Date(2026, 0, 1));
+  const middle = grant("middle", new Date(2026, 3, 1));
+  const newest = grant("newest", new Date(2026, 6, 1));
+
+  it("sorts grants newest-first without mutating the input", () => {
+    const grants = [middle, oldest, newest];
+
+    expect(sortGrantsByRecency(grants).map((g) => g.id)).toEqual([
+      "newest",
+      "middle",
+      "oldest",
+    ]);
+    expect(grants.map((g) => g.id)).toEqual(["middle", "oldest", "newest"]);
+  });
+
+  it("reports the latest timestamp in a group, or 0 when empty", () => {
+    expect(getLatestGrantTime([oldest, newest, middle])).toBe(
+      +newest.createdAt,
+    );
+    expect(getLatestGrantTime([])).toBe(0);
+  });
+
+  it("sorts groups by their most recent grant", () => {
+    const groups = [
+      { id: "a", grants: [oldest] },
+      { id: "b", grants: [oldest, newest] },
+      { id: "c", grants: [middle] },
+    ];
+
+    expect(sortCreditGroupsByRecency(groups).map((g) => g.id)).toEqual([
+      "b",
+      "c",
+      "a",
+    ]);
+    expect(groups.map((g) => g.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("puts a group with no grants last", () => {
+    const groups = [
+      { id: "empty", grants: [] },
+      { id: "dated", grants: [oldest] },
+    ];
+
+    expect(sortCreditGroupsByRecency(groups).map((g) => g.id)).toEqual([
+      "dated",
+      "empty",
     ]);
   });
 });

--- a/components/src/utils/api/credit.ts
+++ b/components/src/utils/api/credit.ts
@@ -53,13 +53,22 @@ export function groupPlanCreditGrants(creditGrants: PlanCreditGrantView[]) {
   return Object.values(map);
 }
 
-interface GroupCreditGrantOptions {
-  groupBy?: "credit" | "bundle";
+/** Comparator ordering anything with a `createdAt` newest-first. */
+function byRecency(a: { createdAt: Date }, b: { createdAt: Date }) {
+  return +b.createdAt - +a.createdAt;
 }
 
-export function groupCreditGrants(
+/**
+ * Rolls active grants up into per-key totals. Entries come back newest-first,
+ * as do the `grants` within each entry, so a truncated list shows the most
+ * recent without the caller sorting anything.
+ *
+ * "Active" is load-bearing: expired and zeroed-out grants are dropped, so a
+ * caller counting the result is counting live grants only.
+ */
+function aggregateActiveGrants(
   creditGrants: CreditCompanyGrantView[],
-  options?: GroupCreditGrantOptions,
+  getKey: (grant: CreditCompanyGrantView) => string,
 ) {
   const today = new Date();
   const map = creditGrants.reduce(
@@ -73,12 +82,7 @@ export function groupCreditGrants(
       const isZeroedOut = !!grant.zeroedOutDate;
 
       if (!isExpired && !isZeroedOut) {
-        const key =
-          options?.groupBy === "bundle"
-            ? grant.billingCreditBundleId || grant.id
-            : options?.groupBy === "credit"
-              ? grant.billingCreditId
-              : grant.id;
+        const key = getKey(grant);
         const current = acc[key];
 
         acc[key] = {
@@ -113,29 +117,42 @@ export function groupCreditGrants(
     {},
   );
 
-  return Object.values(map);
+  // Same ordering rule at two levels: grants within an entry, then entries by
+  // their most recent grant. Both arrays were built fresh above and are aliased
+  // nowhere, so they can be sorted in place.
+  const entries = Object.values(map);
+
+  for (const entry of entries) {
+    entry.grants.sort(byRecency);
+  }
+
+  // Every entry holds at least one grant, now its most recent.
+  return entries.sort((a, b) => byRecency(a.grants[0], b.grants[0]));
 }
 
-interface DatedGrant {
-  createdAt: Date;
+/**
+ * One entry per credit — the company's live balance for each credit, summed
+ * across every grant that supplied it.
+ */
+export function aggregateActiveGrantsByCredit(
+  creditGrants: CreditCompanyGrantView[],
+) {
+  return aggregateActiveGrants(creditGrants, (grant) => grant.billingCreditId);
 }
 
-export function getLatestGrantTime(grants: DatedGrant[]): number {
-  return grants.reduce(
-    (latest, grant) => Math.max(latest, +grant.createdAt),
-    0,
-  );
-}
-
-export function sortGrantsByRecency<T extends DatedGrant>(grants: T[]): T[] {
-  return [...grants].sort((a, b) => +b.createdAt - +a.createdAt);
-}
-
-export function sortCreditGroupsByRecency<T extends { grants: DatedGrant[] }>(
-  groups: T[],
-): T[] {
-  return [...groups].sort(
-    (a, b) => getLatestGrantTime(b.grants) - getLatestGrantTime(a.grants),
+/**
+ * One entry per credit bundle, falling back to one entry per grant for grants
+ * that arrived outside a bundle (plan allocations, promotional grants).
+ *
+ * Note that entries are keyed by bundle but still carry `id: billingCreditId`,
+ * so two bundles of the same credit share an `id` — don't use it as a React key.
+ */
+export function aggregateActiveGrantsByBundle(
+  creditGrants: CreditCompanyGrantView[],
+) {
+  return aggregateActiveGrants(
+    creditGrants,
+    (grant) => grant.billingCreditBundleId || grant.id,
   );
 }
 

--- a/components/src/utils/api/credit.ts
+++ b/components/src/utils/api/credit.ts
@@ -116,6 +116,29 @@ export function groupCreditGrants(
   return Object.values(map);
 }
 
+interface DatedGrant {
+  createdAt: Date;
+}
+
+export function getLatestGrantTime(grants: DatedGrant[]): number {
+  return grants.reduce(
+    (latest, grant) => Math.max(latest, +grant.createdAt),
+    0,
+  );
+}
+
+export function sortGrantsByRecency<T extends DatedGrant>(grants: T[]): T[] {
+  return [...grants].sort((a, b) => +b.createdAt - +a.createdAt);
+}
+
+export function sortCreditGroupsByRecency<T extends { grants: DatedGrant[] }>(
+  groups: T[],
+): T[] {
+  return [...groups].sort(
+    (a, b) => getLatestGrantTime(b.grants) - getLatestGrantTime(a.grants),
+  );
+}
+
 export function isAutoTopupEnabled(grant?: CompanyPlanCreditGrantView) {
   if (grant?.billingCreditAutoTopupSelfService) {
     return grant.companyAutoTopupEnabled ?? false;


### PR DESCRIPTION
Resolves [SCHY-495](https://linear.app/schematic/issue/SCHY-495/components-truncate-top-up-list-in-current-plan-element-with-expansion).

Long credit lists pushed the rest of the element down the page. Both surfaces now cap at 3 entries with a "See all (N)" toggle that expands inline. Three commits, each reviewable on its own.

**1. Truncate credit lists** — the three credit sections in `PlanManager` truncate independently, as does the balance-details grant ledger in `MeteredFeatures` (closing the panel resets it). Adds a shared `useTruncatedList` hook and `ExpandListToggle` component instead of a fifth copy of the hand-rolled pattern already in `IncludedFeatures`, `Invoices`, and both `Plan` components — migrating those is a follow-up.

**2. Add a "Top-ups" section** — auto top-up grants were dropped by PlanManager's `grantReason` switch, so they never appeared at all. They now sit below "Credits in plan", rendered like "Credit bundles", via a fourth case in that switch.

**3. Refactor `groupCreditGrants`** — it silently dropped expired and zeroed-out grants, summed totals, and returned credit-shaped entries, none of which the name admitted. Now `aggregateActiveGrantsByCredit` / `aggregateActiveGrantsByBundle` over a shared private helper: the grouping dimension is in the name, the options bag and its unreachable third mode are gone, and grant ordering is owned by the aggregator so callers stop sorting. Picks up the direct unit tests the function never had.

## Worth a look

- **Repeated top-ups of the same bundle collapse into one row** with a `(3)` prefix, matching the neighbouring bundles section. Easy to switch to one row per event.
- **`aggregateActiveGrantsByBundle` keys by bundle but still sets `id: billingCreditId`**, so two bundles of the same credit share an `id`. That's why PlanManager keys rows by index. Documented rather than fixed — a proper `groupKey` field is a separate change.
- **Left alone:** a single-grant ledger gets `1rem` top and `0` bottom padding, with rows 0/1 flush. Pre-existing; changing the formula risks visual regressions beyond this ticket.

## Testing

`tsc`, `lint`, prettier, and `yarn test` clean — 439 passing, 4 pre-existing skips. New coverage for the hook, the toggle, the aggregator, and both elements (neither had a test file).

Still wants a manual pass on the preview deploy for light/dark theming and the ledger's padding in both expanded and collapsed states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bs1jKxshPBe6g5VJ7zvzAF
