### PR TITLE
chore(deps): resolve dependabot security alerts in js

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -56,7 +56,7 @@
   },
   "resolutions": {
     "rollup": ">=4.59.0",
-    "undici": "^7.28.0"
+    "undici": "^7.29.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -2743,10 +2743,10 @@ undici-types@~7.16.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
-undici@^7.28.0, undici@^8.9.0:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
-  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+undici@^7.29.0, undici@^8.9.0:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 universalify@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Bumps the `undici` yarn resolution in `js/` from `^7.28.0` to `^7.29.0` (resolves 7.28.0 -> 7.29.0) to clear the open Dependabot security alerts on `js/yarn.lock`. Only `js/package.json` and `js/yarn.lock` change.

- GHSA-4cwx-7wf7-3272 — undici — high — 7.28.0 -> 7.29.0 — yarn `resolutions` bump (transitive via `jsdom`)
- GHSA-8xcm-r25x-g524 — undici — medium — 7.28.0 -> 7.29.0 — yarn `resolutions` bump (transitive via `jsdom`)
- GHSA-jr45-8vmc-qm54 — undici — medium — 7.28.0 -> 7.29.0 — yarn `resolutions` bump (transitive via `jsdom`)
- GHSA-m8rv-5g2x-5cg5 — undici — medium — 7.28.0 -> 7.29.0 — yarn `resolutions` bump (transitive via `jsdom`)
- GHSA-v3r7-h72x-cjcm — undici — medium — 7.28.0 -> 7.29.0 — yarn `resolutions` bump (transitive via `jsdom`)
