### PR TITLE
docs: fix self-link to the fallbacks section in the SDK READMEs

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -148,7 +148,7 @@ When events (track, identify) cannot be sent due to network issues, they are aut
 
 ### WebSocket Fallback
 
-In WebSocket mode, if the WebSocket connection fails, the SDK will provide the last known value or the configured fallback values as [outlined above](/#flag-check-fallbacks). The WebSocket will also automatically attempt to re-establish it's connection with Schematic using an exponential backoff. 
+In WebSocket mode, if the WebSocket connection fails, the SDK will provide the last known value or the configured fallback values as [outlined above](#flag-check-fallbacks). The WebSocket will also automatically attempt to re-establish its connection with Schematic using an exponential backoff. 
 
 ## Troubleshooting
 

--- a/react/README.md
+++ b/react/README.md
@@ -260,7 +260,7 @@ When events (track, identify) cannot be sent due to network issues, they are aut
 
 ### WebSocket Fallback
 
-In WebSocket mode, if the WebSocket connection fails, the SDK will provide the last known value or the configured fallback values as [outlined above](/#flag-check-fallbacks). The WebSocket will also automatically attempt to re-establish it's connection with Schematic using an exponential backoff. 
+In WebSocket mode, if the WebSocket connection fails, the SDK will provide the last known value or the configured fallback values as [outlined above](#flag-check-fallbacks). The WebSocket will also automatically attempt to re-establish its connection with Schematic using an exponential backoff. 
 
 ## React Native
 

--- a/vue/README.md
+++ b/vue/README.md
@@ -259,7 +259,7 @@ When events (track, identify) cannot be sent due to network issues, they are aut
 
 ### WebSocket Fallback
 
-In WebSocket mode, if the WebSocket connection fails, the SDK will provide the last known value or the configured fallback values as [outlined above](/#flag-check-fallbacks). The WebSocket will also automatically attempt to re-establish it's connection with Schematic using an exponential backoff. 
+In WebSocket mode, if the WebSocket connection fails, the SDK will provide the last known value or the configured fallback values as [outlined above](#flag-check-fallbacks). The WebSocket will also automatically attempt to re-establish its connection with Schematic using an exponential backoff. 
 
 ## Options API Support
 


### PR DESCRIPTION
The WebSocket fallback paragraph in `js`, `react`, and `vue` links to the section above it as `](/#flag-check-fallbacks)`. The leading slash makes it an absolute path, so it resolves against the host root instead of the current page: on GitHub it goes to `github.com/#flag-check-fallbacks`, and on the docs site it goes to the docs home.

Dropping the slash makes it a same-page anchor, which works in both places.

Also fixes `re-establish it's connection` to `its` in the same sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)