### PR TITLE
chore(deps-dev): bump typescript to 6.0.3 in /vue, with the config fixes it needs

### DIFF
--- a/vue/jest.config.js
+++ b/vue/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
           target: "ES2020",
           module: "commonjs",
           esModuleInterop: true,
+          types: ["jest", "node"],
         },
       },
     ],

--- a/vue/package.json
+++ b/vue/package.json
@@ -46,7 +46,7 @@
     "jest-esbuild": "^0.4.0",
     "prettier": "^3.9.6",
     "ts-jest": "^29.4.12",
-    "typescript": "^5.9.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
     "vue": "^3.5.40"
   },

--- a/vue/tsconfig.json
+++ b/vue/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,

--- a/vue/yarn.lock
+++ b/vue/yarn.lock
@@ -5036,10 +5036,15 @@ typescript-eslint@^8.65.0:
     "@typescript-eslint/typescript-estree" "8.65.0"
     "@typescript-eslint/utils" "8.65.0"
 
-typescript@5.9.3, typescript@^5.9.2:
+typescript@5.9.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
Supersedes #1583, which fails Build + Test on the branch. Same dependency bump (dependabot commit cherry-picked as-is), plus the two config fixes needed to make it green.

1. `vue/tsconfig.json` — `moduleResolution: "node"` is node10 mode, which TS 6 rejects outright (TS5107) and TS 7 removes. Switched to `"bundler"`, which matches `module: ES2020` and is what `js/`, `react/`, `angular/` and `components/` already use — all four are already on `typescript ^6.0.3`, so vue was the last holdout.
2. `vue/jest.config.js` — the ts-jest inline `tsconfig` override stopped resolving ambient `@types` under TS 6, so `src/index.spec.ts` lost `jest`/`describe`/`it`/`expect` (TS2304/TS2593) and `global`. Declared `types: ["jest", "node"]` on that block ("node" for the `global.fetch` mock).

Config only, no source changes.

Verified locally in `vue/` on Node 24 with `yarn install --frozen-lockfile`, reproducing both failures first and then re-running all three CI jobs after the fix: `yarn build` (incl. `tsc` + api-extractor), `yarn test` (10/10 pass), `yarn lint` — all clean. Re-verified after rebasing on main.

Two things I did not do: I left #1583 open rather than closing it (merging this makes dependabot close it), and I did not touch the pre-existing prettier 3.9.6 drift in `vue/src/context/schematic.ts` that `yarn build`'s format step rewrites — unrelated to TS 6, worth its own commit.