### PR TITLE
hide credit `Buy More` when no purchasable bundle exists

### DIFF
--- a/components/src/components/elements/metered-features/MeteredFeatures.test.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.test.tsx
@@ -1,0 +1,149 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { defaultSettings } from "../../../context/embedState";
+import { render } from "../../../test/setup";
+
+import { MeteredFeatures } from "./MeteredFeatures";
+
+const CREDIT_ID = "bilcr_tokens";
+
+function creditGrant() {
+  return {
+    id: "bilcrg_1",
+    billingCreditId: CREDIT_ID,
+    creditName: "Tokens",
+    singularName: "token",
+    pluralName: "tokens",
+    creditDescription: "Tokens",
+    grantReason: "plan",
+    quantity: 100,
+    quantityRemaining: 40,
+    quantityUsed: 60,
+    companyId: "comp_1",
+    companyName: "Acme",
+    planId: "plan_1",
+    planName: "Pro",
+  };
+}
+
+// Referentially-stable embed object: swapped wholesale per test via `setData`.
+const state = vi.hoisted(() => {
+  const embed = {
+    data: {} as Record<string, unknown>,
+    settings: {} as Record<string, unknown>,
+    setCheckoutState: vi.fn(),
+    warningThresholdConfig: undefined,
+  };
+
+  return { embed };
+});
+
+vi.mock("../../../hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../hooks")>();
+
+  return {
+    ...actual,
+    useEmbed: () => state.embed,
+    useWrapChildren: () => false,
+  };
+});
+
+function setData(overrides: {
+  creditBundles?: { id: string; creditId: string }[];
+  includedCreditGrants?: {
+    creditId: string;
+    billingCreditCanBuyBundles?: boolean;
+  }[];
+}) {
+  state.embed.data = {
+    capabilities: { checkout: true },
+    displaySettings: { showCredits: true },
+    featureUsage: { features: [] },
+    creditGrants: [creditGrant()],
+    creditBundles: overrides.creditBundles ?? [],
+    company: {
+      plan: { includedCreditGrants: overrides.includedCreditGrants ?? [] },
+    },
+  };
+}
+
+beforeEach(() => {
+  state.embed.settings = defaultSettings;
+  state.embed.setCheckoutState.mockClear();
+  setData({});
+});
+
+describe("`MeteredFeatures` credit `Buy More`", () => {
+  test("hides `Buy More` when the catalog has no bundle for the credit", () => {
+    // Bundles created on the Credit Type page but never added under
+    // Catalog -> Configuration -> Credit Bundles never reach hydrate, so the
+    // Credits stage would have nothing to show.
+    setData({
+      creditBundles: [],
+      includedCreditGrants: [
+        { creditId: CREDIT_ID, billingCreditCanBuyBundles: true },
+      ],
+    });
+
+    render(<MeteredFeatures />);
+
+    // The credit row itself still renders — only the dead-end CTA is gone.
+    expect(screen.getAllByText("Tokens").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Buy More")).not.toBeInTheDocument();
+  });
+
+  test("shows `Buy More` when a purchasable bundle exists for the credit", () => {
+    setData({
+      creditBundles: [{ id: "bilcrb_1", creditId: CREDIT_ID }],
+      includedCreditGrants: [
+        { creditId: CREDIT_ID, billingCreditCanBuyBundles: true },
+      ],
+    });
+
+    render(<MeteredFeatures />);
+
+    expect(screen.getByText("Buy More")).toBeInTheDocument();
+  });
+
+  test("hides `Buy More` when the only bundles are for other credits", () => {
+    setData({
+      creditBundles: [{ id: "bilcrb_2", creditId: "bilcr_other" }],
+      includedCreditGrants: [
+        { creditId: CREDIT_ID, billingCreditCanBuyBundles: true },
+      ],
+    });
+
+    render(<MeteredFeatures />);
+
+    expect(screen.queryByText("Buy More")).not.toBeInTheDocument();
+  });
+
+  test("hides `Buy More` when the plan grant disallows bundle purchases", () => {
+    setData({
+      creditBundles: [{ id: "bilcrb_1", creditId: CREDIT_ID }],
+      includedCreditGrants: [
+        { creditId: CREDIT_ID, billingCreditCanBuyBundles: false },
+      ],
+    });
+
+    render(<MeteredFeatures />);
+
+    expect(screen.queryByText("Buy More")).not.toBeInTheDocument();
+  });
+
+  test("hides `Buy More` when checkout is not available", () => {
+    setData({
+      creditBundles: [{ id: "bilcrb_1", creditId: CREDIT_ID }],
+      includedCreditGrants: [
+        { creditId: CREDIT_ID, billingCreditCanBuyBundles: true },
+      ],
+    });
+    (state.embed.data as { capabilities: { checkout: boolean } }).capabilities =
+      { checkout: false };
+
+    render(<MeteredFeatures />);
+
+    expect(screen.queryByText("Buy More")).not.toBeInTheDocument();
+  });
+});

--- a/components/src/components/elements/metered-features/MeteredFeatures.tsx
+++ b/components/src/components/elements/metered-features/MeteredFeatures.tsx
@@ -18,10 +18,10 @@ import {
 import type { DeepPartial, ElementProps } from "../../../types";
 import {
   entitlementHasHardLimit,
+  filterCreditBundles,
   formatConsumptionRate,
   formatCurrency,
   formatNumber,
-  getBundleOffCreditIds,
   getFeatureName,
   getSubscriptionPeriod,
   getUsageDetails,
@@ -237,9 +237,22 @@ export const MeteredFeatures = forwardRef<
     [data?.creditGrants],
   );
 
-  const bundleOffCreditIds = useMemo(
-    () => getBundleOffCreditIds(data?.company?.plan?.includedCreditGrants),
-    [data?.company?.plan?.includedCreditGrants],
+  // `Buy More` opens checkout straight onto the Credits stage, which can only
+  // offer the bundles the catalog actually returns. Gating on the plan grant's
+  // bundle-off flag alone isn't enough: when no bundle for this credit has been
+  // added under Catalog -> Configuration -> Credit Bundles the hydrate response
+  // carries none, and the button lands the user on an empty, dead-end stage. So
+  // require a purchasable bundle to exist — `filterCreditBundles` also applies
+  // the bundle-off gating, so this subsumes the old check.
+  const purchasableCreditIds = useMemo(
+    () =>
+      new Set(
+        filterCreditBundles(
+          data?.company?.plan?.includedCreditGrants,
+          data?.creditBundles,
+        ).map((bundle) => bundle.creditId),
+      ),
+    [data?.company?.plan?.includedCreditGrants, data?.creditBundles],
   );
 
   // Track expanded credits by id rather than seeding an array from creditGroups:
@@ -459,7 +472,7 @@ export const MeteredFeatures = forwardRef<
                       }
                     />
 
-                    {canCheckout && !bundleOffCreditIds.has(credit.id) && (
+                    {canCheckout && purchasableCreditIds.has(credit.id) && (
                       <Button
                         type="button"
                         onClick={() => {

--- a/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
+++ b/components/src/components/shared/checkout-dialog/CheckoutDialog.tsx
@@ -845,6 +845,17 @@ export const CheckoutDialog = ({ top }: CheckoutDialogProps) => {
     if (isBypassLoading) return checkoutStage;
 
     let id = checkoutStage;
+
+    // `credits` is only registered as a stage when there are purchasable
+    // bundles. A caller can still ask to open on it (`setCheckoutState({
+    // credits: true })`), which would otherwise render an empty bundle grid
+    // with no breadcrumb entry to navigate away from. Fall back to the first
+    // real stage instead. This is a memo rather than part of the initial
+    // `checkoutStage` state so it resolves correctly once bundles load.
+    if (id === "credits" && !checkoutStages.some((stage) => stage.id === id)) {
+      id = checkoutStages[0]?.id ?? id;
+    }
+
     while (
       (id === "plan" && checkoutState?.bypassPlanSelection) ||
       (id === "usage" && checkoutState?.bypassUsageSelection) ||


### PR DESCRIPTION
From #schematic-syrto: a customer on an active plan couldn't find a way to buy credit bundles in the customer portal. The capability exists (`Buy More` in Metered Features, and `Change plan` → `Next: Credits`), but both depend on bundles having been added under Catalog → Configuration → Credit Bundles — and when they haven't, `Buy More` still renders and opens a dead end.

`Buy More` was gated only on the plan grant's `billingCreditCanBuyBundles`, not on a bundle actually being purchasable. The backend filters catalog bundles through the plan group's ordered bundle list, so an empty list means `data.creditBundles` is empty; the button then opens checkout on the Credits stage, which renders an empty bundle grid and isn't registered as a stage — so there's no breadcrumb to navigate away from either.

Gate the button on the existing `filterCreditBundles` helper (which already applies the bundle-off gating, so this subsumes the old `getBundleOffCreditIds` check). Also fall back to the first registered stage in `CheckoutDialog` when `credits` is requested but not registered, so the dead end isn't reachable from any other caller.

Note this only removes the misleading CTA — it does not make bundles purchasable. The customer-facing fix is still to add the bundles to the catalog config; support is following up on that separately.

Verified: new `MeteredFeatures.test.tsx` covering the empty-catalog, other-credit, bundle-off, and no-checkout-capability cases (the first two fail without the change); full components suite 408 passed / 4 skipped; `yarn tsc` and `yarn lint` clean. Not verified in a browser — reproducing needs an account with a credit grant and an empty catalog bundle list, which the local stack doesn't have seeded, and the local stack serves components from `main` rather than this branch.