### PR TITLE
chore(ci): group Angular toolchain bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,19 @@ updates:
       - "npm"
       - "Dependabot"
     groups:
+      # @angular/core peer-depends on an exact @angular/compiler version, and
+      # ng-packagr peer-depends on @angular/compiler-cli. Bumping any of them
+      # alone builds green against a skewed compiler.
+      angular:
+        patterns:
+          - "@angular/*"
+          - "ng-packagr"
       react:
         patterns:
           - "react"
           - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
     ignore:
       - dependency-name: "react-i18next"
         update-types:


### PR DESCRIPTION
Follow-up to the @angular/core 22.1.0 bump, where Dependabot moved `@angular/core` on its own and left `@angular/compiler`, `@angular/compiler-cli`, and `ng-packagr` on 21.2.x. `@angular/core` peer-depends on an exact `@angular/compiler` version, but the build stayed green against the skewed compiler, so nothing caught it.

Groups `@angular/*` with `ng-packagr` so the toolchain moves as a unit. Dependabot groups include major updates by default, so this covers the case that broke.

Also adds `@types/react`/`@types/react-dom` to the existing react group — same coupling, and they're currently ungrouped in /react and /components.